### PR TITLE
Fix fabric_cli_and_db so it only tests on connected links. (#16309)

### DIFF
--- a/tests/voq/test_fabric_cli_and_db.py
+++ b/tests/voq/test_fabric_cli_and_db.py
@@ -27,7 +27,6 @@ num_links_to_test = 6
 
 def test_fabric_cli_isolate_linecards(duthosts, enum_frontend_dut_hostname):
     """compare the CLI output with the reference data"""
-    allPortsList = []
 
     duthost = duthosts[enum_frontend_dut_hostname]
     logger.info("duthost: {}".format(duthost.hostname))
@@ -36,14 +35,17 @@ def test_fabric_cli_isolate_linecards(duthosts, enum_frontend_dut_hostname):
     num_asics = duthost.num_asics()
     logger.info("num_asics: {}".format(num_asics))
     for asic in range(num_asics):
-        cmd = "show fabric reachability"
-        cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
+        allPortsList = []
+
         asicName = "asic{}".format(asic)
         logger.info(asicName)
         if num_asics > 1:
             asicNamespaceOption = "-n {}".format(asicName)
         else:
             asicNamespaceOption = ""
+
+        cmd = "show fabric reachability {}".format(asicNamespaceOption)
+        cmd_output = duthost.shell(cmd, module_ignore_errors=True)["stdout"].split("\n")
 
         # Create list of ports
         for line in cmd_output:


### PR DESCRIPTION
### Description of PR
Summary: Fix the fabric_cli_and_db test so it only tests connected links. Fixes # (issue)

The fabric_cli_and_db failed in cases where the test selected a link that was not connected. This issue occurred because the portList set was not reset for each chip, allowing links that were connected on other chips to be tested, even though they were not connected on the chip being tested. In this PR, the portList is reset for each chip, and the 'show fabric reachability' command is also run on each chip. As a result, the test now only choose connected links on the chip under test.

### Type of change
* [x]  Bug fix
* [ ]  Testbed and Framework(new/improvement)
* [ ]  Test case(new/improvement)

### Back port request
* [ ]  202012
* [ ]  202205
* [ ]  202305
* [ ]  202311
* [x]  202405

### Approach
#### What is the motivation for this PR?
#### How did you do it?
#### How did you verify/test it?
#### Any platform specific information?
#### Supported testbed topology if it's a new test case?
### Documentation

