### PR TITLE
Increase timeout for wait_bgp_sessions for T2 duts (#16438)

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -624,6 +624,10 @@ def wait_bgp_sessions(duthost, timeout=120):
     A helper function to wait bgp sessions on DUT
     """
     bgp_neighbors = duthost.get_bgp_neighbors_per_asic(state="all")
+    if duthost.get_facts().get("modular_chassis"):
+        timeout = 900
+    logging.info("Wait until all bgp sessions are up in {} sec"
+                 .format(timeout))
     pytest_assert(
         wait_until(timeout, 10, 0, duthost.check_bgp_session_state_all_asics, bgp_neighbors),
         "Not all bgp sessions are established after config reload",


### PR DESCRIPTION
Description of PR
Summary:
Fixes #16436, caused by added BGP check in #15936, which doesn't account for T2 BGP time to come up

Approach
What is the motivation for this PR?
Function wait_bgp_sessions timeout is too short for T2, fails in test_mgmt_ipv6_only test suite causing a fixture to error wrongly and not teardown properly leaving TB in bad state without ipv4 mgmt ip

How did you do it?
Increase timeout to 900s from 120s if duthost it is checking is supervisor

How did you verify/test it?
Run locally on T2

See for passing test:

17/01/2025 07:34:39 utilities.wait_until                     L0153 DEBUG  | check_bgp_session_state_all_asics is False, wait 10 seconds and check again
17/01/2025 07:34:49 utilities.wait_until                     L0135 DEBUG  | Time elapsed: 164.073392 seconds
Confirming it needs more than 120 seconds

Signed-off-by: Javier Tan javiertan@microsoft.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
