### PR TITLE
Revert "Temporarily skipping few testcases in platform_tests/api/test_thermal.py and test_thermal_state_db.py for cisco devices"

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -586,19 +586,15 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_get_low_threshold:
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_maximum_recorded:
   skip:
-    conditions_logical_operator: or
-    reason: "Unsupported platform API in mellanox. Skip in case of Cisco platform for T2 profile due to temperarory bug."
+    reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox']"
-      - "asic_type in ['cisco-8000'] and topo_type in ['t2']"
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_minimum_recorded:
   skip:
-    conditions_logical_operator: or
-    reason: "Unsupported platform API in mellanox. Skip in case of Cisco platform for T2 profile due to temperarory bug."
+    reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox']"
-      - "asic_type in ['cisco-8000'] and topo_type in ['t2']"
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_model:
   # Hardware components that we use for our sensors does not have IDPROM to store model and serial number details.
@@ -630,11 +626,9 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_get_status:
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_temperature:
   skip:
-    conditions_logical_operator: or
-    reason: "Unsupported platform API in mellanox. Skip in case of Cisco platform for T2 profile due to temperarory bug."
+    reason: "Unsupported platform API"
     conditions:
       - "asic_type in ['mellanox']"
-      - "asic_type in ['cisco-8000'] and topo_type in ['t2']"
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_set_high_threshold:
   skip:
@@ -1033,16 +1027,6 @@ platform_tests/test_service_warm_restart.py:
     reason: "Testcase ignored due to sonic-mgmt issue: https://github.com/sonic-net/sonic-mgmt/issues/10362"
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/10362"
-
-#######################################
-#####test_thermal_state_db.py #####
-#######################################
-
-platform_tests/test_thermal_state_db.py:
-  skip:
-    reason: "Skip in case of Cisco platform for T2 profile due to temperarory bug."
-    conditions:
-      - "asic_type in ['cisco-8000'] and topo_type in ['t2']"
 
 #######################################
 #####   test_xcvr_info_in_db.py   #####


### PR DESCRIPTION
Reverts Azure/sonic-mgmt.msft#154