### PR TITLE
[202412] Code sync sonic-net/sonic-mgmt:202411 => 202412

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/py3/wr_arp.py
@@ -24,6 +24,8 @@ import ptf
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
 import ptf.testutils as testutils
+import ptf.packet as scapy    # noqa: F401
+from scapy.arch.linux import attach_filter as attach_filter
 from device_connection import DeviceConnection
 from utilities import parse_show
 import ipaddress
@@ -221,6 +223,11 @@ class ArpTest(BaseTest):
 
     def setUp(self):
         self.dataplane = ptf.dataplane_instance
+
+        # Apply filters
+        for p in self.dataplane.ports.values():
+            port = p.get_packet_source()
+            attach_filter(port.socket, 'arp and not ether dst ff:ff:ff:ff:ff:ff', port.interface_name)
 
         config = self.get_param('config_file')
         self.ferret_ip = self.get_param('ferret_ip')

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -324,3 +324,9 @@ r, ".* ERR kernel:.*sxd_kernel: \[error\] Health-Check: device=1, cause=10 \['SD
 # Ignore gbsynd error for 720DT
 r, ".*ERR gbsyncd#syncd: :- collectData: Failed to get stats of Port Counter.*"
 r, ".*ERR gbsyncd#syncd: :- diagShellThreadProc: Failed to enable switch shell: SAI_STATUS_NOT_SUPPORTED.*"
+r, ".* ERR gbsyncd#syncd: /arsonic/packages/broncos-sai/build/PAI_\d+\.\d+/src/brcm_pai_port\.c:\d+ brcm_pai_get_port_stats.*\s*.*"
+r, ".* ERR gbsyncd#syncd: /arsonic/packages/broncos-sai/build/PAI_\d+\.\d+/src/brcm_pai_adapter\.c:\d+ sai_api_query: :- Invalid sai_api_t \d+ passed#\d+"
+r, ".* ERR gbsyncd#syncd: /arsonic/packages/broncos-sai/build/PAI_\d+\.\d+/src/brcm_pai_switch\.c:\d+ pai_get_switch_attribute: :- Error processing switch attribute \d+\[\d+\]\.#\d+"
+
+# Ignore SAI_NEXT_HOP_GROUP_ATTR_TYPE unsupported
+r, ".* ERR swss#orchagent:.*queryAttributeEnumValuesCapability:.*returned value \d+ is not allowed on SAI_NEXT_HOP_GROUP_ATTR_TYPE"

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -7,7 +7,7 @@
 # By using this practice, we suggest to add different tags for different PTF image versions in docker registry.
 - name: Set default value for ptf_imagetag
   set_fact:
-    ptf_imagetag: "latest"
+    ptf_imagetag: "202411"
   when: ptf_imagetag is not defined
 
 - name: set "PTF" container type, by default

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -12,7 +12,7 @@
   block:
   - name: Set default value for ptf_imagetag
     set_fact:
-      ptf_imagetag: "latest"
+      ptf_imagetag: "202411"
     when: ptf_imagetag is not defined
 
   - name: Stop mux simulator

--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -325,15 +325,6 @@ def create_bfd_sessions_multihop(ptfhost, duthost, loopback_addr, ptf_intf, neig
     logger.info("BFD Summary dump: {}".format(temp['stdout']))
 
 
-def bfd_echo_mode(duthost, neighbor_addrs,):
-    # Apply BFD echo mode configuration with vtysh
-    cmd = "vtysh -c 'configure terminal' -c 'bfd'"
-    for neighbor_addr in neighbor_addrs:
-        cmd += " -c 'bfd peer {}' -c 'echo-mode'".format(neighbor_addr)
-    cmd += " -c 'end' -c 'do write' -c 'exit'"
-    duthost.shell(cmd)
-
-
 def remove_bfd_sessions(duthost, neighbor_addrs):
     # Create a tempfile for BFD sessions
     bfd_file_dir = duthost.shell('mktemp')['stdout']
@@ -494,35 +485,3 @@ def test_bfd_multihop(request, rand_selected_dut, ptfhost, tbinfo,
         duthost.shell(cmd_buffer, module_ignore_errors=True)
         ptfhost.command('supervisorctl stop bfd_responder')
         ptfhost.file(path=BFD_RESPONDER_SCRIPT_DEST_PATH, state="absent")
-
-
-@pytest.mark.parametrize('ipv6', [False, True], ids=['ipv4', 'ipv6'])
-def test_bfd_echo_mode(request, rand_selected_dut, ptfhost, tbinfo, ipv6):
-    duthost = rand_selected_dut
-    bfd_session_cnt = int(request.config.getoption('--num_sessions'))
-
-    # Get neighbors for BFD sessions
-    neighbor_addrs = get_neighbors(duthost, tbinfo, ipv6, count=bfd_session_cnt)[2]
-
-    try:
-        # Use bfd_echo_mode function for direct configuration
-        bfd_echo_mode(duthost, neighbor_addrs)  # Pass None for optional logger
-
-        # Verify BFD sessions with echo mode enabled
-        time.sleep(30)  # Wait for BFD sessions to be established
-        result = duthost.shell("vtysh -c 'show bfd peer'")['stdout'].split('\n')
-        error = False
-        for line in result:
-            if ('Echo transmission interval:' in line) or (
-                    'Echo receive interval:' in line):
-                if 'disabled' in line:
-                    error = True
-        assert error is False
-    finally:
-        # Cleanup: Remove BFD sessions and echo mode configurations
-        remove_bfd_sessions(duthost, neighbor_addrs)
-
-        # No need for temporary BFD echo mode config file or cleanup for it
-
-        # FRR commands to disable bfd instances.
-        duthost.shell("vtysh -c 'configure terminal' -c 'no bfd' -c 'end' -c 'do write' -c 'exit'")

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -21,6 +21,7 @@ from tests.common.dualtor.data_plane_utils import get_peerhost
 from tests.common.dualtor.dual_tor_utils import show_muxcable_status
 from tests.common.fixtures.duthost_utils import check_bgp_router_id
 from tests.common.utilities import wait_until
+from tests.common.helpers.dut_ports import get_vlan_interface_list, get_vlan_interface_info
 
 logger = logging.getLogger(__name__)
 
@@ -203,9 +204,11 @@ class AdvancedReboot:
                                                   self.mgFacts['minigraph_lo_interfaces'][0]['prefixlen'])
 
         vlan_ip_range = dict()
-        for vlan in self.mgFacts['minigraph_vlan_interfaces']:
-            if type(ipaddress.ip_network(vlan['subnet'])) is ipaddress.IPv4Network:
-                vlan_ip_range[vlan['attachto']] = vlan['subnet']
+        vlan_interfaces = get_vlan_interface_list(self.duthost)
+        for vlan_if_name in vlan_interfaces:
+            vlan_ipv4_entry = get_vlan_interface_info(self.duthost, tbinfo, vlan_if_name, "ipv4")
+            vlan_ip_range[vlan_if_name] = vlan_ipv4_entry['subnet']
+        logger.info('Vlan IP range: {}'.format(vlan_ip_range))
         self.rebootData['vlan_ip_range'] = json.dumps(vlan_ip_range)
 
         self.rebootData['dut_username'] = self.creds['sonicadmin_user']
@@ -421,12 +424,14 @@ class AdvancedReboot:
         logger.info('Clearing all fdb entries on DUT  {}'.format(self.duthost.hostname))
         self.duthost.shell('sonic-clear fdb all')
 
-    def __fetchTestLogs(self, rebootOper=None):
+    def __fetchTestLogs(self, rebootOper=None, log_dst_suffix=None):
         """
-        Fetch test logs from duthost and ptfhost after individual test run
+        Fetch test logs from duthost and ptfhost.
+        @param rebootOper: if provided it will be added to each individual file name
+        @param log_dst_suffix: if provided it will be appended to the directory name
         """
-        if rebootOper:
-            dir_name = "{}_{}".format(self.request.node.name, rebootOper)
+        if log_dst_suffix:
+            dir_name = "{}_{}".format(self.request.node.name, log_dst_suffix)
         else:
             dir_name = self.request.node.name
         report_file_dir = os.path.realpath((os.path.join(os.path.dirname(__file__), "../../logs/platform_tests/")))
@@ -597,7 +602,7 @@ class AdvancedReboot:
                 if self.postboot_setup:
                     self.postboot_setup()
                 # capture the test logs, and print all of them in case of failure, or a summary in case of success
-                log_dir = self.__fetchTestLogs(rebootOper)
+                log_dir = self.__fetchTestLogs(rebootOper, log_dst_suffix=rebootOper)
                 self.print_test_logs_summary(log_dir)
                 if self.advanceboot_loganalyzer and post_reboot_analysis:
                     verification_errors = post_reboot_analysis(marker, event_counters=event_counters,
@@ -630,6 +635,88 @@ class AdvancedReboot:
         self.postboot_setup = postboot_setup
         self.imageInstall(prebootList, inbootList, prebootFiles)
         return self.runRebootTest()
+
+    def runMultiHopRebootTestcase(self, upgrade_path_urls, prebootFiles='peer_dev_info,neigh_port_info',
+                                  base_image_setup=None, pre_hop_setup=None,
+                                  post_hop_teardown=None, multihop_advanceboot_loganalyzer_factory=None):
+        """
+        This method validates and prepares test bed for multi-hop reboot test case. It runs the reboot test case using
+        provided test arguments.
+        @param prebootList: list of operation to run before reboot process
+        @param prebootFiles: preboot files
+        """
+        # Install image A (base image)
+        self.imageInstall(None, None, prebootFiles)
+        if base_image_setup:
+            base_image_setup()
+
+        test_results = dict()
+        test_case_name = str(self.request.node.name)
+        test_results[test_case_name] = list()
+        for hop_index, _ in enumerate(upgrade_path_urls[1:], start=1):
+            try:
+                if pre_hop_setup:
+                    pre_hop_setup(hop_index)
+                if multihop_advanceboot_loganalyzer_factory:
+                    pre_reboot_analysis, post_reboot_analysis = multihop_advanceboot_loganalyzer_factory(hop_index)
+                    marker = pre_reboot_analysis()
+                event_counters = self.__setupRebootOper(None)
+
+                # Run the upgrade
+                thread = InterruptableThread(
+                    target=self.__runPtfRunner,
+                    kwargs={"ptf_collect_dir": "./logs/ptf_collect/hop{}/".format(hop_index)})
+                thread.daemon = True
+                thread.start()
+                # give the test REBOOT_CASE_TIMEOUT (1800s) to complete the reboot with IO,
+                # and then additional 300s to examine the pcap, logs and generate reports
+                ptf_timeout = REBOOT_CASE_TIMEOUT + 300
+                thread.join(timeout=ptf_timeout, suppress_exception=True)
+                self.ptfhost.shell("pkill -f 'ptftests advanced-reboot.ReloadTest'", module_ignore_errors=True)
+                # the thread might still be running, and to catch any exceptions after pkill allow 10s to join
+                thread.join(timeout=10)
+
+                self.__verifyRebootOper(None)
+                if self.duthost.num_asics() == 1 and not check_bgp_router_id(self.duthost, self.mgFacts):
+                    test_results[test_case_name].append("Failed to verify BGP router identifier is Loopback0 on %s" %
+                                                        self.duthost.hostname)
+                if post_hop_teardown:
+                    post_hop_teardown(hop_index)
+            except Exception:
+                traceback_msg = traceback.format_exc()
+                err_msg = "Exception caught while running advanced-reboot test on ptf: \n{}".format(traceback_msg)
+                logger.error(err_msg)
+                test_results[test_case_name].append(err_msg)
+            finally:
+                # capture the test logs, and print all of them in case of failure, or a summary in case of success
+                log_dir = self.__fetchTestLogs(log_dst_suffix="hop{}".format(hop_index))
+                self.print_test_logs_summary(log_dir)
+                if multihop_advanceboot_loganalyzer_factory and post_reboot_analysis:
+                    verification_errors = post_reboot_analysis(marker, event_counters=event_counters, log_dir=log_dir)
+                    if verification_errors:
+                        logger.error("Post reboot verification failed. List of failures: {}"
+                                     .format('\n'.join(verification_errors)))
+                        test_results[test_case_name].extend(verification_errors)
+                    # Set the post_reboot_analysis to None to avoid using it again after post_hop_teardown
+                    # on the subsequent iteration in the event that we land in the finally block before
+                    # the new one is initialised
+                    post_reboot_analysis = None
+                self.acl_manager_checker(test_results[test_case_name])
+                self.__clearArpAndFdbTables()
+                self.__revertRebootOper(None)
+
+            failed_list = [(testcase, failures) for testcase, failures in list(test_results.items())
+                           if len(failures) != 0]
+            pytest_assert(len(failed_list) == 0, "Advanced-reboot failure. Failed multi-hop test {testname} "
+                                                 "on update {hop_index} from {from_image} to {to_image}, "
+                                                 "failure summary:\n{fail_summary}".format(
+                                                    testname=self.request.node.name,
+                                                    hop_index=hop_index,
+                                                    from_image=upgrade_path_urls[hop_index-1],
+                                                    to_image=upgrade_path_urls[hop_index],
+                                                    fail_summary=failed_list
+                                                ))
+        return True  # Success
 
     def __setupRebootOper(self, rebootOper):
         if self.dual_tor_mode:
@@ -695,10 +782,11 @@ class AdvancedReboot:
             logger.info('Running revert handler for reboot operation {}'.format(rebootOper))
             rebootOper.revert()
 
-    def __runPtfRunner(self, rebootOper=None):
+    def __runPtfRunner(self, rebootOper=None, ptf_collect_dir="./logs/ptf_collect/"):
         """
         Run single PTF advanced-reboot.ReloadTest
         @param rebootOper:Reboot operation to conduct before/during reboot process
+        @param ptf_collect_dir: PTF log collection directory
         """
         logger.info("Running PTF runner on PTF host: {0}".format(self.ptfhost))
 
@@ -776,6 +864,7 @@ class AdvancedReboot:
             platform="remote",
             params=params,
             log_file='/tmp/advanced-reboot.ReloadTest.log',
+            ptf_collect_dir=ptf_collect_dir,
             module_ignore_errors=self.moduleIgnoreErrors,
             timeout=REBOOT_CASE_TIMEOUT,
             is_python3=True

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -210,15 +210,16 @@ def setup_vlan_arp_responder(ptfhost, rand_selected_dut, tbinfo):
     if 'dualtor' in tbinfo['topo']['name']:
         server_ip = mux_cable_server_ip(rand_selected_dut)
 
+    ip_offset = 0
     for port in vlan_members:
         ptf_index = dut_to_ptf_port_map[port]
+        ip_offset = ptf_index + 1  # Add one since PTF indices start at 0
         if 'dualtor' in tbinfo['topo']['name']:
             arp_responder_cfg['eth{}'.format(ptf_index)] = [
                 server_ip[port]['server_ipv4'].split('/')[0],
                 server_ip[port]['server_ipv6'].split('/')[0]
             ]
             continue
-        ip_offset = ptf_index + 1  # Add one since PTF indices start at 0
         arp_responder_cfg['eth{}'.format(ptf_index)] = [
             str(ipv4_base.ip + ip_offset), str(ipv6_base.ip + ip_offset)
         ]

--- a/tests/common/helpers/dut_ports.py
+++ b/tests/common/helpers/dut_ports.py
@@ -99,7 +99,7 @@ def get_vlan_interfaces_dict(duthost, tbinfo):
             ip_with_prefix = f"{interface['addr']}/{interface['prefixlen']}"
             if ip_with_prefix in config_facts['VLAN_INTERFACE'][vlan]:
                 config = config_facts['VLAN_INTERFACE'][vlan][ip_with_prefix]
-                if config.get('secondary') == 'true':
+                if isinstance(config, dict) and config.get('secondary') == 'true':
                     interface_info['secondary'] = True
 
         # Add to appropriate IP version list
@@ -155,7 +155,7 @@ def get_vlan_interface_info(duthost, tbinfo, vlan_name, ip_version="ipv4"):
 
     for interface in vlan_interfaces_dict[vlan_name][ip_version]:
         # Skip secondary addresses
-        if interface.get('secondary'):
+        if isinstance(interface, dict) and interface.get('secondary'):
             continue
 
         result = interface

--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 class TrafficPorts(object):
     """ Generate a list of ports needed for the PFC Watchdog test"""
-    def __init__(self, mg_facts, neighbors, vlan_nw):
+    def __init__(self, mg_facts, neighbors, vlan_nw, topo, config_facts):
         """
         Args:
             mg_facts (dict): parsed minigraph info
@@ -51,6 +51,8 @@ class TrafficPorts(object):
         self.pfc_wd_rx_port_addr = None
         self.pfc_wd_rx_neighbor_addr = None
         self.pfc_wd_rx_port_id = None
+        self.topo = topo
+        self.config_facts = config_facts
 
     def build_port_list(self):
         """
@@ -225,7 +227,9 @@ class TrafficPorts(object):
         rx_port = self.pfc_wd_rx_port if isinstance(self.pfc_wd_rx_port, list) else [self.pfc_wd_rx_port]
         rx_port_id = self.pfc_wd_rx_port_id if isinstance(self.pfc_wd_rx_port_id, list) else [self.pfc_wd_rx_port_id]
         for item in vlan_members:
-            temp_ports[item] = {'test_neighbor_addr': self.vlan_nw,
+            ip_addr = self.vlan_nw if 'dualtor' not in self.topo else \
+                      self.config_facts['MUX_CABLE'][item]['server_ipv4'].split('/')[0]
+            temp_ports[item] = {'test_neighbor_addr': ip_addr,
                                 'rx_port': rx_port,
                                 'rx_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
                                 'peer_device': self.neighbors.get(item, {}).get('peerdevice', ''),

--- a/tests/common/platform/args/advanced_reboot_args.py
+++ b/tests/common/platform/args/advanced_reboot_args.py
@@ -136,6 +136,12 @@ def add_advanced_reboot_args(parser):
         )
 
     parser.addoption(
+        "--multi_hop_upgrade_path",
+        default="",
+        help="Specify the multi-hop upgrade path as a comma separated list of image URLs to download",
+    )
+
+    parser.addoption(
         "--restore_to_image",
         default="",
         help="Specify the target image to restore to, or stay in target image if empty",

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -977,7 +977,7 @@ generic_config_updater/test_dynamic_acl.py:
       - "hwsku in ['Cisco-8111-O64']"
       - "topo_name in ['m0-2vlan']"
       - "'t2' in topo_name"
-      - "platform in ['x86_64-8101_32fh_o-r0', 'x86_64-8102_64h_o-r0', 'Cisco-8101-32FH-O-C01']"
+      - "platform in ['x86_64-8101_32fh_o-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o_c01-r0']"
 
 generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -996,6 +996,14 @@ platform_tests/mellanox:
     conditions:
       - "asic_type not in ['mellanox', 'nvidia-bluefield']"
 
+platform_tests/mellanox/test_check_sfp_eeprom.py:
+  skip:
+    reason: "202405 and 202411 not support command like 'mlxlink -d /dev/mst/mt53104_pci_cr0 -p 1 -m' on mellanox spc3 devices when software control is enabled"
+    conditions_logical_operator: or
+    conditions:
+      - "'SN4' in hwsku and (release in ['202405', '202411'])"
+      - "'SN5' in hwsku and (release in ['202405', '202411'])"
+
 platform_tests/mellanox/test_check_sfp_using_ethtool.py:
   skip:
     reason: "Deprecated as Mellanox do not use ethtool in release 202305 or higher / Mellanox platform tests only supported on Mellanox devices"

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -148,7 +148,7 @@ class LogAnalyzer:
             if (self.expect_regex and (self.expected_matches_target > 0)
                and result["total"]["expected_match"] != self.expected_matches_target):
                 err_target = "Log analyzer expected {} messages but found only {}\n"\
-                    .format(self.expected_matches_target, len(self.expect_regex))
+                    .format(self.expected_matches_target, result["total"]["expected_match"])
                 raise LogAnalyzerError(err_target + result_str)
 
     def save_matching_errors(self, result_log_errors):

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -665,7 +665,10 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                         setup_info,  # noqa F811
                                         setup_mirror_session,
                                         dest_port_type, ptfadapter, tbinfo,
-                                        erspan_ip_ver):  # noqa F811
+                                        erspan_ip_ver,  # noqa F811
+                                        toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
+                                        setup_standby_ports_on_rand_unselected_tor_unconditionally    # noqa F811
+                                        ):
         """
         Verify basic forwarding scenarios for the Everflow feature with background traffic.
         Background Traffic PKT1 IP in IP with same ports & macs but with dummy ips

--- a/tests/generic_config_updater/test_portchannel_interface.py
+++ b/tests/generic_config_updater/test_portchannel_interface.py
@@ -34,6 +34,14 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
+def rand_portchannel_name(cfg_facts):
+    portchannel_dict = cfg_facts.get('PORTCHANNEL', {})
+    pytest_require(portchannel_dict, "Portchannel table is empty")
+    for portchannel_key in portchannel_dict:
+        return portchannel_key
+
+
+@pytest.fixture(scope="module")
 def portchannel_table(cfg_facts):
     def _is_ipv4_address(ip_addr):
         return ipaddress.ip_address(ip_addr).version == 4
@@ -66,7 +74,7 @@ def setup_env(duthosts, rand_one_dut_hostname, portchannel_table):
     Setup/teardown fixture for portchannel interface config
     Args:
         duthosts: list of DUTs.
-        rand_selected_dut: The fixture returns a randomly selected DuT.
+        rand_one_dut_hostname: The fixture returns a randomly selected DuT.
     """
     duthost = duthosts[rand_one_dut_hostname]
     create_checkpoint(duthost)
@@ -81,22 +89,22 @@ def setup_env(duthosts, rand_one_dut_hostname, portchannel_table):
         delete_checkpoint(duthost)
 
 
-def portchannel_interface_tc1_add_duplicate(duthost, portchannel_table):
+def portchannel_interface_tc1_add_duplicate(duthost, portchannel_table, rand_portchannel_name):
     """ Test adding duplicate portchannel interface
     """
-    dup_ip = portchannel_table["PortChannel101"]["ip"]
-    dup_ipv6 = portchannel_table["PortChannel101"]["ipv6"]
+    dup_ip = portchannel_table[rand_portchannel_name]["ip"]
+    dup_ipv6 = portchannel_table[rand_portchannel_name]["ipv6"]
     json_patch = [
         {
             "op": "add",
             "path": create_path(["PORTCHANNEL_INTERFACE",
-                                 "PortChannel101|{}".format(dup_ip)]),
+                                 "{}|{}".format(rand_portchannel_name, dup_ip)]),
             "value": {}
         },
         {
             "op": "add",
             "path": create_path(["PORTCHANNEL_INTERFACE",
-                                 "PortChannel101|{}".format(dup_ipv6.upper())]),
+                                 "{}|{}".format(rand_portchannel_name, dup_ipv6.upper())]),
             "value": {}
         }
     ]
@@ -109,13 +117,13 @@ def portchannel_interface_tc1_add_duplicate(duthost, portchannel_table):
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost, output)
 
-        check_show_ip_intf(duthost, "PortChannel101", [dup_ip], [], is_ipv4=True)
-        check_show_ip_intf(duthost, "PortChannel101", [dup_ipv6], [], is_ipv4=False)
+        check_show_ip_intf(duthost, rand_portchannel_name, [dup_ip], [], is_ipv4=True)
+        check_show_ip_intf(duthost, rand_portchannel_name, [dup_ipv6], [], is_ipv4=False)
     finally:
         delete_tmpfile(duthost, tmpfile)
 
 
-def portchannel_interface_tc1_xfail(duthost):
+def portchannel_interface_tc1_xfail(duthost, rand_portchannel_name):
     """ Test invalid ip address and remove unexited interface
 
     ("add", "PortChannel101", "10.0.0.256/31", "FC00::71/126"), ADD Invalid IPv4 address
@@ -124,10 +132,10 @@ def portchannel_interface_tc1_xfail(duthost):
     ("remove", "PortChannel101", "10.0.0.56/31", "FC00::72/126"), REMOVE Unexist IPv6 address
     """
     xfail_input = [
-        ("add", "PortChannel101", "10.0.0.256/31", "FC00::71/126"),
-        ("add", "PortChannel101", "10.0.0.56/31", "FC00::xyz/126"),
-        ("remove", "PortChannel101", "10.0.0.57/31", "FC00::71/126"),
-        ("remove", "PortChannel101", "10.0.0.56/31", "FC00::72/126")
+        ("add", rand_portchannel_name, "10.0.0.256/31", "FC00::71/126"),
+        ("add", rand_portchannel_name, "10.0.0.56/31", "FC00::xyz/126"),
+        ("remove", rand_portchannel_name, "10.0.0.57/31", "FC00::71/126"),
+        ("remove", rand_portchannel_name, "10.0.0.56/31", "FC00::72/126")
     ]
 
     for op, po_name, ip, ipv6 in xfail_input:
@@ -157,34 +165,34 @@ def portchannel_interface_tc1_xfail(duthost):
             delete_tmpfile(duthost, tmpfile)
 
 
-def portchannel_interface_tc1_add_and_rm(duthost, portchannel_table):
+def portchannel_interface_tc1_add_and_rm(duthost, portchannel_table, rand_portchannel_name):
     """ Test portchannel interface replace ip address
     """
-    org_ip = portchannel_table["PortChannel101"]["ip"]
-    org_ipv6 = portchannel_table["PortChannel101"]["ipv6"]
+    org_ip = portchannel_table[rand_portchannel_name]["ip"]
+    org_ipv6 = portchannel_table[rand_portchannel_name]["ipv6"]
     rep_ip = "10.0.0.156/31"
     rep_ipv6 = "fc00::171/126"
     json_patch = [
         {
             "op": "remove",
             "path": create_path(["PORTCHANNEL_INTERFACE",
-                                 "PortChannel101|{}".format(org_ip)])
+                                 "{}|{}".format(rand_portchannel_name, org_ip)])
         },
         {
             "op": "remove",
             "path": create_path(["PORTCHANNEL_INTERFACE",
-                                 "PortChannel101|{}".format(org_ipv6.upper())])
+                                 "{}|{}".format(rand_portchannel_name, org_ipv6.upper())])
         },
         {
             "op": "add",
             "path": create_path(["PORTCHANNEL_INTERFACE",
-                                 "PortChannel101|{}".format(rep_ip)]),
+                                 "{}|{}".format(rand_portchannel_name, rep_ip)]),
             "value": {}
         },
         {
             "op": "add",
             "path": create_path(["PORTCHANNEL_INTERFACE",
-                                 "PortChannel101|{}".format(rep_ipv6)]),
+                                 "{}|{}".format(rand_portchannel_name, rep_ipv6)]),
             "value": {}
         }
     ]
@@ -197,16 +205,17 @@ def portchannel_interface_tc1_add_and_rm(duthost, portchannel_table):
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost, output)
 
-        check_show_ip_intf(duthost, "PortChannel101", [rep_ip], [org_ip], is_ipv4=True)
-        check_show_ip_intf(duthost, "PortChannel101", [rep_ipv6], [org_ipv6], is_ipv4=False)
+        check_show_ip_intf(duthost, rand_portchannel_name, [rep_ip], [org_ip], is_ipv4=True)
+        check_show_ip_intf(duthost, rand_portchannel_name, [rep_ipv6], [org_ipv6], is_ipv4=False)
     finally:
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_portchannel_interface_tc1_suite(rand_selected_dut, portchannel_table):
-    portchannel_interface_tc1_add_duplicate(rand_selected_dut, portchannel_table)
-    portchannel_interface_tc1_xfail(rand_selected_dut)
-    portchannel_interface_tc1_add_and_rm(rand_selected_dut, portchannel_table)
+def test_portchannel_interface_tc1_suite(duthosts, rand_one_dut_hostname, portchannel_table, rand_portchannel_name):
+    duthost = duthosts[rand_one_dut_hostname]
+    portchannel_interface_tc1_add_duplicate(duthost, portchannel_table, rand_portchannel_name)
+    portchannel_interface_tc1_xfail(duthost, rand_portchannel_name)
+    portchannel_interface_tc1_add_and_rm(duthost, portchannel_table, rand_portchannel_name)
 
 
 def verify_po_running(duthost, portchannel_table):
@@ -249,7 +258,7 @@ def verify_attr_change(duthost, po_name, attr, value):
         pytest_assert(output['stdout'].startswith(value), "{} {} change failed".format(po_name, attr))
 
 
-def portchannel_interface_tc2_replace(duthost):
+def portchannel_interface_tc2_replace(duthost, rand_portchannel_name):
     """Test PortChannelXXXX attribute change
     """
     attributes = [
@@ -262,7 +271,7 @@ def portchannel_interface_tc2_replace(duthost):
     for attr, value in attributes:
         patch = {
             "op": "replace",
-            "path": "/PORTCHANNEL/PortChannel101/{}".format(attr),
+            "path": "/PORTCHANNEL/{}/{}".format(rand_portchannel_name, attr),
             "value": value
         }
         json_patch.append(patch)
@@ -275,21 +284,21 @@ def portchannel_interface_tc2_replace(duthost):
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost, output)
 
-        verify_po_running(duthost, ["PortChannel101"])
+        verify_po_running(duthost, [rand_portchannel_name])
         for attr, value in attributes:
-            verify_attr_change(duthost, "PortChannel101", attr, value)
+            verify_attr_change(duthost, rand_portchannel_name, attr, value)
     finally:
         delete_tmpfile(duthost, tmpfile)
 
 
-def portchannel_interface_tc2_incremental(duthost):
+def portchannel_interface_tc2_incremental(duthost, rand_portchannel_name):
     """Test PortChannelXXXX incremental change
     """
     json_patch = [
         {
          "op": "add",
-         "path": "/PORTCHANNEL/PortChannel101/description",
-         "value": "Description for PortChannel101"
+         "path": "/PORTCHANNEL/{}/description".format(rand_portchannel_name),
+         "value": "Description for {}".format(rand_portchannel_name)
         }
     ]
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
@@ -304,6 +313,7 @@ def portchannel_interface_tc2_incremental(duthost):
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_portchannel_interface_tc2_attributes(rand_selected_dut):
-    portchannel_interface_tc2_replace(rand_selected_dut)
-    portchannel_interface_tc2_incremental(rand_selected_dut)
+def test_portchannel_interface_tc2_attributes(duthosts, rand_one_dut_hostname, rand_portchannel_name):
+    duthost = duthosts[rand_one_dut_hostname]
+    portchannel_interface_tc2_replace(duthost, rand_portchannel_name)
+    portchannel_interface_tc2_incremental(duthost, rand_portchannel_name)

--- a/tests/hash/test_generic_hash.py
+++ b/tests/hash/test_generic_hash.py
@@ -667,7 +667,7 @@ def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, rest
 
     with allure.step(f'Randomly choose a reboot type: {reboot_type}, and reboot'):
         # Save config if reboot type is config reload or cold reboot
-        if reboot_type in ['cold', 'reload']:
+        if reboot_type in ['cold', 'reload', 'warm']:
             duthost.shell('config save -y')
         # Reload/Reboot the dut
         if reboot_type == 'reload':

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -149,12 +149,14 @@ def setup_pfc_test(
             exclude_ips=[vlan_addr])['ansible_facts']['generated_ips']
         vlan_nw = vlan_ips[0].split('/')[0]
 
+    topo = tbinfo["topo"]["name"]
+
     # build the port list for the test
-    tp_handle = TrafficPorts(mg_facts, neighbors, vlan_nw)
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    tp_handle = TrafficPorts(mg_facts, neighbors, vlan_nw, topo, config_facts)
     test_ports = tp_handle.build_port_list()
 
     # In T1 topology update test ports by removing inactive ports
-    topo = tbinfo["topo"]["name"]
     if topo in SUPPORTED_T1_TOPOS:
         test_ports = update_t1_test_ports(
             duthost, mg_facts, test_ports, tbinfo

--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common import port_toggle
 from tests.platform_tests.link_flap.link_flap_utils import build_test_candidates,\
-    check_orch_cpu_utilization, check_bgp_routes
+    check_orch_cpu_utilization, check_bgp_routes, get_avg_redis_mem_usage, validate_redis_memory_increase
 from tests.common.utilities import wait_until
 from tests.common.devices.eos import EosHost
 from tests.common.devices.sonic import SonicHost
@@ -66,7 +66,7 @@ class TestContLinkFlap(object):
             3.) Watch for memory (show system-memory), FRR daemons memory(vtysh -c "show memory bgp/zebra"),
                 orchagent CPU Utilization and Redis_memory.
 
-        Pass Criteria: All routes must be re-learned with < 5% increase in Redis/FRR memory usage and
+        Pass Criteria: All routes must be re-learned with < 10% increase in Redis/FRR memory usage and
             ORCH agent CPU consumption below threshold after 3 mins after stopping flaps.
         """
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
@@ -78,9 +78,8 @@ class TestContLinkFlap(object):
         logging.info("Memory Status at start: %s", memory_output)
 
         # Record Redis Memory at start
-        start_time_redis_memory = duthost.shell(
-            r"redis-cli info memory | grep used_memory_human | sed -e 's/.*:\(.*\)M/\1/'")["stdout"]
-        logging.info("Redis Memory: %s M", start_time_redis_memory)
+        start_time_redis_memory = get_avg_redis_mem_usage(duthost, 5, 5)
+        logging.info("Redis Memory: %f M", start_time_redis_memory)
 
         # Record ipv4 route counts at start
         sumv4, sumv6 = duthost.get_ip_route_summary(skip_kernel_tunnel=True)
@@ -209,26 +208,17 @@ class TestContLinkFlap(object):
             logging.info("Orchagent PID {0} CPU Util at end: {1}".format(pid, util))
 
         # Record Redis Memory at end
-        end_time_redis_memory = duthost.shell(
-            r"redis-cli info memory | grep used_memory_human | sed -e 's/.*:\(.*\)M/\1/'")["stdout"]
-        logging.info("Redis Memory at start: %s M", start_time_redis_memory)
-        logging.info("Redis Memory at end: %s M", end_time_redis_memory)
+        end_time_redis_memory = get_avg_redis_mem_usage(duthost, 5, 5)
+        logging.info("Redis Memory at start: %f M", start_time_redis_memory)
+        logging.info("Redis Memory at end: %f M", end_time_redis_memory)
 
-        # Calculate diff in Redis memory
-        incr_redis_memory = float(end_time_redis_memory) - float(start_time_redis_memory)
-        logging.info("Redis absolute  difference: %d", incr_redis_memory)
-
-        # Check redis memory only if it is increased else default to pass
-        if incr_redis_memory > 0.0:
-            percent_incr_redis_memory = (incr_redis_memory / float(start_time_redis_memory)) * 100
-            logging.info("Redis Memory percentage Increase: %d", percent_incr_redis_memory)
-            incr_redis_memory_threshold = 10 if tbinfo["topo"]["type"] in ["m0", "mx"] else 5
-            pytest_assert(percent_incr_redis_memory < incr_redis_memory_threshold,
-                          "Redis Memory Increase more than expected: {}".format(percent_incr_redis_memory))
+        result = validate_redis_memory_increase(tbinfo, start_time_redis_memory, end_time_redis_memory)
+        pytest_assert(result, "Redis Memory Increases more than expected: start {}, end {}"
+                      .format(start_time_redis_memory, end_time_redis_memory))
 
         # Orchagent CPU should consume < orch_cpu_threshold at last.
         logging.info("watch orchagent CPU utilization when it goes below %d", orch_cpu_threshold)
-        pytest_assert(wait_until(45, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
+        pytest_assert(wait_until(120, 5, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
                       "Orch CPU utilization {} > orch cpu threshold {} after link flap"
                       .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
                               orch_cpu_threshold))

--- a/tests/platform_tests/link_flap/test_link_flap.py
+++ b/tests/platform_tests/link_flap/test_link_flap.py
@@ -4,7 +4,8 @@ Tests the link flap in SONiC.
 import logging
 import pytest
 
-from tests.platform_tests.link_flap.link_flap_utils import check_orch_cpu_utilization, build_test_candidates
+from tests.platform_tests.link_flap.link_flap_utils import check_orch_cpu_utilization, build_test_candidates, \
+    get_avg_redis_mem_usage, validate_redis_memory_increase
 from tests.common.platform.device_utils import toggle_one_link
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
@@ -35,9 +36,8 @@ def test_link_flap(request, duthosts, rand_one_dut_hostname, tbinfo, fanouthosts
     logger.info("Memory Status at start: %s", memory_output)
 
     # Record Redis Memory at start
-    start_time_redis_memory = duthost.shell(
-        r"redis-cli info memory | grep used_memory_human | sed -e 's/.*:\(.*\)M/\1/'")["stdout"]
-    logger.info("Redis Memory: %s M", start_time_redis_memory)
+    start_time_redis_memory = get_avg_redis_mem_usage(duthost, 5, 5)
+    logging.info("Redis Memory: %f M", start_time_redis_memory)
 
     # Make Sure Orch CPU < orch_cpu_threshold before starting test.
     logger.info("Make Sure orchagent CPU utilization is less that %d before link flap", orch_cpu_threshold)
@@ -70,26 +70,17 @@ def test_link_flap(request, duthosts, rand_one_dut_hostname, tbinfo, fanouthosts
     logger.info("Orchagent CPU Util at end: %s", orch_cpu)
 
     # Record Redis Memory at end
-    end_time_redis_memory = duthost.shell(
-        r"redis-cli info memory | grep used_memory_human | sed -e 's/.*:\(.*\)M/\1/'")["stdout"]
-    logger.info("Redis Memory at start: %s M", start_time_redis_memory)
-    logger.info("Redis Memory at end: %s M", end_time_redis_memory)
+    end_time_redis_memory = get_avg_redis_mem_usage(duthost, 5, 5)
+    logging.info("Redis Memory at start: %f M", start_time_redis_memory)
+    logging.info("Redis Memory at end: %f M", end_time_redis_memory)
 
-    # Calculate diff in Redis memory
-    incr_redis_memory = float(end_time_redis_memory) - float(start_time_redis_memory)
-    logger.info("Redis absolute  difference: %d", incr_redis_memory)
-
-    # Check redis memory only if it is increased else default to pass
-    if incr_redis_memory > 0.0:
-        percent_incr_redis_memory = (incr_redis_memory / float(start_time_redis_memory)) * 100
-        logger.info("Redis Memory percentage Increase: %d", percent_incr_redis_memory)
-        incr_redis_memory_threshold = 10 if tbinfo["topo"]["type"] in ["m0", "mx"] else 5
-        pytest_assert(percent_incr_redis_memory < incr_redis_memory_threshold,
-                      "Redis Memory Increase more than expected: {}".format(percent_incr_redis_memory))
+    result = validate_redis_memory_increase(tbinfo, start_time_redis_memory, end_time_redis_memory)
+    pytest_assert(result, "Redis Memory increases more than expected: start {}, end {}"
+                  .format(start_time_redis_memory, end_time_redis_memory))
 
     # Orchagent CPU should consume < orch_cpu_threshold at last.
     logger.info("watch orchagent CPU utilization when it goes below %d", orch_cpu_threshold)
-    pytest_assert(wait_until(45, 2, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
+    pytest_assert(wait_until(120, 5, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
                   "Orch CPU utilization {} > orch cpu threshold {} before link flap"
                   .format(duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
                           orch_cpu_threshold))

--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -12,14 +12,18 @@ import six
 logger = logging.getLogger(__name__)
 
 
-def ptf_collect(host, log_file, skip_pcap=False):
+def ptf_collect(host, log_file, skip_pcap=False, dst_dir='./logs/ptf_collect/'):
+    """
+    Collect PTF log and pcap files from PTF container to sonic-mgmt container.
+    Optionally, save the files to a sub-directory in the destination.
+    """
     pos = log_file.rfind('.')
     filename_prefix = log_file[0:pos] if pos > -1 else log_file
 
     pos = filename_prefix.rfind('/') + 1
     rename_prefix = filename_prefix[pos:] if pos > 0 else filename_prefix
     suffix = str(datetime.utcnow()).replace(' ', '.')
-    filename_log = './logs/ptf_collect/' + rename_prefix + '.' + suffix + '.log'
+    filename_log = dst_dir + rename_prefix + '.' + suffix + '.log'
     host.fetch(src=log_file, dest=filename_log, flat=True, fail_on_missing=False)
     allure.attach.file(filename_log, 'ptf_log: ' + filename_log, allure.attachment_type.TEXT)
     if skip_pcap:
@@ -31,7 +35,7 @@ def ptf_collect(host, log_file, skip_pcap=False):
         compressed_pcap_file = pcap_file + '.tar.gz'
         host.archive(path=pcap_file, dest=compressed_pcap_file, format='gz')
         # Copy compressed file from ptf to sonic-mgmt
-        filename_pcap = './logs/ptf_collect/' + rename_prefix + '.' + suffix + '.pcap.tar.gz'
+        filename_pcap = dst_dir + rename_prefix + '.' + suffix + '.pcap.tar.gz'
         host.fetch(src=compressed_pcap_file, dest=filename_pcap, flat=True, fail_on_missing=False)
         allure.attach.file(filename_pcap, 'ptf_pcap: ' + filename_pcap, allure.attachment_type.PCAP)
 
@@ -101,9 +105,10 @@ def is_py3_compat(test_fpath):
 
 def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                platform="remote", qlen=0, relax=True, debug_level="info",
-               socket_recv_size=None, log_file=None, device_sockets=[], timeout=0, custom_options="",
+               socket_recv_size=None, log_file=None,
+               ptf_collect_dir="./logs/ptf_collect/",
+               device_sockets=[], timeout=0, custom_options="",
                module_ignore_errors=False, is_python3=None, async_mode=False, pdb=False):
-
     dut_type = get_dut_type(host)
     kvm_support = params.get("kvm_support", False)
     if dut_type == "kvm" and kvm_support is False:
@@ -201,7 +206,7 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
         result = host.shell(cmd, chdir="/root", module_ignore_errors=module_ignore_errors, module_async=async_mode)
         if not async_mode:
             if log_file:
-                ptf_collect(host, log_file)
+                ptf_collect(host, log_file, dst_dir=ptf_collect_dir)
             if result:
                 allure.attach(json.dumps(result, indent=4), 'ptf_console_result', allure.attachment_type.TEXT)
         if module_ignore_errors:
@@ -209,7 +214,7 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                 return result
     except Exception:
         if log_file:
-            ptf_collect(host, log_file)
+            ptf_collect(host, log_file, dst_dir=ptf_collect_dir)
         traceback_msg = traceback.format_exc()
         allure.attach(traceback_msg, 'ptf_runner_exception_traceback', allure.attachment_type.TEXT)
         logger.error("Exception caught while executing case: {}. Error message: {}".format(testname, traceback_msg))

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -604,8 +604,6 @@ def test_pfc_watermark_extra_lossless_standby(ptfhost, fanouthosts, rand_selecte
             testutils.send(ptfadapter, src_port, pkt, num_storm_pkts)
         finally:
             stop_pfc_storm(storm_handler)
-        # Clear out packets for futher verification
-        testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, dst_ports, timeout=0.5)
         # Record new watermark after congestion and clear
         queue_wmk = get_queue_watermark(rand_selected_dut, actual_port_name, wmk_stat_queue, True)
         # Expect the watermark to have increased by a small proportion of the traffic
@@ -696,8 +694,6 @@ def test_pfc_watermark_extra_lossless_active(ptfhost, fanouthosts, rand_selected
             testutils.send_packet(ptfadapter, src_port, tunnel_pkt.exp_pkt, num_storm_pkts)
         finally:
             stop_pfc_storm(storm_handler)
-        # Clear out packets for futher verification
-        testutils.count_matched_packets(ptfadapter, exp_pkt, dualtor_meta['target_server_port'], timeout=0.5)
         # Record new watermark after congestion and clear
         queue_wmk = get_queue_watermark(rand_selected_dut, dualtor_meta['selected_port'], queue, True)
         # Expect the watermark to have increased by a small proportion of the traffic

--- a/tests/snmp/test_snmp_fdb.py
+++ b/tests/snmp/test_snmp_fdb.py
@@ -92,6 +92,43 @@ def is_port_channel_up(duthost, config_portchannels):
     return True
 
 
+def check_snmp_facts(duthost, localhost, hostip, creds_all_duts, config_portchannels, send_cnt, send_portchannels_cnt):
+    dummy_mac_cnt = 0
+    recv_portchannels_cnt = 0
+    snmp_facts = get_snmp_facts(
+        duthost, localhost, host=hostip, version="v2c",
+        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+    if 'snmp_fdb' not in snmp_facts:
+        logger.info("'snmp_fdb' not in snmp_facts")
+        return False
+    if 'snmp_interfaces' not in snmp_facts:
+        logger.info("'snmp_interfaces' not in snmp_facts")
+        return False
+    for key in snmp_facts['snmp_fdb']:
+        # key is string: vlan.mac
+        items = key.split('.')
+        if len(items) != 2:
+            continue
+        if DUMMY_MAC_PREFIX in items[1]:
+            dummy_mac_cnt += 1
+            idx = str(snmp_facts['snmp_fdb'][key])
+            if idx not in snmp_facts['snmp_interfaces']:
+                logger.info(f"{idx} not in snmp_facts['snmp_interfaces']")
+                return False
+            if 'name' not in snmp_facts['snmp_interfaces'][idx]:
+                logger.info(f"'name' not in snmp_facts['snmp_interfaces'][{idx}]")
+                return False
+            if snmp_facts['snmp_interfaces'][idx]['name'] in config_portchannels:
+                recv_portchannels_cnt += 1
+    if send_cnt != dummy_mac_cnt:
+        logger.info("Dummy MAC count does not match")
+        return False
+    if send_portchannels_cnt != recv_portchannels_cnt:
+        logger.info("Portchannels count does not match")
+        return False
+    return True
+
+
 @pytest.mark.bsl
 @pytest.mark.po2vlan
 def test_snmp_fdb_send_tagged(ptfadapter, duthosts, rand_one_dut_hostname,          # noqa F811
@@ -138,25 +175,6 @@ def test_snmp_fdb_send_tagged(ptfadapter, duthosts, rand_one_dut_hostname,      
 
     hostip = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_host']
-    snmp_facts = get_snmp_facts(
-        duthost, localhost, host=hostip, version="v2c",
-        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
-    assert 'snmp_fdb' in snmp_facts
-    assert 'snmp_interfaces' in snmp_facts
-    dummy_mac_cnt = 0
-    recv_portchannels_cnt = 0
-    for key in snmp_facts['snmp_fdb']:
-        # key is string: vlan.mac
-        items = key.split('.')
-        if len(items) != 2:
-            continue
-        logger.info("FDB entry: {}".format(items))
-        if DUMMY_MAC_PREFIX in items[1]:
-            dummy_mac_cnt += 1
-            idx = str(snmp_facts['snmp_fdb'][key])
-            assert idx in snmp_facts['snmp_interfaces']
-            assert 'name' in snmp_facts['snmp_interfaces'][idx]
-            if snmp_facts['snmp_interfaces'][idx]['name'] in config_portchannels:
-                recv_portchannels_cnt += 1
-    assert send_cnt == dummy_mac_cnt, "Dummy MAC count does not match"
-    assert send_portchannels_cnt == recv_portchannels_cnt, "Portchannels count does not match"
+
+    assert wait_until(60, 5, 0, check_snmp_facts, duthost, localhost, hostip, creds_all_duts,
+                      config_portchannels, send_cnt, send_portchannels_cnt), "SNMP facts validation failure"

--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -22,7 +22,7 @@ LOCAL_LOG_GENERATOR_FILE = os.path.join(BASE_DIR, 'log_generator.py')
 REMOTE_LOG_GENERATOR_FILE = os.path.join('/tmp', 'log_generator.py')
 DOCKER_LOG_GENERATOR_FILE = '/log_generator.py'
 # rsyslogd prints this log when rate-limiting reached
-LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = '.*begin to drop messages due to rate-limiting.*'
+LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = '.*rate-limit-test>: begin to drop messages due to rate-limiting.*'
 # Log pattern for tests/syslog/log_generator.py
 LOG_EXPECT_LAST_MESSAGE = '.*{}rate-limit-test: This is a test log:.*'
 

--- a/tests/upgrade_path/conftest.py
+++ b/tests/upgrade_path/conftest.py
@@ -4,6 +4,9 @@ import pytest
 def pytest_runtest_setup(item):
     from_list = item.config.getoption('base_image_list')
     to_list = item.config.getoption('target_image_list')
+    multi_hop_upgrade_path = item.config.getoption('multi_hop_upgrade_path')
+    if multi_hop_upgrade_path:
+        return
     if not from_list or not to_list:
         pytest.skip("base_image_list or target_image_list is empty")
 

--- a/tests/upgrade_path/test_multi_hop_upgrade_path.py
+++ b/tests/upgrade_path/test_multi_hop_upgrade_path.py
@@ -1,0 +1,76 @@
+import pytest
+import logging
+from tests.common.fixtures.advanced_reboot import get_advanced_reboot                                   # noqa F401
+from tests.common.fixtures.consistency_checker.consistency_checker import consistency_checker_provider  # noqa F401
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.reboot import get_reboot_cause
+from tests.common.utilities import wait_until
+from tests.common.platform.device_utils import check_neighbors, \
+    multihop_advanceboot_loganalyzer_factory, verify_dut_health                                         # noqa F401
+from tests.common.helpers.upgrade_helpers import SYSTEM_STABILIZE_MAX_TIME, check_copp_config, check_reboot_cause, \
+    check_services, install_sonic, multi_hop_warm_upgrade_test_helper, check_asic_and_db_consistency
+from tests.upgrade_path.utilities import cleanup_prev_images, boot_into_base_image
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                 # noqa F401
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.sanity_check(skip_sanity=True),
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.skip_check_dut_health
+]
+logger = logging.getLogger(__name__)
+
+
+def test_multi_hop_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request,
+                                get_advanced_reboot, multihop_advanceboot_loganalyzer_factory,  # noqa F811
+                                verify_dut_health, consistency_checker_provider):  # noqa F811
+    duthost = duthosts[rand_one_dut_hostname]
+    multi_hop_upgrade_path = request.config.getoption('multi_hop_upgrade_path')
+    upgrade_type = request.config.getoption('upgrade_type')
+    assert upgrade_type == "warm", "test_multi_hop_upgrade_path only supports warm upgrade"
+    enable_cpa = request.config.getoption('enable_cpa')
+    upgrade_path_urls = multi_hop_upgrade_path.split(",")
+    if len(upgrade_path_urls) < 2:
+        pytest.skip("Need atleast 2 URLs to test multi-hop upgrade path")
+
+    def base_image_setup():
+        """Run only once, to boot the device into the base image"""
+        base_image = upgrade_path_urls[0]
+        logger.info("Setting up base image {}".format(base_image))
+        cleanup_prev_images(duthost)
+
+        # Install base image
+        boot_into_base_image(duthost, localhost, base_image, tbinfo)
+        logger.info("Base image setup complete")
+
+    def pre_hop_setup(hop_index):
+        """Run before each hop in the multi-hop upgrade path"""
+        # Install target image
+        to_image = upgrade_path_urls[hop_index]
+        logger.info("Installing hop {} image {}".format(hop_index, to_image))
+        install_sonic(duthost, to_image, tbinfo)
+        logger.info("Finished setup for hop {} image {}".format(hop_index, to_image))
+
+    def post_hop_teardown(hop_index):
+        """Run after each hop in the multi-hop upgrade path"""
+        to_image = upgrade_path_urls[hop_index]
+        logger.info("Starting post hop teardown for hop {} image {}".format(hop_index, to_image))
+
+        logger.info("Check reboot cause of hop {}. Expected cause {}".format(hop_index, upgrade_type))
+        networking_uptime = duthost.get_networking_uptime().seconds
+        timeout = max((SYSTEM_STABILIZE_MAX_TIME - networking_uptime), 1)
+        pytest_assert(wait_until(timeout, 5, 0, check_reboot_cause, duthost, upgrade_type),
+                      "Reboot cause {} did not match the trigger - {}".format(get_reboot_cause(duthost), upgrade_type))
+        check_services(duthost)
+        check_neighbors(duthost, tbinfo)
+        check_copp_config(duthost)
+        check_asic_and_db_consistency(request.config, duthost, consistency_checker_provider)
+        logger.info("Finished post hop teardown for hop {} image {}".format(hop_index, to_image))
+
+    multi_hop_warm_upgrade_test_helper(
+        duthost, localhost, ptfhost, tbinfo, get_advanced_reboot, upgrade_type,
+        upgrade_path_urls,
+        multihop_advanceboot_loganalyzer_factory=multihop_advanceboot_loganalyzer_factory,
+        base_image_setup=base_image_setup,
+        pre_hop_setup=pre_hop_setup, post_hop_teardown=post_hop_teardown,
+        enable_cpa=enable_cpa)

--- a/tests/upgrade_path/utilities.py
+++ b/tests/upgrade_path/utilities.py
@@ -1,0 +1,41 @@
+import logging
+import re
+from tests.common.errors import RunAnsibleModuleFail
+from tests.common.helpers.upgrade_helpers import install_sonic, reboot, check_sonic_version
+
+logger = logging.getLogger(__name__)
+
+
+def boot_into_base_image(duthost, localhost, base_image, tbinfo):
+    logger.info("Installing {}".format(base_image))
+    try:
+        target_version = install_sonic(duthost, base_image, tbinfo)
+    except RunAnsibleModuleFail as err:
+        migration_err_regexp = r"Traceback.*migrate_sonic_packages.*SonicRuntimeException"
+        msg = err.results['msg'].replace('\n', '')
+        if re.search(migration_err_regexp, msg):
+            logger.info(
+                "Ignore the package migration error when downgrading to base_image")
+            target_version = duthost.shell(
+                "cat /tmp/downloaded-sonic-image-version")['stdout']
+        else:
+            raise err
+    # Remove old config_db before rebooting the DUT in case it is not successfully
+    # removed in install_sonic due to migration error
+    logger.info("Remove old config_db file if exists, to load minigraph from scratch")
+    if duthost.shell("ls /host/old_config/minigraph.xml", module_ignore_errors=True)['rc'] == 0:
+        duthost.shell("rm -f /host/old_config/config_db.json")
+    # Perform a cold reboot
+    logger.info("Cold reboot the DUT to make the base image as current")
+    # for 6100 devices, sometimes cold downgrade will not work, use soft-reboot here
+    reboot_type = 'soft' if "s6100" in duthost.facts["platform"] else 'cold'
+    reboot(duthost, localhost, reboot_type=reboot_type)
+    check_sonic_version(duthost, target_version)
+
+
+def cleanup_prev_images(duthost):
+    logger.info("Cleaning up previously installed images on DUT")
+    current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']
+    duthost.shell("sonic_installer set_next_boot {}".format(current_os_version), module_ignore_errors=True)
+    duthost.shell("sonic_installer set-next-boot {}".format(current_os_version), module_ignore_errors=True)
+    duthost.shell("sonic_installer cleanup -y", module_ignore_errors=True)


### PR DESCRIPTION
Code sync sonic-net/sonic-mgmt:202411 => 202412

```
*   c527f2299 (HEAD -> code-sync-202412, origin/code-sync-202412) r12f 250409:0151 - Merge remote-tracking branch 'base/202411' into code-sync-202412
|\  
| * 8934e0753 (base/202411) Justin Wong 250408:1838 - Backport upgrade_path/test_multi_hop_upgrade_path.py to 202411 (#17827)
| * 8515c2daf Justin Wong 250407:1814 - Ignore error logs from experimental SAI values (#17843)
| * 9f0949444 Nana@Nvidia 250327:0005 - Fix the issue introduced when handle the 2 PRs #16948 and #16970 (#17543)
| * aa26ca893 Zhaohui Sun 250407:1054 - Choose correct vlan ip for 2vlan config in advance_reboot (#17831)
| * 8e478eca3 Rajendra Kumar Thirumurthi 250407:0143 - warm boot to config save before reboot (#17849)
| * e3cfd676b Yawen 250407:1324 - skip dynamic_acl on platform x86_64-8101_32fh_o_c01-r0 (#17848)
| * 214e751bd Hua Liu 250313:0159 - Improve TACACS local accounting test case by add retry (#17350)
| * d2b5b1e01 Vivek Verma 250407:0811 - Fix pfcwd/test_pfcwd_function.py for dualtor topologies (#17833)
| * b5f59889c rbpittman 250306:1606 - Remove packet counter, can lockup due to constant ICMP responder packets. Also not necessary as packet verification in the next loop will use a different DSCP, so will not match a previous iteration's packets. (#17257)
| * 6536ef6be pragnya-arista 250407:0812 - [202411]Fix for generic_config_updater/test_portchannel_interfaces.py on dualtor (#17842)
| * f4271121f Dhanasekar Rathinavel 250403:2101 - Fixed syslog rate-limit tests (#17817)
| * ef900ef3a Chuan Wu 250404:0027 - Loop check snmp facts in test_snmp_fdb.py (#17678)
| * 6f103e57a Justin Wong 250328:1536 - Fix wr_arp slow arp response time on big topos (#17709)
| * 7ecb26d87 Sai Kiran 250403:1912 - [202411] Modify ptf_imagetag default value to branch based tag value (#17792)
| * 79dc77163 Rida Hanif 250401:1857 - Revert "Test case for BFD echo-mode (#12642)" (#15886)
| * ae6a0737c wumiao_nokia 241209:0149 - Fix for redis memory check failure after link flap and also sometimes cpu usage high failure (#15732)
| * a29256df3 Jibin Bao 250319:0035 - [Mellanox] Skip test_check_sfp_eeprom_with_option_dom on spc3 and later (#17541)
| * a4d2e08f7 Justin Wong 250402:1808 -  Add log ignore for 720DT (resolve backport conflict for 16681) (#17725)
| * 17af778f9 Olympia Karavasili Arapogianni 250402:2105 - [202411] Conflict resolution for Replacing hardcoded values for GCU suites with dynamic calculated (#17509)
| * f2e78173b pragnya-arista 250403:0608 - [202411]Fix everflow/test_everflow_testbed.py for dualtor-aa/dualtor-… (#17359)
```