### PR TITLE
Porting 17012 to sonic-mgmt.msft/202405: Static route ixia

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -9,6 +9,7 @@ import sys
 import random
 import snappi_convergence
 from tests.common.helpers.assertions import pytest_require
+from tests.common.errors import RunAnsibleModuleFail
 from ipaddress import ip_address, IPv4Address, IPv6Address
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa: F401
 from tests.common.snappi_tests.common_helpers import get_addrs_in_subnet, get_peer_snappi_chassis, \
@@ -858,6 +859,9 @@ def __intf_config_multidut(config, port_config_list, duthost, snappi_ports, setu
             cmd = "add"
         else:
             cmd = "remove"
+        if not setup:
+            static_routes_cisco_8000(tgenIp, duthost, port['peer_port'], port['asic_value'], setup)
+
         if port['asic_value'] is None:
             duthost.command('sudo config interface ip {} {} {}/{} \n' .format(
                                                                                 cmd,
@@ -871,6 +875,8 @@ def __intf_config_multidut(config, port_config_list, duthost, snappi_ports, setu
                                                                                     port['peer_port'],
                                                                                     dutIp,
                                                                                     prefix_length))
+        if setup:
+            static_routes_cisco_8000(tgenIp, duthost, port['peer_port'], port['asic_value'], setup)
         if setup is False:
             continue
         port['intf_config_changed'] = True
@@ -1293,3 +1299,59 @@ def check_fabric_counters(duthost):
                               format(crc_errors, duthost.hostname, val_list[0], val_list[1]))
                 pytest_assert(fec_uncor_err == 0, 'Forward Uncorrectable errors:{} for DUT:{}, ASIC:{}, Port:{}'.
                               format(fec_uncor_err, duthost.hostname, val_list[0], val_list[1]))
+
+
+DEST_TO_GATEWAY_MAP = {}
+
+
+# Add static routes using CLI WAY.
+def static_routes_cisco_8000(addr, dut=None, intf=None, namespace=None, setup=True):
+    '''
+        Return a static route-d IP address for the given IP gateway(Ixia port address).
+        Also configure the same in the DUT.
+    '''
+    global DEST_TO_GATEWAY_MAP
+    if dut is None:
+        if addr not in DEST_TO_GATEWAY_MAP:
+            raise RuntimeError(f"Request for dest addr: {addr} without setting it in advance.")
+        return DEST_TO_GATEWAY_MAP[addr]['dest']
+
+    if (dut.facts['asic_type'] != "cisco-8000" or
+            not dut.get_facts().get("modular_chassis", None)):
+        return addr
+
+    if setup:
+        if addr in DEST_TO_GATEWAY_MAP:
+            return DEST_TO_GATEWAY_MAP[addr]['dest']
+
+    '''
+        Create a new IP address, which is computed from
+        (given addr + 3.0.0.0) addresses later.
+        So the dest for 200.0.0.1 will be 203.0.0.1/32
+    '''
+    ip_addr = ip_address(addr)
+    DEST_TO_GATEWAY_MAP[addr] = {}
+    DEST_TO_GATEWAY_MAP[addr]['dest'] = str(ip_addr + 3*256*256*256)
+    DEST_TO_GATEWAY_MAP[addr]['intf'] = intf
+    cmd = "del"
+    if setup:
+        cmd = "add"
+    asic_arg = ""
+    if namespace is not None:
+        asic_arg = f"ip netns exec {namespace}"
+    try:
+        dut.shell(
+            "{} config route {} prefix {}/32 nexthop {} {}".format(
+                asic_arg, cmd, DEST_TO_GATEWAY_MAP[addr]['dest'], addr,
+                DEST_TO_GATEWAY_MAP[addr]['intf']))
+    except RunAnsibleModuleFail:
+        if setup:
+            raise
+        else:
+            # Its already removed by reboot
+            pass
+
+    if setup:
+        return DEST_TO_GATEWAY_MAP[addr]['dest']
+    else:
+        del DEST_TO_GATEWAY_MAP[addr]

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -15,6 +15,7 @@ from tests.common.snappi_tests.common_helpers import get_egress_queue_count, pfc
 from tests.common.snappi_tests.port import select_ports, select_tx_port
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
 from tests.common.cisco_data import is_cisco_device
 
 # Imported to support rest_py in ixnetwork
@@ -164,7 +165,7 @@ def generate_test_flows(testbed_config,
             eth.pfc_queue.value = pfcQueueValueDict[prio]
 
         ipv4.src.value = base_flow_config["tx_port_config"].ip
-        ipv4.dst.value = base_flow_config["rx_port_config"].ip
+        ipv4.dst.value = static_routes_cisco_8000(base_flow_config["rx_port_config"].ip)
         ipv4.priority.choice = ipv4.priority.DSCP
         ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
         ipv4.priority.dscp.ecn.value = (ipv4.priority.dscp.ecn.CONGESTION_ENCOUNTERED if congested else
@@ -250,7 +251,7 @@ def generate_background_flows(testbed_config,
             eth.pfc_queue.value = pfcQueueValueDict[prio]
 
         ipv4.src.value = base_flow_config["tx_port_config"].ip
-        ipv4.dst.value = base_flow_config["rx_port_config"].ip
+        ipv4.dst.value = static_routes_cisco_8000(base_flow_config["rx_port_config"].ip)
         ipv4.priority.choice = ipv4.priority.DSCP
         ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
         ipv4.priority.dscp.ecn.value = (

--- a/tests/snappi_tests/conftest.py
+++ b/tests/snappi_tests/conftest.py
@@ -76,3 +76,19 @@ def enable_packet_aging_after_test(duthosts, rand_one_dut_hostname):
 
     duthost = duthosts[rand_one_dut_hostname]
     enable_packet_aging(duthost)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def ignore_route_check_for_cisco_8000(duthosts, loganalyzer):
+    if not loganalyzer:
+        yield
+        return
+    ignore_list = [r".*'routeCheck' status failed .*", r".*missing interface entry for static route.*"]
+    for dut in duthosts:
+        if (dut.facts['asic_type'] == "cisco-8000" and
+                dut.get_facts().get("modular_chassis", None)):
+            for line in ignore_list:
+                loganalyzer[dut.hostname].ignore_regex.append(line)
+
+    yield
+    return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
For cisco-8000, if the traffic flows to a connected route, the system uses the default voq. If we use static route, it uses the split-voq. In this PR, we change the dest IP address of the traffic streams to a static routed destination, and add that static route as well in the DUT. To test it, we have used the ECN script, and had to modify it as well.

In ECN we keep hitting the drop or other limits before hitting the xoff limits, due to the default voq. So changing it to static route helps in passing the tests.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Approach
#### What is the motivation for this PR?
Hitting failures in multiple tests due to traffic taking default voq (due to the connected routes).

#### How did you do it?
Added a new function to add static route in DUT, and use the new IP destination value for the traffic stream.

#### How did you verify/test it?
Alpesh had run the code in 202405 in my TB.

#### Any platform specific information?
Only for cisco-8000.