### PR TITLE
fix UnboundLocalError in test_pfcwd_function.py (#16631)

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -723,7 +723,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         test_ports_info = {self.pfc_wd['rx_port'][0]: self.pfc_wd}
         queues = [self.storm_hndle.pfc_queue_idx]
 
-        if dut.facts['asic_type'] == "mellanox":
+        extra_pfc_storm_timeout_needed = dut.facts['asic_type'] in ["mellanox", "cisco-8000"]
+        if extra_pfc_storm_timeout_needed:
             PFC_STORM_TIMEOUT = 30
             pfcwd_stats_before_test = check_pfc_storm_state(dut, port, self.storm_hndle.pfc_queue_idx)
 
@@ -743,8 +744,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             if self.pfc_wd['fake_storm']:
                 PfcCmd.set_storm_status(dut, self.queue_oid, "enabled")
 
-            if dut.facts['asic_type'] in ["mellanox", "cisco-8000"]:
-                # On Mellanox platform, more time is required for PFC storm being triggered
+            if extra_pfc_storm_timeout_needed:
+                # On Mellanox and Cisco platform, more time is required for PFC storm being triggered
                 # as PFC pause sent from Non-Mellanox leaf fanout is not continuous sometimes.
                 pytest_assert(wait_until(PFC_STORM_TIMEOUT, 2, 0,
                                         lambda: check_pfc_storm_state(dut, port, self.storm_hndle.pfc_queue_idx) != pfcwd_stats_before_test),  # noqa: E501, E128


### PR DESCRIPTION
### Description of PR
Summary: Fixes the following error per discussion in #16535

`UnboundLocalError: local variable 'PFC_STORM_TIMEOUT' referenced before assignment`

### Type of change
* [ ]  Bug fix
* [ ]  Testbed and Framework(new/improvement)
* [ ]  New Test case
  
  * [ ]  Skipped for non-supported platforms
* [ ]  Test case improvement

### Back port request
* [ ]  202012
* [ ]  202205
* [ ]  202305
* [ ]  202311
* [x]  202405
* [x]  202411

### Approach
#### What is the motivation for this PR?
fix syntax error in test_pfcwd_function.py:

#### How did you do it?
#### How did you verify/test it?
passed on msn2700. failed on 8102.

#### Any platform specific information?
#### Supported testbed topology if it's a new test case?
### Documentation

