### PR TITLE
Additional test cases that verify the reliability of SRv6 functionalities (#17133)

### DIFF
--- a/tests/srv6/srv6_utils.py
+++ b/tests/srv6/srv6_utils.py
@@ -287,3 +287,11 @@ def collect_frr_debugfile(duthosts, rand_one_dut_hostname, nbrhosts, filename, v
     nbrhost.shell(cmd, module_ignore_errors=True)
     cmd = "docker cp bgp:{} {}".format(filename, test_log_dir)
     nbrhost.shell(cmd, module_ignore_errors=True)
+
+
+#
+# Verify that the SID entry is programmed in APPL_DB
+#
+def verify_appl_db_sid_entry_exist(duthost, sonic_db_cli, key, exist):
+    appl_db_my_sids = duthost.command(sonic_db_cli + " APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
+    return key in appl_db_my_sids if exist else key not in appl_db_my_sids

--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -7,8 +7,9 @@ from scapy.all import Raw
 from scapy.layers.inet6 import IPv6, ICMPv6EchoRequest, UDP
 from scapy.layers.l2 import Ether
 
-from srv6_utils import runSendReceive
-from common.helpers.voq_helpers import get_neighbor_info
+from srv6_utils import runSendReceive, verify_appl_db_sid_entry_exist
+from common.reboot import reboot
+from common.utilities import wait_until
 from ptf.testutils import simple_ipv6_sr_packet
 
 logger = logging.getLogger(__name__)
@@ -42,9 +43,36 @@ def get_ptf_src_port_and_dut_port_and_neighbor(dut, tbinfo):
     return dut_port, ptf_src_port, None
 
 
-@pytest.mark.parametrize("with_srh", [True, False])
-def test_srv6_uN_forwarding(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index,
-                            ptfadapter, ptfhost, tbinfo, nbrhosts, with_srh):
+def run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh):
+    for i in range(0, 10):
+        # generate a random payload
+        payload = ''.join(random.choices(string.ascii_letters + string.digits, k=20))
+        if with_srh:
+            injected_pkt = simple_ipv6_sr_packet(
+                eth_dst=dut_mac,
+                eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode(),
+                ipv6_src=ptfhost.mgmt_ipv6,
+                ipv6_dst="fcbb:bbbb:1:2::",
+                srh_seg_left=1,
+                srh_nh=41,
+                inner_frame=IPv6() / UDP(dport=4791) / Raw(load=payload)
+            )
+        else:
+            injected_pkt = Ether(dst=dut_mac, src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode()) \
+                / IPv6(src=ptfhost.mgmt_ipv6, dst="fcbb:bbbb:1:2::") \
+                / IPv6() / UDP(dport=4791) / Raw(load=payload)
+
+        expected_pkt = injected_pkt.copy()
+        expected_pkt['Ether'].dst = get_neighbor_mac(duthost, neighbor_ip)
+        expected_pkt['Ether'].src = dut_mac
+        expected_pkt['IPv6'].dst = "fcbb:bbbb:2::"
+        expected_pkt['IPv6'].hlim -= 1
+        logger.debug("Expected packet #{}: {}".format(i, expected_pkt.summary()))
+        runSendReceive(injected_pkt, ptf_src_port, expected_pkt, [ptf_src_port], True, ptfadapter)
+
+
+@pytest.fixture(scope="module")
+def setup_uN(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, tbinfo):
     duthost = duthosts[enum_frontend_dut_hostname]
     asic_index = enum_frontend_asic_index
 
@@ -78,81 +106,50 @@ def test_srv6_uN_forwarding(duthosts, enum_frontend_dut_hostname, enum_frontend_
     sonic_db_cli = "sonic-db-cli" + cli_options
 
     # add a locator configuration entry
-    duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_LOCATORS\\|loc1 prefix fcbb:bbbb:1::")
+    duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_LOCATORS\\|loc1 prefix fcbb:bbbb:1:: func_len 0")
     # add a uN sid configuration entry
     duthost.command(sonic_db_cli +
                     " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48 action uN decap_dscp_mode pipe")
     # add the static route for IPv6 forwarding towards PTF's uSID
     duthost.command(sonic_db_cli + " CONFIG_DB HSET STATIC_ROUTE\\|default\\|fcbb:bbbb:2::/48 nexthop {} ifname {}"
                     .format(neighbor_ip, dut_port))
+    duthost.command("config save -y")
     time.sleep(5)
 
-    for i in range(0, 10):
-        # generate a random payload
-        payload = ''.join(random.choices(string.ascii_letters + string.digits, k=20))
-        if with_srh:
-            injected_pkt = simple_ipv6_sr_packet(
-                eth_dst=dut_mac,
-                eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode(),
-                ipv6_src=ptfhost.mgmt_ipv6,
-                ipv6_dst="fcbb:bbbb:1:2::",
-                srh_seg_left=1,
-                srh_nh=41,
-                inner_frame=IPv6() / UDP(dport=4791) / Raw(load=payload)
-            )
-        else:
-            injected_pkt = Ether(dst=dut_mac, src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode()) \
-                / IPv6(src=ptfhost.mgmt_ipv6, dst="fcbb:bbbb:1:2::") \
-                / IPv6() / UDP(dport=4791) / Raw(load=payload)
+    setup_info = {
+        "asic_index": asic_index,
+        "duthost": duthost,
+        "dut_mac": dut_mac,
+        "ptf_src_port": ptf_src_port,
+        "neighbor_ip": neighbor_ip,
+        "cli_options": cli_options
+    }
 
-        expected_pkt = injected_pkt.copy()
-        expected_pkt['Ether'].dst = get_neighbor_mac(duthost, neighbor_ip)
-        expected_pkt['Ether'].src = dut_mac
-        expected_pkt['IPv6'].dst = "fcbb:bbbb:2::"
-        expected_pkt['IPv6'].hlim -= 1
-        logger.debug("Expected packet #{}: {}".format(i, expected_pkt.summary()))
-        runSendReceive(injected_pkt, ptf_src_port, expected_pkt, [ptf_src_port], True, ptfadapter)
+    yield setup_info
 
     # delete the SRv6 configuration
     duthost.command(sonic_db_cli + " CONFIG_DB DEL SRV6_MY_LOCATORS\\|loc1")
     duthost.command(sonic_db_cli + " CONFIG_DB DEL SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48")
     duthost.command(sonic_db_cli + " CONFIG_DB DEL STATIC_ROUTE\\|default\\|fcbb:bbbb:2::/48")
+    duthost.command("config save -y")
 
 
 @pytest.mark.parametrize("with_srh", [True, False])
-def test_srv6_uN_decap_pipe_mode(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index,
-                                 ptfadapter, ptfhost, tbinfo, nbrhosts, with_srh):
-    duthost = duthosts[enum_frontend_dut_hostname]
-    asic_index = enum_frontend_asic_index
+def test_srv6_uN_forwarding(setup_uN, ptfadapter, ptfhost, with_srh):
+    duthost = setup_uN['duthost']
+    dut_mac = setup_uN['dut_mac']
+    ptf_src_port = setup_uN['ptf_src_port']
+    neighbor_ip = setup_uN['neighbor_ip']
 
-    if duthost.is_multi_asic:
-        cli_options = " -n " + duthost.get_namespace_from_asic_id(asic_index)
-        dut_asic = duthost.asic_instance[asic_index]
-        dut_mac = dut_asic.get_router_mac()
-        dut_port, ptf_src_port, neighbor = get_ptf_src_port_and_dut_port_and_neighbor(dut_asic, tbinfo)
-    else:
-        cli_options = ''
-        dut_mac = duthost._get_router_mac()
-        dut_port, ptf_src_port, neighbor = get_ptf_src_port_and_dut_port_and_neighbor(duthost, tbinfo)
+    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh)
 
-    logger.info("Doing test on DUT port {} | PTF port {}".format(dut_port, ptf_src_port))
 
-    # get neighbor IP
-    lines = duthost.command("show ipv6 bgp sum")['stdout'].split("\n")
-    for line in lines:
-        if neighbor in line:
-            neighbor_ip = line.split()[0]
-    assert neighbor_ip
-
-    sonic_db_cli = "sonic-db-cli" + cli_options
-
-    # add a locator configuration entry
-    duthost.command(sonic_db_cli + " CONFIG_DB HSET SRV6_MY_LOCATORS\\|loc1 prefix fcbb:bbbb:1::")
-    # add a uN sid configuration entry
-    duthost.command(sonic_db_cli +
-                    " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48 action uN decap_dscp_mode pipe")
-
-    time.sleep(5)
+@pytest.mark.parametrize("with_srh", [True, False])
+def test_srv6_uN_decap_pipe_mode(setup_uN, ptfadapter, ptfhost, with_srh):
+    duthost = setup_uN['duthost']
+    dut_mac = setup_uN['dut_mac']
+    ptf_src_port = setup_uN['ptf_src_port']
+    neighbor_ip = setup_uN['neighbor_ip']
 
     for i in range(0, 10):
         if with_srh:
@@ -170,11 +167,78 @@ def test_srv6_uN_decap_pipe_mode(duthosts, enum_frontend_dut_hostname, enum_fron
                 / IPv6(src=ptfhost.mgmt_ipv6, dst="fcbb:bbbb:1::") \
                 / IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6) / ICMPv6EchoRequest(seq=i)
 
-        expected_pkt = Ether(dst=get_neighbor_info(neighbor_ip, nbrhosts)['mac'], src=dut_mac) / \
+        expected_pkt = Ether(dst=get_neighbor_mac(duthost, neighbor_ip), src=dut_mac) / \
             IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6, tc=0x1, hlim=63)/ICMPv6EchoRequest(seq=i)
         logger.debug("Expected packet #{}: {}".format(i, expected_pkt.summary()))
         runSendReceive(injected_pkt, ptf_src_port, expected_pkt, [ptf_src_port], True, ptfadapter)
 
-    # delete the SRv6 configuration
-    duthost.command(sonic_db_cli + " CONFIG_DB DEL SRV6_MY_LOCATORS\\|loc1")
-    duthost.command(sonic_db_cli + " CONFIG_DB DEL SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48")
+
+@pytest.mark.parametrize("with_srh", [True, False])
+def test_srv6_dataplane_after_config_reload(setup_uN, ptfadapter, ptfhost, with_srh):
+    duthost = setup_uN['duthost']
+    dut_mac = setup_uN['dut_mac']
+    ptf_src_port = setup_uN['ptf_src_port']
+    neighbor_ip = setup_uN['neighbor_ip']
+
+    # verify the forwarding works
+    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, with_srh)
+
+    # reload the config
+    duthost.command("config reload -y -f")
+    time.sleep(180)
+
+    sonic_db_cli = "sonic-db-cli" + setup_uN['cli_options']
+    # wait for the config to be reprogrammed
+    assert wait_until(180, 2, 0, verify_appl_db_sid_entry_exist, duthost, sonic_db_cli,
+                      "SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1::", True), "SID is missing in APPL_DB"
+
+    # verify the forwarding works after config reload
+    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh)
+
+
+@pytest.mark.parametrize("with_srh", [True, False])
+def test_srv6_dataplane_after_bgp_restart(setup_uN, ptfadapter, ptfhost, with_srh):
+    duthost = setup_uN['duthost']
+    dut_mac = setup_uN['dut_mac']
+    ptf_src_port = setup_uN['ptf_src_port']
+    neighbor_ip = setup_uN['neighbor_ip']
+
+    # verify the forwarding works
+    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, with_srh)
+
+    # restart BGP service, which will restart the BGP container
+    if duthost.is_multi_asic:
+        duthost.command("systemctl restart bgp@{}".format(setup_uN['asic_index']))
+    else:
+        duthost.command("systemctl restart bgp")
+    time.sleep(180)
+
+    sonic_db_cli = "sonic-db-cli" + setup_uN['cli_options']
+    # wait for the config to be reprogrammed
+    assert wait_until(180, 2, 0, verify_appl_db_sid_entry_exist, duthost, sonic_db_cli,
+                      "SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1::", True), "SID is missing in APPL_DB"
+
+    # verify the forwarding works after BGP restart
+    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh)
+
+
+@pytest.mark.parametrize("with_srh", [True, False])
+def test_srv6_dataplane_after_reboot(setup_uN, ptfadapter, ptfhost, localhost, with_srh):
+    duthost = setup_uN['duthost']
+    dut_mac = setup_uN['dut_mac']
+    ptf_src_port = setup_uN['ptf_src_port']
+    neighbor_ip = setup_uN['neighbor_ip']
+
+    # verify the forwarding works
+    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, with_srh)
+
+    # reboot DUT
+    reboot(duthost, localhost, safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
+
+    sonic_db_cli = "sonic-db-cli" + setup_uN['cli_options']
+    # wait for the config to be reprogrammed
+    assert wait_until(180, 2, 0, verify_appl_db_sid_entry_exist, duthost, sonic_db_cli,
+                      "SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1::", True), "SID is missing in APPL_DB"
+
+    # verify the forwarding works after reboot
+    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh)

--- a/tests/srv6/test_srv6_static_config.py
+++ b/tests/srv6/test_srv6_static_config.py
@@ -1,17 +1,13 @@
 import time
 import pytest
 from tests.common.utilities import wait_until
+from srv6_utils import verify_appl_db_sid_entry_exist
 
 pytestmark = [
     pytest.mark.topology('t0', 't1')
 ]
 
 WAIT_TIME = 5
-
-
-def verify_appl_db_sid_entry_exist(duthost, sonic_db_cli, key, exist):
-    appl_db_my_sids = duthost.command(sonic_db_cli + " APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
-    return key in appl_db_my_sids if exist else key not in appl_db_my_sids
 
 
 def test_uN_config(duthosts, enum_frontend_dut_hostname, enum_rand_one_asic_index):


### PR DESCRIPTION
Cherry-pick PR

Summary: In daily operations, the switches may perform configuration reloading or BGP service restart to recover from transient failures. We need to add test cases to verify that SRv6 functionalities work correctly after the recovery.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
