### PR TITLE
[Chassis] ignore log analyzers on config reload/reboot, and bfd test (#16625)

### DIFF
--- a/tests/bfd/test_bfd_static_route.py
+++ b/tests/bfd/test_bfd_static_route.py
@@ -11,7 +11,11 @@ from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.reboot import reboot
 
-pytestmark = [pytest.mark.topology("t2")]
+pytestmark = [
+    pytest.mark.topology("t2"),
+    pytest.mark.device_type('physical'),
+    pytest.mark.disable_loganalyzer
+]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -96,13 +96,14 @@ def fanouthost(duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
 
 
 @pytest.fixture
-def configure_copp_drop_for_ttl_error(duthosts, rand_one_dut_hostname):
+def configure_copp_drop_for_ttl_error(duthosts, rand_one_dut_hostname, loganalyzer):
     """
     Fixture that allows to update copp configuration for dropping packets with TTL=0
 
     Args:
         duthosts: fixture to get DUT hosts defined in testbed
         rand_one_dut_hostname: fixture to return the randomly selected duthost
+        loganalyzer: loganalyzer
     """
     duthost = duthosts[rand_one_dut_hostname]
     copp_trap_group_json = "/tmp/copp_trap_group.json"
@@ -144,7 +145,7 @@ EOF
     yield
 
     duthost.command("rm {} {}".format(copp_trap_group_json, copp_trap_rule_json))
-    config_reload(duthost, safe_reload=True)
+    config_reload(duthost, safe_reload=True, ignore_loganalyzer=loganalyzer)
 
 
 def is_mellanox_devices(hwsku):

--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -15,9 +15,10 @@ pytestmark = [
 ]
 
 
-def load_new_cfg(duthost, data):
+def load_new_cfg(duthost, data, loganalyzer):
     duthost.copy(content=json.dumps(data, indent=4), dest=CFG_DB_PATH)
-    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True,
+                  ignore_loganalyzer=loganalyzer)
 
 
 def get_queue_ctrs(duthost, cmd):
@@ -136,7 +137,7 @@ def test_snmp_queue_counters(duthosts,
     # to removing buffer queues
     data['DEVICE_METADATA']["localhost"]["create_only_config_db_buffers"] \
         = "true"
-    load_new_cfg(duthost, data)
+    load_new_cfg(duthost, data, loganalyzer)
     stat_queue_counters_cnt_pre = get_queuestat_ctrs(duthost, get_queue_stat_cmd) * UNICAST_CTRS
     wait_until(60, 20, 0, check_snmp_cmd_output, duthost, get_bfr_queue_cntrs_cmd)
     queue_counters_cnt_pre = get_queue_ctrs(duthost, get_bfr_queue_cntrs_cmd)
@@ -148,7 +149,7 @@ def test_snmp_queue_counters(duthosts,
 
     # Remove buffer queue and reload and get number of queue counters of selected interface
     del data['BUFFER_QUEUE'][buffer_queue_to_del]
-    load_new_cfg(duthost, data)
+    load_new_cfg(duthost, data, loganalyzer)
     stat_queue_counters_cnt_post = get_queuestat_ctrs(duthost, get_queue_stat_cmd) * UNICAST_CTRS
     wait_until(60, 20, 0, check_snmp_cmd_output, duthost, get_bfr_queue_cntrs_cmd)
     queue_counters_cnt_post = get_queue_ctrs(duthost, get_bfr_queue_cntrs_cmd)


### PR DESCRIPTION
### Description of PR
Summary: Fixes MSFT PBI#30938349

### Type of change
* [ ]  Bug fix
* [ ]  Testbed and Framework(new/improvement)
* [ ]  New Test case
  
  * [ ]  Skipped for non-supported platforms
* [x]  Test case improvement

### Back port request
* [ ]  202012
* [ ]  202205
* [ ]  202305
* [ ]  202311
* [x]  202405
* [ ]  202411

### Approach
#### What is the motivation for this PR?
1. Ignore the err logs during loganalyzer analyzer on config_reload and reboot, so that we can enable log analyzer on other codes beyond config reload/reboot, rather than skip on all of the test module.
2. Ignore err logs in bfd_static_route tests

#### How did you do it?
1. Ignore the err logs during loganalyzer analyzer on config_reload and reboot, so that we can enable log analyzer on other codes beyond config reload/reboot, rather than skip on all of the test module.
2. Ignore err logs in bfd_static_route tests

#### How did you verify/test it?
Verified on physical chassis testbeds

#### Any platform specific information?
#### Supported testbed topology if it's a new test case?
### Documentation

