### PR TITLE
Updated ECN configuration test to reference the correct WRED profile to AZURE

### DIFF
--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -94,7 +94,7 @@ def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, opera
 
     json_patch = list()
     values = list()
-    ecn_data = duthost.shell('sonic-db-cli CONFIG_DB hgetall "WRED_PROFILE|AZURE_LOSSLESS"')['stdout']
+    ecn_data = duthost.shell('sonic-db-cli CONFIG_DB hgetall "WRED_PROFILE|AZURE"')['stdout']
     ecn_data = ast.literal_eval(ecn_data)
     for field in configdb_field.split(','):
         value = int(ecn_data[field]) + 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Updated ECN configuration test to reference the correct WRED profile for Azure. Changed path from "AZURE_LOSSLESS" profile to "AZURE" to comply with changes.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405

### Approach
#### What is the motivation for this PR?
AZURE_LOSSLESS profile is not relevant for specific SKUs and the updated profile is AZURE.

#### How did you do it?
changed the profile name

#### How did you verify/test it?
ran the test with the AZURE profile.

#### Any platform specific information?
sn5600/sn5640 only with specific SKUs.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
