### PR TITLE
Fix missing quote in autosync_pub_msft.yml script

### DIFF
--- a/.github/workflows/autosync_pub_msft.yml
+++ b/.github/workflows/autosync_pub_msft.yml
@@ -114,4 +114,4 @@ jobs:
             - **workflow:** '${{ github.workflow }}'\n
             - **trigger:** '${{ github.actor }}'\n
             - **details:** [details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-          }' "${{ secrets.TEAMS_WEBHOOK_URL }}
+          }' "${{ secrets.TEAMS_WEBHOOK_URL }}"


### PR DESCRIPTION
We miss a `"` at the end of the script `autosync_pub_msft.yml`. In this PR, we fix this issue. 