### PR TITLE
[202405] MIGSMSFT-965 T2 failures in test_pfcwd_basic_with_snappi.py reboot cases

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -220,6 +220,15 @@ def perform_reboot(duthost, pool, reboot_command, reboot_helper=None, reboot_kwa
     return [reboot_res, dut_datetime]
 
 
+def check_dshell_ready(duthost):
+    show_command = "sudo show platform npu rx cgm_global"
+    err_msg = "debug shell server for asic 0 is not running"
+    output = duthost.command(show_command)['stdout']
+    if err_msg in output:
+        return False
+    return True
+
+
 @support_ignore_loganalyzer
 def reboot(duthost, localhost, reboot_type='cold', delay=10,
            timeout=0, wait=0, wait_for_ssh=True, wait_warmboot_finalizer=False, warmboot_finalizer_timeout=0,
@@ -298,6 +307,11 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         if check_intf_up_ports:
             pytest_assert(wait_until(wait + 300, 20, 0, check_interface_status_of_up_ports, duthost),
                           "{}: Not all ports that are admin up on are operationally up".format(hostname))
+
+        if duthost.facts['asic_type'] == "cisco-8000":
+            # Wait dshell initialization finish
+            pytest_assert(wait_until(wait + 300, 20, 0, check_dshell_ready, duthost),
+                          "dshell not ready")
     else:
         time.sleep(wait)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Double commit https://github.com/sonic-net/sonic-mgmt/pull/18001

test_pfcwd_basic_single_lossless_prio_reboot failed due to dshell initialization.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Fix the failures caused by dshell initialization.

#### How did you do it?
If cisco-8000, wait dshell ready after reboot.

#### How did you verify/test it?
Tested it on T2 testbed.
```
23:44:54 base._run                                L0108 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#136: [yy39top-lc4] AnsibleModule::command Result => {"changed": true, "stdout": "PFC support is enabled on the device\nSQG counters:\n   SQG 0: 0          (0x0)\n   SQG 1: 0          (0x0)\n   SQG 2: 0          (0x0)\n   SQG 3: 0          (0x0)\n\nTC counters (global):\n   CTC 0: 0          (0x0)\n   CTC 1: 0          (0x0)\n   CTC 2: 0          (0x0)\n   CTC 3: 0          (0x0)\n   CTC 4: 0          (0x0)\n   CTC 5: 0          (0x0)\n   CTC 6: 0          (0x0)\n   CTC 7: 0          (0x0)\n\nCounter-A: unicast packet buffers 0, 0.00 MB\nCounter-G: mirrored packet buffers 0\nCounter-B,E: multicast packet buffers 0\nCounter-A threshold config for congestion:\n  Counter-a threshold 163840 buffers, 62914560 bytes 60.00 MB, rx-cgm status (0)\n  Counter-a threshold 180224 buffers, 69206016 bytes 66.00 MB, rx-cgm status (1)\n  Counter-a threshold 196608 buffers, 75497472 bytes 72.00 MB, rx-cgm status (2)\n\nNumber of rx_cgm_profiles is 4\n  rx-cgm-profile 0:\n    rx cgm thresholds [201326208, 201326208, 201326208]\n    headroom  0 headroom hex 0x0\n  rx-cgm-profile 1:\n    rx cgm thresholds [201326208, 201326208, 201326208]\n    headroom  0 headroom hex 0x0\n  rx-cgm-profile 2:\n    rx cgm thresholds [67108992, 67108992, 67108992]\n    headroom  201326208 headroom hex 0xbfffe80\n  rx-cgm-profile 3:\n    rx cgm thresholds [1572864, 3145728, 5242752]\n    headroom  441600 headroom hex 0x6bd00\nPFC CGM profile\n  PFC Rx PDR SMS0 = 262144\n  PFC Rx PDR SMS1 = 294912\n  PFC Counter A0 = 163840\n  PFC Counter A1 = 180224\n  PFC Counter A2 = 196608", "stderr": "", "rc": 0, "cmd": ["sudo", "show", "platform", "npu", "rx", "cgm_global"], "start": "2025-04-15 23:46:43.236426", "end": "2025-04-15 23:46:44.547165", "delta": "0:00:01.310739", "msg": "", "invocation": {"module_args": {"_raw_params": "sudo show platform npu rx cgm_global", "_uses_shell": false, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["PFC support is enabled on the device", "SQG counters:", "   SQG 0: 0          (0x0)", "   SQG 1: 0          (0x0)", "   SQG 2: 0          (0x0)", "   SQG 3: 0          (0x0)", "", "TC counters (global):", "   CTC 0: 0          (0x0)", "   CTC 1: 0          (0x0)", "   CTC 2: 0          (0x0)", "   CTC 3: 0          (0x0)", "   CTC 4: 0          (0x0)", "   CTC 5: 0          (0x0)", "   CTC 6: 0          (0x0)", "   CTC 7: 0          (0x0)", "", "Counter-A: unicast packet buffers 0, 0.00 MB", "Counter-G: mirrored packet buffers 0", "Counter-B,E: multicast packet buffers 0", "Counter-A threshold config for congestion:", "  Counter-a threshold 163840 buffers, 62914560 bytes 60.00 MB, rx-cgm status (0)", "  Counter-a threshold 180224 buffers, 69206016 bytes 66.00 MB, rx-cgm status (1)", "  Counter-a threshold 196608 buffers, 75497472 bytes 72.00 MB, rx-cgm status (2)", "", "Number of rx_cgm_profiles is 4", "  rx-cgm-profile 0:", "    rx cgm thresholds [201326208, 201326208, 201326208]", "    headroom  0 headroom hex 0x0", "  rx-cgm-profile 1:", "    rx cgm thresholds [201326208, 201326208, 201326208]", "    headroom  0 headroom hex 0x0", "  rx-cgm-profile 2:", "    rx cgm thresholds [67108992, 67108992, 67108992]", "    headroom  201326208 headroom hex 0xbfffe80", "  rx-cgm-profile 3:", "    rx cgm thresholds [1572864, 3145728, 5242752]", "    headroom  441600 headroom hex 0x6bd00", "PFC CGM profile", "  PFC Rx PDR SMS0 = 262144", "  PFC Rx PDR SMS1 = 294912", "  PFC Counter A0 = 163840", "  PFC Counter A1 = 180224", "  PFC Counter A2 = 196608"], "stderr_lines": [], "_ansible_no_log": null, "failed": false}
DEBUG:tests.common.utilities:check_dshell_ready is True, exit early with True
23:44:54 utilities.wait_until                     L0150 DEBUG  | check_dshell_ready is True, exit early with True

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
