### PR TITLE
Include import in the timer setup scripts for pfcwd. (#18198)

### DIFF
--- a/tests/pfcwd/cisco/default_pfc_time.py
+++ b/tests/pfcwd/cisco/default_pfc_time.py
@@ -1,4 +1,7 @@
 # Verified on Q200 @ 100G port speed. e.g. 687 is bit time to pause for 50ms (clock at 900Mhz).
+from common import is_graphene2, tree, is_gr, port_to_sai_lane_map, \
+    sai_lane_to_slice_ifg_pif, dd0, is_pac, is_gb, sdk, get_mac_port, d0
+
 
 def get_ifg_reg_list(slice_idx):
     ''' Gr2 does not have an ifg list, listify '''

--- a/tests/pfcwd/cisco/set_pfc_time.py
+++ b/tests/pfcwd/cisco/set_pfc_time.py
@@ -1,4 +1,7 @@
 # Verified on Q200 @ 100G port speed. e.g. 687 is bit time to pause for 50ms (clock at 900Mhz).
+from common import is_graphene2, tree, is_gr, port_to_sai_lane_map, \
+    sai_lane_to_slice_ifg_pif, dd0, is_pac, is_gb, sdk, d0
+
 
 import math
 


### PR DESCRIPTION
Summary:

The pfc-512bit script was working in previous builds, but fails in later builds. It started giving the unknown variable error. This is because the later images have stopped the auto-import of the variables used in the scripts.

Approach
What is the motivation for this PR?
Pls see description.

How did you do it?
Added the new import in the scripts.

How did you verify/test it?
Ran the failing test on T2 TB:

====================================================================================================================== warnings summary ====================================================================================================================== ../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html =========================================================================================================================== PASSES =========================================================================================================================== ________________________________________________________________________________________________ TestPfcwdAllPortStorm.test_all_port_storm_restore[xx37-lc0] _________________________________________________________________________________________________ ________________________________________________________________________________________________ TestPfcwdAllPortStorm.test_all_port_storm_restore[xx37-lc1] _________________________________________________________________________________________________ ________________________________________________________________________________________________ TestPfcwdAllPortStorm.test_all_port_storm_restore[xx37-lc7] _________________________________________________________________________________________________ ------------------------------------------------------------------ generated xml file: /run_logs/pfcwd-all-port/2025-04-30-04-32-00/pfcwd/test_pfcwd_all_port_storm_2025-04-30-04-32-00.xml ------------------------------------------------------------------ ------------------------------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------------------------------
04:52:29 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================================================== short test summary info ===================================================================================================================
PASSED pfcwd/test_pfcwd_all_port_storm.py::TestPfcwdAllPortStorm::test_all_port_storm_restore[xx37-lc0]
PASSED pfcwd/test_pfcwd_all_port_storm.py::TestPfcwdAllPortStorm::test_all_port_storm_restore[xx37-lc1]
PASSED pfcwd/test_pfcwd_all_port_storm.py::TestPfcwdAllPortStorm::test_all_port_storm_restore[xx37-lc7]
========================================================================================================= 3 passed, 1 warning in 1226.90s (0:20:26) ==========================================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_all_port_storm_restore[xx37-lc7]>
DEBUG:tests.conftest:append custom_msg: {'dut_check_result': {'config_db_check_failed': True, 'core_dump_check_failed': False}}
INFO:root:Can not get Allure report URL. Please check logs
sonic@sonic-mgmt-DNT-msft-202405:/data/tests$
Any platform specific information?
Cisco-8000

co-authorized by: jianquanye@microsoft.com