### PR TITLE
[manual] [PR:17385] Fix duthost.fetch causing delays in the test_fib

### DIFF
--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -63,7 +63,8 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts):
             asic = duthost.asic_instance(asic_index)
 
             asic.shell("{} redis-dump -d 0 -k 'ROUTE*' -y > /tmp/fib.{}.txt".format(asic.ns_arg, timestamp))
-            duthost.fetch(src="/tmp/fib.{}.txt".format(timestamp), dest="/tmp/fib")
+            # change fetch to fetch_no_slurp to resolve slow fetch issue
+            duthost.fetch_no_slurp(src="/tmp/fib.{}.txt".format(timestamp), dest="/tmp/fib")
 
             po_members = asic_cfg_facts.get('PORTCHANNEL_MEMBER', {})
             ports = asic_cfg_facts.get('PORT', {})


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This is a cherry-picked PR with resolved auto merge conflict issue to merge test_fib changes already delivered to master, targeting 202411 branch.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #31598080 fib/test_fib.py spend long time
duthost.fetch can cause significant delays in the test and this PR replaces it with duthost.fetch_no_slurp, where we observe dramatic save in time during the test.

Before the change, it caused 10 mins per fetch per ASIC in Cisco T2 chassis, where as the fix reduced this time down to ~3seconds per fetch per ASIC. Since we have 3 ASICs per LC and 3 LCs in DUT, this fix will theoretically save 5373s/89.55mins per test, which is 99.5% reduction in fetch time.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Before:
22/02/2025 23:04:02 base._run L0071 DEBUG | /var/src/sonic-mgmt_xxx/tests/common/fixtures/fib_utils.py::get_t2_fib_info#66: [lc1] AnsibleModule::fetch, args=[], kwargs={"src": "/tmp/fib.2025-02-22-22:49:32.txt", "dest": "/tmp/fib"}
22/02/2025 23:13:51 base._run L0108 DEBUG | /var/src/sonic-mgmt_xxx/tests/common/fixtures/fib_utils.py::get_t2_fib_info#66: [lc1] AnsibleModule::fetch Result => {"changed": true, "md5sum": "e968d9d58e41dabdfc084a3e52f39ee3", "dest": "/tmp/fib/lc1/tmp/fib.2025-02-22-22:49:32.txt", "remote_md5sum": null, "checksum": "ea17dc6889b0c809ef719dd712baa58e068374e0", "remote_checksum": "ea17dc6889b0c809ef719dd712baa58e068374e0", "_ansible_no_log": null, "failed": false}

After:
06/03/2025 04:19:49 base._run L0071 DEBUG | /var/src/sonic-mgmt_xxx/tests/common/fixtures/fib_utils.py::get_t2_fib_info#70: [lc1] AnsibleModule::fetch_no_slurp, args=[], kwargs={"src": "/tmp/fib.2025-03-06-04:18:56.txt", "dest": "/tmp/fib"}
06/03/2025 04:19:52 base._run L0108 DEBUG | /var/src/sonic-mgmt_xxx/tests/common/fixtures/fib_utils.py::get_t2_fib_info#70: [lc1] AnsibleModule::fetch_no_slurp Result => {"changed": true, "md5sum": "d00cc1029cdae8824202fd9741398479", "dest": "/tmp/fib/lc1/tmp/fib.2025-03-06-04:18:56.txt", "remote_md5sum": null, "checksum": "1baae288d8d0da9eeaa1d3da920973a0581e87fa", "remote_checksum": "1baae288d8d0da9eeaa1d3da920973a0581e87fa", "_ansible_no_log": null, "failed": false}
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
