### PR TITLE
Use alternate check for reboot for T2 after reboot with REBOOT_TYPE_POWEROFF (#16348 + #16581)

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -268,6 +268,8 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     # Create a temporary file in tmpfs before reboot
     logger.info('DUT {} create a file /dev/shm/test_reboot before rebooting'.format(hostname))
     duthost.command('sudo touch /dev/shm/test_reboot')
+    # Get reboot-cause history before reboot
+    prev_reboot_cause_history = duthost.show_and_parse("show reboot-cause history")
 
     reboot_res, dut_datetime = perform_reboot(duthost, pool, reboot_command, reboot_helper, reboot_kwargs, reboot_type)
 
@@ -318,14 +320,20 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     # some device does not have onchip clock and requires obtaining system time a little later from ntp
     # or SUP to obtain the correct time so if the uptime is less than original device time, it means it
     # is most likely due to this issue which we can wait a little more until the correct time is set in place.
-    if float(dut_uptime.strftime("%s")) < float(dut_datetime.strftime("%s")):
-        logger.info('DUT {} timestamp went backwards'.format(hostname))
-        wait_until(120, 5, 0, positive_uptime, duthost, dut_datetime)
 
-    dut_uptime = duthost.get_up_time()
+    # Use an alternative reboot check if T2 device and REBOOT_TYPE_POWEROFF
+    if duthost.get_facts().get("modular_chassis") and reboot_type == REBOOT_TYPE_POWEROFF:
+        curr_reboot_cause_history = duthost.show_and_parse("show reboot-cause history")
+        pytest_assert(prev_reboot_cause_history != curr_reboot_cause_history, "No new input into history-queue")
+    else:
+        if float(dut_uptime.strftime("%s")) < float(dut_datetime.strftime("%s")):
+            logger.info('DUT {} timestamp went backwards'.format(hostname))
+            wait_until(120, 5, 0, positive_uptime, duthost, dut_datetime)
 
-    assert float(dut_uptime.strftime("%s")) > float(dut_datetime.strftime("%s")), "Device {} did not reboot". \
-        format(hostname)
+        dut_uptime = duthost.get_up_time()
+
+        assert float(dut_uptime.strftime("%s")) > float(dut_datetime.strftime("%s")), "Device {} did not reboot". \
+            format(hostname)
 
     if wait_for_bgp:
         bgp_neighbors = duthost.get_bgp_neighbors_per_asic(state="all")


### PR DESCRIPTION
### Description of PR
Summary: Fixes #16289 + merges #16581 to remove double reboot bug

### Type of change
* [x]  Bug fix
* [ ]  Testbed and Framework(new/improvement)
* [ ]  Test case(new/improvement)

### Back port request
* [ ]  202012
* [ ]  202205
* [ ]  202305
* [ ]  202311
* [x]  202405

### Approach
#### What is the motivation for this PR?
REBOOT_TYPE_POWEROFF reboot causes test failures on T2 as NTP slew doesn't recover for a while

#### How did you do it?
Skip dut uptime check on reboot for REBOOT_TYPE_POWEROFF reboot on T2

#### How did you verify/test it?
Was previously casing test_power_off_reboot.py to fail, no longer causing it to fail

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation

