### PR TITLE
Temporarily skipping few testcases in platform_tests/api/test_thermal.py and test_thermal_state_db.py for cisco devices

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -586,15 +586,19 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_get_low_threshold:
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_maximum_recorded:
   skip:
-    reason: "Unsupported platform API"
+    conditions_logical_operator: or
+    reason: "Unsupported platform API in mellanox. Skip in case of Cisco platform for T2 profile due to temperarory bug."
     conditions:
       - "asic_type in ['mellanox']"
+      - "asic_type in ['cisco-8000'] and topo_type in ['t2']"
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_minimum_recorded:
   skip:
-    reason: "Unsupported platform API"
+    conditions_logical_operator: or
+    reason: "Unsupported platform API in mellanox. Skip in case of Cisco platform for T2 profile due to temperarory bug."
     conditions:
       - "asic_type in ['mellanox']"
+      - "asic_type in ['cisco-8000'] and topo_type in ['t2']"
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_model:
   # Hardware components that we use for our sensors does not have IDPROM to store model and serial number details.
@@ -626,9 +630,11 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_get_status:
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_temperature:
   skip:
-    reason: "Unsupported platform API"
+    conditions_logical_operator: or
+    reason: "Unsupported platform API in mellanox. Skip in case of Cisco platform for T2 profile due to temperarory bug."
     conditions:
       - "asic_type in ['mellanox']"
+      - "asic_type in ['cisco-8000'] and topo_type in ['t2']"
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_set_high_threshold:
   skip:
@@ -1027,6 +1033,16 @@ platform_tests/test_service_warm_restart.py:
     reason: "Testcase ignored due to sonic-mgmt issue: https://github.com/sonic-net/sonic-mgmt/issues/10362"
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/10362"
+
+#######################################
+#####test_thermal_state_db.py #####
+#######################################
+
+platform_tests/test_thermal_state_db.py:
+  skip:
+    reason: "Skip in case of Cisco platform for T2 profile due to temperarory bug."
+    conditions:
+      - "asic_type in ['cisco-8000'] and topo_type in ['t2']"
 
 #######################################
 #####   test_xcvr_info_in_db.py   #####


### PR DESCRIPTION
### Description of PR
Due to a Jira, temporarily skipping few testcases in platform_tests/api/test_thermal.py and test_thermal_state_db.py. Will revert it as soon as the jira is fixed

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405

### Approach
#### What is the motivation for this PR?
Due to a Jira, temporarily skipping few testcases in platform_tests/api/test_thermal.py and test_thermal_state_db.py. Will revert it as soon as the jira is fixed

#### How did you do it?
Skip in conditional_mark file

SKIPPED [9] platform_tests/api/test_thermal.py: Unsupported platform API in mellanox. Skip in case of Cisco platform for T2 profile due to temperarory bug.

#### Any platform specific information?
Cisco 8808 chassis and T2 profile

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
