### PR TITLE
[chassis][Arista] Increase mem threshold for arista 7800 devices (#16105)

### DIFF
--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -35,6 +35,8 @@ def setup_thresholds(duthosts, enum_rand_one_per_hwsku_hostname):
     memory_threshold = 60
     high_cpu_consume_procs = {}
     is_asan = is_asan_image(duthosts, enum_rand_one_per_hwsku_hostname)
+    if ('arista_7800' in duthost.facts['platform'].lower()):
+        memory_threshold = 75
     if duthost.facts['platform'] in ('x86_64-arista_7050_qx32', 'x86_64-kvm_x86_64-r0', 'x86_64-arista_7050_qx32s',
                                      'x86_64-cel_e1031-r0', 'x86_64-arista_7800r3a_36dm2_lc') or is_asan:
         memory_threshold = 90


### PR DESCRIPTION
### Description of PR
Summary: Fixes #16104

### Type of change
* [x]  Bug fix
* [ ]  Testbed and Framework(new/improvement)
* [ ]  Test case(new/improvement)

### Back port request
* [ ]  202012
* [ ]  202205
* [ ]  202305
* [ ]  202311
* [x]  202405

### Approach
#### What is the motivation for this PR?
We wish to increase the mem threshold for Arista 7800 devices to 90 in order to help the platform_tests pass.

#### How did you do it?
Modified the threshold in `tests/platform_tests/test_cpu_memory_usage.py`

#### How did you verify/test it?
Pending testing

#### Any platform specific information?
#### Supported testbed topology if it's a new test case?
### Documentation

