### PR TITLE
Explicit permission requirement for gihub actions token in autosync workflow. 

### DIFF
--- a/.github/workflows/autosync_pub_msft.yml
+++ b/.github/workflows/autosync_pub_msft.yml
@@ -4,6 +4,10 @@ on:
   # Set it manually trigger temporarily
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   sync-and-push:
     if: github.repository_owner == 'Azure'
@@ -77,9 +81,6 @@ jobs:
                 description="<h1>Please merge $CommitID into sonic-mgmt.msft.Do not Cherry-pick!!!</h1>"
                 description="code conflict: sonic-net/sonic-mgmt:$branch_head -> Azure/sonic-mgmt.msft:$branch_base<br>"
                 description+=$(git log $prehead..HEAD --merge --pretty=format:'%h -%d %s (%cs) [%aN]')
-                # assign="Gen-Hwa Chiang <gechiang@microsoft.com>"
-                # update work-item
-                # az boards work-item update --org https://dev.azure.com/mssonic/ --id $ADO_ID --discussion "$description" -f "Custom Field 1=type_A"
               fi
             fi
             GIT_EDITOR=true git merge --continue || true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Due to the current settings of Azure/sonic-mgmt.msft, the GitHub Actions token only has read permissions. Therefore, we need to explicitly define the required permissions for the workflow.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Due to the current settings of Azure/sonic-mgmt.msft, the GitHub Actions token only has read permissions. Therefore, we need to explicitly define the required permissions for the workflow.

#### How did you do it?
Explicitly define the required permissions for the workflow

#### How did you verify/test it?
Changed the settings in my own repo, and test. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
