### PR TITLE
feat: add option to toggle on FEC in minigraph (#17295)

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -300,6 +300,7 @@ class LabGraph(object):
             vlan_ID = link["VlanID"]
             vlan_mode = link["VlanMode"]
             autoneg_mode = link.get("AutoNeg")
+            fec_disable = link.get("FECDisable", False)
 
             if start_device not in links:
                 links[start_device] = {}
@@ -314,11 +315,13 @@ class LabGraph(object):
                 "peerdevice": end_device,
                 "peerport": end_port,
                 "speed": band_width,
+                "fec_disable": fec_disable
             }
             links[end_device][end_port] = {
                 "peerdevice": start_device,
                 "peerport": start_port,
                 "speed": band_width,
+                "fec_disable": fec_disable
             }
 
             if autoneg_mode:

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -1,6 +1,6 @@
 {%- set ns = namespace(link_metadata_defined=False) -%}
 
-{%- if 'dualtor' in topo or (macsec_card is defined and macsec_card == True and 't2' in topo) -%}
+{%- if 'dualtor' in topo or (macsec_card is defined and enable_macsec is defined and macsec_card == True and 't2' in topo) or ("ixia" in topo) -%}
     {% set ns.link_metadata_defined = True %}
 {%- endif -%}
 
@@ -81,6 +81,19 @@
             <a:Key>{{ device_conn[inventory_hostname][iface_name]['peerdevice'] }}:{{ device_conn[inventory_hostname][iface_name]['peerport'] }};{{ inventory_hostname }}:{{ port_name_map[iface_name] }}</a:Key>
             </a:LinkMetadata>
 {% endif %}
+{% endif %}
+{% if device_conn[inventory_hostname][iface_name]["fec_disable"] %}
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+            <a:DeviceProperty>
+                 <a:Name>FECDisabled</a:Name>
+                 <a:Reference i:nil="true"/>
+                 <a:Value>True</a:Value>
+            </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>{{ device_conn[inventory_hostname][iface_name]["peerdevice"] }}:{{ device_conn[inventory_hostname][iface_name]["peerport"]}};{{ inventory_hostname }}:{{ port_name_map[iface_name] }}</a:Key>
+        </a:LinkMetadata>
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Description of PR
Cherry-pick conflict https://github.com/sonic-net/sonic-mgmt/pull/17295
Summary: Add option to toggle on FEC for minigraph in ixia topo Fixes # (issue) 31623287

Approach
What is the motivation for this PR?
When in ixia FEC enabled port doesn't work well in some breakout ports. We want an option to force turn off FEC.

To use it, modify the links file. For example suppose we have the original _links.csv:
```
StartDevice,StartPort,EndDevice,EndPort,BandWidth,VlanID,VlanMode,AutoNeg str-msn2700-01,Ethernet0,str-7260-10,Ethernet1,40000,1681,Access,on str-msn2700-01,Ethernet4,str-7260-10,Ethernet2,40000,1682,Access,on str-msn2700-01,Ethernet8,str-7260-10,Ethernet3,40000,1683,Access,on str-msn2700-01,Ethernet12,str-7260-10,Ethernet4,40000,1684,Access,on str-msn2700-01,Ethernet16,str-7260-10,Ethernet5,40000,1685,Access,on str-msn2700-01,Ethernet20,str-7260-10,Ethernet6,40000,1686,Access,on str-msn2700-01,Ethernet24,str-7260-10,Ethernet7,40000,1687,Access,on ...
Let's say we want to force disable FEC on Ethernet24:
```

```
StartDevice,StartPort,EndDevice,EndPort,BandWidth,VlanID,VlanMode,AutoNeg,FECDisable str-msn2700-01,Ethernet0,str-7260-10,Ethernet1,40000,1681,Access,on str-msn2700-01,Ethernet4,str-7260-10,Ethernet2,40000,1682,Access,on str-msn2700-01,Ethernet8,str-7260-10,Ethernet3,40000,1683,Access,on str-msn2700-01,Ethernet12,str-7260-10,Ethernet4,40000,1684,Access,on str-msn2700-01,Ethernet16,str-7260-10,Ethernet5,40000,1685,Access,on str-msn2700-01,Ethernet20,str-7260-10,Ethernet6,40000,1686,Access,on str-msn2700-01,Ethernet24,str-7260-10,Ethernet7,40000,1687,Access,on,true Note that in here we only add the header and modify the Ethernet24, the other lines we don't need to modify anything
```

How did you do it?
Add attribute in minigraph to disable at deploy-mg phase

How did you verify/test it?
T2 physical testbed