### PR TITLE
[msft-202405 cherry-pick] Use number of logs instead of timestamp fix

### DIFF
--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -10,7 +10,7 @@ from .test_authorization import ssh_connect_remote_retry, ssh_run_command, \
         remove_all_tacacs_server
 from .utils import stop_tacacs_server, start_tacacs_server, \
         check_server_received, per_command_accounting_skip_versions, \
-        change_and_wait_aaa_config_update, get_auditd_config_reload_timestamp, \
+        change_and_wait_aaa_config_update, get_auditd_config_reload_line_count, \
         ensure_tacacs_server_running_after_ut  # noqa: F401
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert
@@ -260,7 +260,7 @@ def test_accounting_tacacs_only_some_tacacs_server_down(
     # when tacacs config change multiple time in short time
     # auditd service may been request reload during reloading
     # when this happen, auditd will ignore request and only reload once
-    last_timestamp = get_auditd_config_reload_timestamp(duthost)
+    last_line_count = get_auditd_config_reload_line_count(duthost)
 
     duthost.shell("sudo config tacacs timeout 1")
     remove_all_tacacs_server(duthost)
@@ -268,7 +268,7 @@ def test_accounting_tacacs_only_some_tacacs_server_down(
     duthost.shell("sudo config tacacs add %s" % tacacs_server_ip)
     change_and_wait_aaa_config_update(duthost,
                                       "sudo config aaa accounting tacacs+",
-                                      last_timestamp)
+                                      last_line_count)
 
     cleanup_tacacs_log(ptfhost, rw_user_client)
 

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -362,27 +362,24 @@ def check_server_received(ptfhost, data, timeout=30):
     pytest_assert(exist, "Not found data: {} in tacplus server log".format(data))
 
 
-def get_auditd_config_reload_timestamp(duthost):
+def get_auditd_config_reload_line_count(duthost):
     res = duthost.shell("sudo journalctl -u auditd --boot --no-pager | grep 'audisp-tacplus re-initializing configuration'") # noqa E501
     logger.info("aaa config file timestamp {}".format(res["stdout_lines"]))
 
-    if len(res["stdout_lines"]) == 0:
-        return ""
-
-    return res["stdout_lines"][-1]
+    return len(res["stdout_lines"])
 
 
-def change_and_wait_aaa_config_update(duthost, command, last_timestamp=None, timeout=10):
-    if not last_timestamp:
-        last_timestamp = get_auditd_config_reload_timestamp(duthost)
+def change_and_wait_aaa_config_update(duthost, command, last_line_count=None, timeout=10):
+    if not last_line_count:
+        last_line_count = get_auditd_config_reload_line_count(duthost)
 
     duthost.shell(command)
 
     # After AAA config update, hostcfgd will modify config file and notify auditd reload config
     # Wait auditd reload config finish
     def log_exist(duthost):
-        latest_timestamp = get_auditd_config_reload_timestamp(duthost)
-        return latest_timestamp != last_timestamp
+        latest_line_count = get_auditd_config_reload_line_count(duthost)
+        return latest_line_count > last_line_count
 
     exist = wait_until(timeout, 1, 0, log_exist, duthost)
     pytest_assert(exist, "Not found aaa config update log: {}".format(command))


### PR DESCRIPTION
Use number of logs instead of timestamp in `change_and_wait_aaa_config_update`
https://github.com/sonic-net/sonic-mgmt/pull/16723
