### PR TITLE
[PR: 18083][202412] fix sanity check for ipv6 only topo 

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -603,10 +603,14 @@ def check_bgp_router_id(duthost, mgFacts):
     """
     Check bgp router ID is same as Loopback0
     """
-    check_bgp_router_id_cmd = r'vtysh -c "show ip bgp summary json"'
+    check_bgp_router_id_cmd = r'vtysh -c "show bgp summary json"'
     bgp_summary = duthost.shell(check_bgp_router_id_cmd, module_ignore_errors=True)
     try:
         bgp_summary_json = json.loads(bgp_summary['stdout'])
+        if 'ipv4Unicast' not in bgp_summary_json:
+            logger.info("No ipv4Unicast in BGP summary")
+            # for Ipv6 only device, just check if routerId exists or not.
+            return 'routerId' in bgp_summary_json['ipv6Unicast']
         router_id = str(bgp_summary_json['ipv4Unicast']['routerId'])
         loopback0 = str(mgFacts['minigraph_lo_interfaces'][0]['addr'])
         if router_id == loopback0:

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -161,6 +161,7 @@ def check_interfaces(duthosts):
         results[dut.hostname] = check_result
     return _check
 
+
 @pytest.fixture(scope="module")
 def check_bgp(duthosts, tbinfo):
     init_result = {"failed": False, "check_item": "bgp"}
@@ -199,8 +200,10 @@ def check_bgp(duthosts, tbinfo):
             for asic_index, a_asic_facts in enumerate(bgp_facts):
                 a_asic_result = False
                 a_asic_neighbors = a_asic_facts['ansible_facts']['bgp_neighbors']
-                num_v4_neighbors = len([neigh_addr for neigh_addr, neigh_detail in list(a_asic_neighbors.items()) if neigh_detail['ip_version'] == 4])
-                num_v6_neighbors = len([neigh_addr for neigh_addr, neigh_detail in list(a_asic_neighbors.items()) if neigh_detail['ip_version'] == 6])
+                num_v4_neighbors = len([neigh_addr for neigh_addr, neigh_detail in list(a_asic_neighbors.items())
+                                        if neigh_detail['ip_version'] == 4])
+                num_v6_neighbors = len([neigh_addr for neigh_addr, neigh_detail in list(a_asic_neighbors.items())
+                                        if neigh_detail['ip_version'] == 6])
                 if a_asic_neighbors is not None and len(a_asic_neighbors) > 0:
                     down_neighbors = [k for k, v in list(a_asic_neighbors.items())
                                       if v['state'] != 'established']

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -161,7 +161,6 @@ def check_interfaces(duthosts):
         results[dut.hostname] = check_result
     return _check
 
-
 @pytest.fixture(scope="module")
 def check_bgp(duthosts, tbinfo):
     init_result = {"failed": False, "check_item": "bgp"}

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -7,7 +7,7 @@ import pytest
 import time
 
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
-from tests.common.utilities import wait, wait_until
+from tests.common.utilities import wait, wait_until, is_ipv4_address
 from tests.common.dualtor.mux_simulator_control import get_mux_status, reset_simulator_port     # noqa F401
 from tests.common.dualtor.mux_simulator_control import restart_mux_simulator                    # noqa F401
 from tests.common.dualtor.nic_simulator_control import restart_nic_simulator                    # noqa F401
@@ -127,7 +127,10 @@ def check_interfaces(duthosts):
             if "PORTCHANNEL_INTERFACE" in cfg_facts:
                 ip_interfaces = list(cfg_facts["PORTCHANNEL_INTERFACE"].keys())
             if "VLAN_INTERFACE" in cfg_facts:
-                ip_interfaces += list(cfg_facts["VLAN_INTERFACE"].keys())
+                for vlan in cfg_facts["VLAN_INTERFACE"]:
+                    # check for IPv4 address only for now.
+                    if any(is_ipv4_address(addr) for addr in cfg_facts["VLAN_INTERFACE"][vlan]):
+                        ip_interfaces.append(vlan)
 
             logger.info(json.dumps(phy_interfaces, indent=4))
             logger.info(json.dumps(ip_interfaces, indent=4))
@@ -157,7 +160,6 @@ def check_interfaces(duthosts):
         check_result["down_ports"] = down_ports
         results[dut.hostname] = check_result
     return _check
-
 
 @pytest.fixture(scope="module")
 def check_bgp(duthosts, tbinfo):
@@ -197,6 +199,8 @@ def check_bgp(duthosts, tbinfo):
             for asic_index, a_asic_facts in enumerate(bgp_facts):
                 a_asic_result = False
                 a_asic_neighbors = a_asic_facts['ansible_facts']['bgp_neighbors']
+                num_v4_neighbors = len([neigh_addr for neigh_addr, neigh_detail in list(a_asic_neighbors.items()) if neigh_detail['ip_version'] == 4])
+                num_v6_neighbors = len([neigh_addr for neigh_addr, neigh_detail in list(a_asic_neighbors.items()) if neigh_detail['ip_version'] == 6])
                 if a_asic_neighbors is not None and len(a_asic_neighbors) > 0:
                     down_neighbors = [k for k, v in list(a_asic_neighbors.items())
                                       if v['state'] != 'established']
@@ -217,12 +221,12 @@ def check_bgp(duthosts, tbinfo):
                 # Chassis and multi_asic is not supported for now
                 if not dut.is_multi_asic and not (dut.get_facts().get("modular_chassis") is True or
                                                   dut.get_facts().get("modular_chassis") == "True"):
-                    if not _check_default_route(4, dut):
+                    if num_v4_neighbors and not _check_default_route(4, dut):
                         if asic_key not in check_result:
                             check_result[asic_key] = {}
                         check_result[asic_key]["no_v4_default_route"] = True
                         a_asic_result = True
-                    if not _check_default_route(6, dut):
+                    if num_v6_neighbors and not _check_default_route(6, dut):
                         if asic_key not in check_result:
                             check_result[asic_key] = {}
                         check_result[asic_key]["no_v6_default_route"] = True

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -221,12 +221,12 @@ def check_bgp(duthosts, tbinfo):
                 # Chassis and multi_asic is not supported for now
                 if not dut.is_multi_asic and not (dut.get_facts().get("modular_chassis") is True or
                                                   dut.get_facts().get("modular_chassis") == "True"):
-                    if num_v4_neighbors and not _check_default_route(4, dut):
+                    if (num_v4_neighbors > 0) and not _check_default_route(4, dut):
                         if asic_key not in check_result:
                             check_result[asic_key] = {}
                         check_result[asic_key]["no_v4_default_route"] = True
                         a_asic_result = True
-                    if num_v6_neighbors and not _check_default_route(6, dut):
+                    if (num_v6_neighbors > 0) and not _check_default_route(6, dut):
                         if asic_key not in check_result:
                             check_result[asic_key] = {}
                         check_result[asic_key]["no_v6_default_route"] = True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes sanity check for isolated-v6 which is ipv6 only topology

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
support ipv6 only topology in sanity check.

#### How did you do it?
- check ip_interface for IPv4 only.
- check bgp router id same as loopback0 for IPv4 only.
- check v4_default_route only when there are IPv4 BGP neighbors.

#### How did you verify/test it?
Test passed on local testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
