### PR TITLE
Running test_gnmi.py on each hwsku instead of selecting one rand hwsku

### DIFF
--- a/tests/gnmi/test_gnmi.py
+++ b/tests/gnmi/test_gnmi.py
@@ -11,11 +11,11 @@ pytestmark = [
 ]
 
 
-def test_gnmi_capabilities(duthosts, rand_one_dut_hostname, localhost):
+def test_gnmi_capabilities(duthosts, enum_rand_one_per_hwsku_hostname, localhost):
     '''
     Verify GNMI capabilities
     '''
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     ret, msg = gnmi_capabilities(duthost, localhost)
     assert ret == 0, msg
     assert "sonic-db" in msg, msg
@@ -23,8 +23,8 @@ def test_gnmi_capabilities(duthosts, rand_one_dut_hostname, localhost):
 
 
 @pytest.fixture(scope="function")
-def setup_invalid_client_cert_cname(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def setup_invalid_client_cert_cname(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     del_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
     add_gnmi_client_common_name(duthost, "invalid.cname")
 
@@ -38,14 +38,14 @@ def setup_invalid_client_cert_cname(duthosts, rand_one_dut_hostname):
 
 
 def test_gnmi_authorize_failed_with_invalid_cname(duthosts,
-                                                  rand_one_dut_hostname,
+                                                  enum_rand_one_per_hwsku_hostname,
                                                   ptfhost,
                                                   setup_invalid_client_cert_cname):
     '''
     Verify GNMI native write, incremental config for configDB
     GNMI set request with invalid path
     '''
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     file_name = "vnet.txt"
     text = "{\"Vnet1\": {\"vni\": \"1000\", \"guid\": \"559c6ce8-26ab-4193-b946-ccc6e8f930b2\"}}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
Enhanced test_gnmi.py to support execution across multiple HWSKUs on a testbed, rather than limiting it to a single HWSKU.

Previously, the test was designed to run on a randomly selected DUT using rand_one_dut_hostname, which could be either a line card or a supervisor node. However, an issue was observed where the test failed on the supervisor, and this was not detected until the test was executed as part of a nightly run that randomly selected a supervisor node.

To address this, the implementation has been updated to ensure that the test runs on both the supervisor and at least one of the line cards, improving coverage and reliability.
-->

Summary:
Fixes # (issue)
ADO: 30909878
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [x ] 202012
- [x ] 202205
- [x ] 202305
- [x ] 202311
- [x ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Replacing rand_one_dut_hostname with enum_rand_one_per_hwsku_hostname

#### How did you verify/test it?
Ran on testbeds in Microsoft Lab

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
