### PR TITLE
[PR:17393][202405] disable pfcwd before running qos_sai testing.

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -29,6 +29,9 @@ from tests.common.system_utils import docker  # noqa F401
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common import config_reload
 from tests.common.devices.eos import EosHost
+from tests.common.snappi_tests.qos_fixtures import get_pfcwd_config, reapply_pfcwd
+from tests.common.snappi_tests.common_helpers import \
+        stop_pfcwd, disable_packet_aging, enable_packet_aging
 
 logger = logging.getLogger(__name__)
 
@@ -1933,6 +1936,19 @@ class QosSaiBase(QosBase):
                     config_reload,
                     duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True,
                 )
+
+    @pytest.fixture(scope='module', autouse=True)
+    def dut_disable_pfcwd(self, duthosts):
+        pfcwd_value = {}
+        for duthost in duthosts:
+            pfcwd_value[duthost.hostname] = get_pfcwd_config(duthost)
+            stop_pfcwd(duthost)
+            disable_packet_aging(duthost)
+        yield
+        for duthost in duthosts:
+            reapply_pfcwd(duthost, pfcwd_value[duthost.hostname])
+            enable_packet_aging(duthost)
+
 
     @pytest.fixture(scope='class', autouse=True)
     def sharedHeadroomPoolSize(

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1941,6 +1941,7 @@ class QosSaiBase(QosBase):
     def dut_disable_pfcwd(self, duthosts):
         switch_type = duthosts[0].facts.get('switch_type')
         if switch_type != 'chassis-packet':
+            yield
             return
 
         # for packet chassis, the packet may go through backplane

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1939,6 +1939,13 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='module', autouse=True)
     def dut_disable_pfcwd(self, duthosts):
+        switch_type = duthosts[0].facts.get('switch_type')
+        if switch_type != 'chassis-packet':
+            return
+
+        # for packet chassis, the packet may go through backplane
+        # once tx is disabled on egress port, the continuous PFC PAUSE frame will trigger PFCWD on backplane ports
+        # to avoid the impact, we will disable it first before running the test
         pfcwd_value = {}
         for duthost in duthosts:
             pfcwd_value[duthost.hostname] = get_pfcwd_config(duthost)
@@ -1948,7 +1955,6 @@ class QosSaiBase(QosBase):
         for duthost in duthosts:
             reapply_pfcwd(duthost, pfcwd_value[duthost.hostname])
             enable_packet_aging(duthost)
-
 
     @pytest.fixture(scope='class', autouse=True)
     def sharedHeadroomPoolSize(


### PR DESCRIPTION
Cherry pick sonic-mgmt #17393
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
After https://github.com/sonic-net/sonic-utilities/pull/3792, we need to disable pfcwd on backplane ports. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
PFCWD needs to be disabled on backplane ports when running qos_sai testing

#### How did you do it?
added module level fixture to disable pfcwd

#### How did you verify/test it?
TBD

#### Any platform specific information?


#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
