### PR TITLE
Adding fix for gnmi tests to sync dut time with NTP Server

### DIFF
--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -4,7 +4,7 @@ import logging
 
 from tests.common.helpers.assertions import pytest_require as pyrequire
 from tests.common.helpers.dut_utils import check_container_state
-from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config, create_ext_conf
+from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config, create_ext_conf, update_system_time_using_NTP
 from tests.gnmi.helper import GNMI_SERVER_START_WAIT_TIME
 from tests.generic_config_updater.gu_utils import create_checkpoint, rollback
 
@@ -156,3 +156,4 @@ def check_dut_timestamp(duthosts, rand_one_dut_hostname, localhost):
     time_diff = local_time - dut_time
     if time_diff >= GNMI_SERVER_START_WAIT_TIME:
         logger.warning("DUT time is wrong (%d), please check NTP" % (-time_diff))
+        update_system_time_using_NTP(duthost)


### PR DESCRIPTION
During our recent nightly runs, we observed failures in the gNMI tests due to the DUT time being out of sync with the NTP server. To address this, we’ve updated the time synchronization function to ensure the DUT time is aligned with the NTP server, and we now invoke this function prior to calling setup_gnmi_server.

Microsoft ADO: 32627324