### PR TITLE
[API transceiver_info] update xcvr info keys

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -103,6 +103,7 @@ class TestSfpApi(PlatformApiTestBase):
         'cable_length',
         'specification_compliance',
         'nominal_bit_rate',
+        'vdm_supported'
     ]
 
     # some new keys added for QSFP-DD and OSFP in 202205 or later branch
@@ -425,6 +426,9 @@ class TestSfpApi(PlatformApiTestBase):
                             if 'ZR' in info_dict['media_interface_code']:
                                 UPDATED_EXPECTED_XCVR_INFO_KEYS = UPDATED_EXPECTED_XCVR_INFO_KEYS + \
                                                                   self.QSFPZR_EXPECTED_XCVR_INFO_KEYS
+                        elif info_dict["type_abbrv_name"] == "SFP":
+                            UPDATED_EXPECTED_XCVR_INFO_KEYS = [
+                                key for key in self.EXPECTED_XCVR_INFO_KEYS if key != 'vdm_supported']
                         else:
                             UPDATED_EXPECTED_XCVR_INFO_KEYS = self.EXPECTED_XCVR_INFO_KEYS
                     missing_keys = set(UPDATED_EXPECTED_XCVR_INFO_KEYS) - set(actual_keys)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
Update xcvr info keys based on PR https://github.com/Azure/sonic-platform-common.msft/pull/69.
The change is not related to SFP cable.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
Allign the test with latest changes


#### How did you verify/test it?
Executed test test_get_transceiver_info on setup with different cable.



