### PR TITLE
[PR:16691]T2:snappi_tests:Don't save config after copying over the backup files. 

### DIFF
--- a/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/multidut/pfcwd/test_multidut_pfcwd_basic_with_snappi.py
@@ -33,7 +33,7 @@ def number_of_tx_rx_ports():
 
 
 @pytest.fixture(autouse=False)
-def save_restore_config(setup_ports_and_dut):    # noqa: F811
+def save_restore_config(setup_ports_and_dut):          # noqa: F811
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
     timestamp = time.time()
     dest = f'~/{timestamp}'
@@ -46,7 +46,6 @@ def save_restore_config(setup_ports_and_dut):    # noqa: F811
 
     for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
         duthost.shell(f"sudo cp {dest}/config_db*json /etc/sonic/")
-        duthost.shell("sudo config save -y")
 
     for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
         config_reload(duthost)


### PR DESCRIPTION
### Description of PR
Summary: In the function: save_restore_config() in test_multidut_pfcwd_basic_with_snappi.py, the teardown section copies back the backup files to /etc/sonic/. But the next line is to save config, which is not right. This PR fixes this issue.

### Type of change
* [x]  Bug fix
* [ ]  Testbed and Framework(new/improvement)
* [ ]  New Test case
  
  * [ ]  Skipped for non-supported platforms
* [ ]  Test case improvement

### Back port request
* [ ]  202012
* [ ]  202205
* [ ]  202305
* [ ]  202311
* [x]  202405
* [x]  202411

### Approach
#### What is the motivation for this PR?
The backup files contain the original configs for the DUT, but the config save command will overwrite them. In teardown, we want the original configs back, not the running configs.

#### How did you do it?
Remove the config-save command in teardown.

#### How did you verify/test it?
Ran it on my TB. I checked if the running config is different from saved config, and verified the new code works correctly.
