### PR TITLE
[loganalyzer] Fix the bug of ignore_loganalyzer decorator (#16624)

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.plugins.loganalyzer.utils import ignore_loganalyzer
+from tests.common.plugins.loganalyzer.utils import support_ignore_loganalyzer
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
 from tests.configlet.util.common import chk_for_pfc_wd
@@ -112,7 +112,7 @@ def pfcwd_feature_enabled(duthost):
     return pfc_status == 'enable' and switch_role not in ['MgmtToRRouter', 'BmcMgmtToRRouter']
 
 
-@ignore_loganalyzer
+@support_ignore_loganalyzer
 def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True,
                   safe_reload=False, wait_before_force_reload=0, wait_for_bgp=False,
                   check_intf_up_ports=False, traffic_shift_away=False, override_config=False,

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -267,6 +267,10 @@ class LogAnalyzer:
         """
         Adds the start ignore marker to the log files
         """
+        # We copy 'loganalyzer.py' to /tmp dir during loganalyzer initialization,
+        # but the file could be auto removed by rebooting device,
+        # always copy script to make sure the marker can be added successfully.
+        self.ansible_host.copy(src=ANSIBLE_LOGANALYZER_MODULE, dest=os.path.join(self.dut_run_dir, "loganalyzer.py"))
         add_start_ignore_mark = ".".join((self.marker_prefix, time.strftime("%Y-%m-%d-%H:%M:%S", time.gmtime())))
         cmd = "python {run_dir}/loganalyzer.py --action add_start_ignore_mark --run_id {add_start_ignore_mark}"\
             .format(run_dir=self.dut_run_dir, add_start_ignore_mark=add_start_ignore_mark)
@@ -281,6 +285,10 @@ class LogAnalyzer:
         """
         Adds the end ignore marker to the log files
         """
+        # We copy 'loganalyzer.py' to /tmp dir during loganalyzer initialization,
+        # but the file could be auto removed by rebooting device,
+        # always copy script to make sure the marker can be added successfully.
+        self.ansible_host.copy(src=ANSIBLE_LOGANALYZER_MODULE, dest=os.path.join(self.dut_run_dir, "loganalyzer.py"))
         marker = self._markers.pop()
         cmd = "python {run_dir}/loganalyzer.py --action add_end_ignore_mark --run_id {marker}"\
             .format(run_dir=self.dut_run_dir, marker=marker)

--- a/tests/common/plugins/loganalyzer/utils.py
+++ b/tests/common/plugins/loganalyzer/utils.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 
-def ignore_loganalyzer(func):
+def support_ignore_loganalyzer(func):
     @wraps(func)
     def decorated(*args, **kwargs):
         """
@@ -12,10 +12,10 @@ def ignore_loganalyzer(func):
             and set ignore_loganalyzer markers before and after the decorated function on all log analyzer instances.
         """
 
-        loganalyzer = None
-        if 'ignore_loganalyzer' in kwargs and kwargs['ignore_loganalyzer'] is not None:
-            loganalyzer = kwargs['ignore_loganalyzer']
-            kwargs.pop('ignore_loganalyzer')
+        # Need to remove parameter 'ignore_loganalyzer' from kwargs
+        # Otherwise it breaks the decorated func
+        # Since the parameter 'ignore_loganalyzer' is not defined in the signature
+        loganalyzer = kwargs.pop('ignore_loganalyzer', {})
 
         if loganalyzer:
             for _, dut_loganalyzer in list(loganalyzer.items()):

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -10,6 +10,7 @@ from collections import deque
 from .helpers.assertions import pytest_assert
 from .platform.interface_utils import check_interface_status_of_up_ports
 from .platform.processes_utils import wait_critical_processes
+from .plugins.loganalyzer.utils import support_ignore_loganalyzer
 from .utilities import wait_until, get_plt_reboot_ctrl
 from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs
 
@@ -219,6 +220,7 @@ def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwa
     return [reboot_res, dut_datetime]
 
 
+@support_ignore_loganalyzer
 def reboot(duthost, localhost, reboot_type='cold', delay=10,
            timeout=0, wait=0, wait_for_ssh=True, wait_warmboot_finalizer=False, warmboot_finalizer_timeout=0,
            reboot_helper=None, reboot_kwargs=None, plt_reboot_ctrl_overwrite=True,


### PR DESCRIPTION
### Description of PR
Summary: Fixes #7313

### Type of change
* [x]  Bug fix
* [x]  Testbed and Framework(new/improvement)
* [ ]  New Test case
  
  * [ ]  Skipped for non-supported platforms
* [ ]  Test case improvement

### Back port request
* [ ]  202012
* [ ]  202205
* [ ]  202305
* [ ]  202311
* [ ]  202405
* [ ]  202411

### Approach
#### What is the motivation for this PR?
Fix the bug that run with --disable_loganalyzer

#### How did you do it?
1. Always remove ignore_loganalyzer from the original kwargs
2. Rename to a more correct name

#### How did you verify/test it?
Tested on physical T2 testbeds

#### Any platform specific information?
#### Supported testbed topology if it's a new test case?
### Documentation

