### PR TITLE
[202503] Code sync sonic-net/sonic-mgmt:202411 => 202503

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -12,7 +12,7 @@ broadcom_hwskus: [ "Force10-S6000", "Accton-AS7712-32X", "Celestica-DX010-C32", 
 broadcom_td2_hwskus: ['Force10-S6000', 'Force10-S6000-Q24S32', 'Arista-7050-QX32', 'Arista-7050-QX-32S', 'Arista-7050QX32S-Q32']
 broadcom_td3_hwskus: ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']
 broadcom_th_hwskus: ['Force10-S6100', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-C32-T1', 'Arista-7060CX-32S-D48C8', 'Celestica-DX010-C32', "Seastone-DX010" ]
-broadcom_th2_hwskus: ['Arista-7260CX3-D108C8',  'Arista-7260CX3-C64', 'Arista-7260CX3-Q64']
+broadcom_th2_hwskus: ['Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Arista-7260CX3-C64', 'Arista-7260CX3-Q64']
 broadcom_th3_hwskus: ['DellEMC-Z9332f-M-O16C64',  'DellEMC-Z9332f-O32']
 broadcom_th4_hwskus: ['Arista-7060DX5-32', 'Arista-7060DX5-64S']
 broadcom_th5_hwskus: ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -259,8 +259,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             if hwsku == "Arista-7260CX3-D108C10":
                 # The first 2 ports are 100G
                 s100G_ports.extend([x for x in range(1, 3)])
-
-            if hwsku == "Arista-7260CX3-D108C8-AILAB":
+            elif hwsku == "Arista-7260CX3-D108C8-AILAB":
                 s100G_ports = [x for x in range(45, 53)]
             elif hwsku == "Arista-7260CX3-D108C8-CSI":
                 # Treat 40G port as 100G ports

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1392,6 +1392,10 @@ class ReloadTest(BaseTest):
         self.assertTrue(is_good, errors)
 
     def runTest(self):
+        # Set LACP timer multiplier to 5 for cEOS peers
+        if self.test_params['neighbor_type'] == "eos":
+            self.ceos_set_lacp_all_neighs(5)
+
         self.pre_reboot_test_setup()
         try:
             self.log("Check that device is alive and pinging")
@@ -1445,7 +1449,28 @@ class ReloadTest(BaseTest):
             traceback_msg = traceback.format_exc()
             self.fails['dut'].add(traceback_msg)
         finally:
+            # Restore cEOS LACP timer multiplier to default (3)
+            if self.test_params['neighbor_type'] == "eos":
+                self.ceos_set_lacp_all_neighs(3)
+
             self.handle_post_reboot_test_reports()
+
+    def ceos_set_lacp_all_neighs(self, multiplier):
+        for neigh in self.ssh_targets:
+            self.neigh_handle = HostDevice.getHostDeviceInstance(
+                                    self.test_params['neighbor_type'], neigh, None, self.test_params)
+            self.neigh_handle.connect()
+
+            raw_json = self.neigh_handle.do_cmd("show lacp interface | json")
+            neigh_int_json = json.loads(raw_json[raw_json.find("{"):raw_json.rfind("}")+1])
+
+            self.neigh_handle.do_cmd("config")
+            for lag in neigh_int_json["portChannels"]:
+                for neigh_int in neigh_int_json["portChannels"][lag]['interfaces']:
+                    self.neigh_handle.do_cmd(f"interface {neigh_int}")
+                    self.neigh_handle.do_cmd(f"lacp timer multiplier {multiplier}")
+
+            self.neigh_handle.disconnect()
 
     def neigh_lag_status_check(self):
         """
@@ -1698,9 +1723,7 @@ class ReloadTest(BaseTest):
 
         # in the list of all LACPDUs received by T1, find the largest time gap between two consecutive LACPDUs
         max_lacp_session_wait = None
-        max_allowed_lacp_session_wait = 90
-        if self.test_params['neighbor_type'] == "sonic":
-            max_allowed_lacp_session_wait = 150
+        max_allowed_lacp_session_wait = 150
         if lacp_pdu_all_times and len(lacp_pdu_all_times) > 1:
             lacp_pdu_all_times.sort()
             max_lacp_session_wait = 0

--- a/ansible/roles/test/files/ptftests/py3/fdb_mac_learning_test.py
+++ b/ansible/roles/test/files/ptftests/py3/fdb_mac_learning_test.py
@@ -1,6 +1,6 @@
 import ptf
 from ptf.base_tests import BaseTest
-from ptf.testutils import send, simple_eth_packet, test_params_get
+from ptf.testutils import send, simple_arp_packet, test_params_get
 
 
 class FdbMacLearningTest(BaseTest):
@@ -20,10 +20,9 @@ class FdbMacLearningTest(BaseTest):
     def populateFdbForInterface(self):
         for dut_port, ptf_port in self.dut_ptf_ports:
             mac = self.dummy_mac_prefix + ":" + "{:02X}".format(ptf_port)
-            pkt = simple_eth_packet(eth_dst=self.router_mac,        # noqa: F405
-                                    eth_src=mac,
-                                    eth_type=0x1234)
-            send(self, ptf_port, pkt)
+            pkt = simple_arp_packet(eth_dst=self.router_mac,        # noqa: F405
+                                    eth_src=mac)
+            send(self, ptf_port, pkt, count=10)
             self.mac_table.append((ptf_port, mac))
 
     # --------------------------------------------------------------------------

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -62,6 +62,12 @@ class HashTest(BaseTest):
             if param not in self.test_params:
                 raise Exception("Missing required parameter {}".format(param))
 
+    def generate_random_sport(self):
+        while True:
+            port = random.randint(0, 65535)
+            if port != 53:
+                return port
+
     def setUp(self):
         '''
         @summary: Setup for the test
@@ -926,7 +932,7 @@ class VxlanHashTest(HashTest):
         ) if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
         sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
         dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
-        outer_sport = random.randint(0, 65535) if hash_key == 'outer-src-port' else 1234
+        outer_sport = self.generate_random_sport() if hash_key == 'outer-src-port' else 1234
 
         src_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
             if hash_key == 'src-mac' else self.base_mac
@@ -1044,7 +1050,7 @@ class VxlanHashTest(HashTest):
             if hash_key == 'dst-mac' else self.base_mac
         router_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']
 
-        outer_sport = random.randint(0, 65535) if hash_key == 'outer-src-port' else 1234
+        outer_sport = self.generate_random_sport() if hash_key == 'outer-src-port' else 1234
 
         if self.ipver == 'ipv6-ipv6':
             pkt_opts = {

--- a/ansible/roles/test/tasks/dir_bcast.yml
+++ b/ansible/roles/test/tasks/dir_bcast.yml
@@ -7,7 +7,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is invalid."
-  when: testbed_type not in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116']
+  when: testbed_type not in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116', 't0-118']
 
 - include_vars: "vars/topo_{{testbed_type}}.yml"
 

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -2,7 +2,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{test_type}} is invalid"
-  when: testbed_type not in ['t0', 't0-64', 't0-116', 't0-52']
+  when: testbed_type not in ['t0', 't0-64', 't0-116', 't0-118', 't0-52']
 
 - name: Gather minigraph facts about the device
   minigraph_facts: host={{inventory_hostname}}

--- a/ansible/roles/test/tasks/fdb_mac_expire.yml
+++ b/ansible/roles/test/tasks/fdb_mac_expire.yml
@@ -2,7 +2,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{test_type}} is invalid"
-  when: testbed_type not in ['t0', 't0-64', 't0-64-32', 't0-116', 't0-52']
+  when: testbed_type not in ['t0', 't0-64', 't0-64-32', 't0-116', 't0-118', 't0-52']
 
 - name: set fdb_aging_time to default if no user input
   set_fact:

--- a/ansible/roles/test/tasks/pfc_wd/choose_test_port.yml
+++ b/ansible/roles/test/tasks/pfc_wd/choose_test_port.yml
@@ -23,27 +23,27 @@
 
 - set_fact:
     random_seed: "{{range(4) | list | shuffle}}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_test_portchannel: "{{minigraph_portchannel_interfaces[0].attachto}}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_rx_portchannel: "{%for p in minigraph_portchannel_interfaces if p['attachto']!=pfc_wd_test_portchannel %}{%if loop.first %}{{p['attachto']}}{%endif%}{%endfor%}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_test_port: "{{minigraph_portchannels[pfc_wd_test_portchannel]['members'][0]}}"
     pfc_wd_rx_port: "{{minigraph_portchannels[pfc_wd_rx_portchannel]['members'][0]}}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_test_port_addr: "{%for p in minigraph_portchannel_interfaces%}{%if p['attachto']==pfc_wd_test_portchannel and p['addr']|ipv4%}{{p['addr']}}{%endif %}{%endfor%}"
     pfc_wd_rx_port_addr: "{%for p in minigraph_portchannel_interfaces%}{%if p['attachto']==pfc_wd_rx_portchannel and p['addr']|ipv4%}{{p['addr']}}{%endif %}{%endfor%}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_test_port_id: "{{minigraph_port_indices[pfc_wd_test_port]}}"
     pfc_wd_rx_port_id: "{{minigraph_port_indices[pfc_wd_rx_port]}}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]

--- a/ansible/roles/test/tasks/pfc_wd/iterate_portchannels.yml
+++ b/ansible/roles/test/tasks/pfc_wd/iterate_portchannels.yml
@@ -46,11 +46,11 @@
 
 - set_fact:
     p: "{{pfc_wd_test_port[1]}}"
-  when: rx_pc_port is defined and test_pc_port is defined and testbed_type in ['t0-64', 't0-116', 't1-lag']
+  when: rx_pc_port is defined and test_pc_port is defined and testbed_type in ['t0-64', 't0-116', 't0-118', 't1-lag']
 
 - set_fact:
     test_ports: "{{ test_ports | combine( {p:{'test_neighbor_addr':pfc_wd_test_neighbor_addr, 'rx_port':pfc_wd_rx_port, 'rx_neighbor_addr': pfc_wd_rx_neighbor_addr, 'peer_device':neighbors[p]['peerdevice'], 'test_port_id': minigraph_port_indices[p], 'rx_port_id': pfc_wd_rx_port_id.split(' ') | list, 'test_portchannel_members': pfc_wd_test_port_id.split(' ') | list, 'test_port_type':'portchannel' }})  }}"
-  when: rx_pc_port is defined and test_pc_port is defined and testbed_type in ['t0-64', 't0-116', 't1-lag']
+  when: rx_pc_port is defined and test_pc_port is defined and testbed_type in ['t0-64', 't0-116', 't0-118', 't1-lag']
 
 - set_fact:
     p: "{{pfc_wd_rx_port[0]}}"
@@ -62,11 +62,11 @@
 
 - set_fact:
     p: "{{pfc_wd_rx_port[1]}}"
-  when: first_pair and testbed_type in ['t0-64', 't0-116']
+  when: first_pair and testbed_type in ['t0-64', 't0-116', 't0-118']
 
 - set_fact:
     test_ports: "{{ test_ports | combine( {p:{'test_neighbor_addr':pfc_wd_rx_neighbor_addr, 'rx_port':pfc_wd_test_port, 'rx_neighbor_addr': pfc_wd_test_neighbor_addr, 'peer_device':neighbors[p]['peerdevice'], 'test_port_id': minigraph_port_indices[p], 'rx_port_id': pfc_wd_test_port_id.split(' ') | list , 'test_portchannel_members': pfc_wd_rx_port_id.split(' ') | list, 'test_port_type':'portchannel' }})  }}"
-  when: first_pair and testbed_type in ['t0-64', 't0-116']
+  when: first_pair and testbed_type in ['t0-64', 't0-116', 't0-118']
 
 - set_fact:
     used: false

--- a/ansible/roles/test/tasks/qos_sai.yml
+++ b/ansible/roles/test/tasks/qos_sai.yml
@@ -117,7 +117,7 @@
     - name: Init PTF base test parameters
       set_fact:
         ptf_base_params:
-        - router_mac={% if testbed_type not in ['t0', 't0-64', 't0-116'] %}'{{ansible_Ethernet0['macaddress']}}'{% else %}''{% endif %}
+        - router_mac={% if testbed_type not in ['t0', 't0-64', 't0-116', 't0-118'] %}'{{ansible_Ethernet0['macaddress']}}'{% else %}''{% endif %}
         - server='{{ansible_host}}'
         - port_map_file='/root/{{ptf_portmap | basename}}'
         - sonic_asic_type='{{sonic_asic_type}}'
@@ -151,7 +151,7 @@
         - dst_port_3_ip='{{dst_port_3_ip}}'
         - src_port_id='{{src_port_id}}'
         - src_port_ip='{{src_port_ip}}'
-      when: testbed_type in ['t0', 't0-64', 't0-116'] or arp_entries.stdout.find('incomplete') == -1
+      when: testbed_type in ['t0', 't0-64', 't0-116', 't0-118'] or arp_entries.stdout.find('incomplete') == -1
 
     - include_tasks: qos_sai_ptf.yml
       vars:
@@ -268,7 +268,7 @@
         - pkts_num_hdrm_full={{qp_sc.hdrm_pool_size.pkts_num_hdrm_full}}
         - pkts_num_hdrm_partial={{qp_sc.hdrm_pool_size.pkts_num_hdrm_partial}}
       when: minigraph_hwsku is defined and
-            minigraph_hwsku in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64']
+            minigraph_hwsku in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64']
 
     # Lossy queue
     - include_tasks: qos_sai_ptf.yml
@@ -348,11 +348,11 @@
         - packet_size='{{qp.wm_pg_shared_lossless.packet_size}}'
         - cell_size='{{qp.wm_pg_shared_lossless.cell_size}}'
       when: minigraph_hwsku is defined and
-            (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8'])
+            (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10'])
     - debug:
         var: out.stdout_lines
       when: minigraph_hwsku is defined and
-            (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8'])
+            (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10'])
 
     # Clear all watermarks before each watermark test
     # because of the clear on read polling mode
@@ -378,11 +378,11 @@
         - packet_size='{{qp.wm_pg_shared_lossy.packet_size}}'
         - cell_size='{{qp.wm_pg_shared_lossy.cell_size}}'
       when: minigraph_hwsku is defined and
-            minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8']
+            minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10']
     - debug:
         var: out.stdout_lines
       when: minigraph_hwsku is defined and
-            minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8']
+            minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10']
 
     # Clear all watermarks before each watermark test
     # because of the clear on read polling mode

--- a/ansible/roles/test/tasks/shared-fib.yml
+++ b/ansible/roles/test/tasks/shared-fib.yml
@@ -18,7 +18,7 @@
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['common']}}"
-  when: testbed_type in ['t0',  't0-52', 't0-56', 't0-64', 't0-64-32', 't0-116']
+  when: testbed_type in ['t0',  't0-52', 't0-56', 't0-64', 't0-64-32', 't0-116', 't0-118']
 
 - name: Expand ToR properties into props
   set_fact: props_tor="{{configuration_properties['tor']}}"

--- a/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
+++ b/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
@@ -12,7 +12,7 @@
 - name: Add all lag member down case
   set_fact:
       pre_list: "{{ pre_list + ['dut_lag_member_down:2:{{ lag_memb_cnt }}', 'neigh_lag_member_down:3:{{ lag_memb_cnt }}']}}"
-  when: testbed_type in ['t0-64', 't0-116', 't0-64-32']
+  when: testbed_type in ['t0-64', 't0-116', 't0-118', 't0-64-32']
 
 - name: set default values vnet variables
   set_fact:

--- a/ansible/roles/test/tasks/warm-reboot-sad-lag-member.yml
+++ b/ansible/roles/test/tasks/warm-reboot-sad-lag-member.yml
@@ -12,7 +12,7 @@
 - name: Add all lag member down case
   set_fact:
       pre_list: "{{ pre_list + ['dut_lag_member_down:2:{{ lag_memb_cnt }}', 'neigh_lag_member_down:3:{{ lag_memb_cnt }}']}}"
-  when: testbed_type in ['t0-64', 't0-116', 't0-64-32']
+  when: testbed_type in ['t0-64', 't0-116', 't0-118', 't0-64-32']
 
 - name: set default values vnet variables
   set_fact:

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -19,6 +19,9 @@
 {% elif testbed_type == 't0-116' %}
 0.0.0.0/0 [24 25] [26 27] [28 29] [30 31]
 ::/0 [24 25] [26 27] [28 29] [30 31]
+{% elif testbed_type == 't0-118' %}
+0.0.0.0/0 [22 23] [24 25] [26 27] [28 29]
+::/0 [22 23] [24 25] [26 27] [28 29]
 {% endif %}
 {#routes to uplink#}
 {#Limit the number of podsets and subnets to be covered to limit script execution time#}
@@ -61,7 +64,7 @@
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
 {% endif %}
-{% elif testbed_type == 't0-116' %}
+{% elif (testbed_type == 't0-116') or (testbed_type == 't0-118') %}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (subnet * props.tor_subnet_size) ) %}

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -26,7 +26,7 @@ testcases:
 
     bgp_fact:
       filename: bgp_fact.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     bgp_multipath_relax:
       filename: bgp_multipath_relax.yml
@@ -37,19 +37,19 @@ testcases:
 
     bgp_speaker:
       filename: bgp_speaker.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
 
     config:
         filename: config.yml
-        topologies: [t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-64, t0-116, t0-120]
+        topologies: [t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-64, t0-116, t0-118, t0-120]
 
     continuous_reboot:
       filename: continuous_reboot.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-56-o8v48, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t1-28-lag]
+      topologies: [t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-56-o8v48, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t1-28-lag]
 
     copp:
       filename: copp.yml
@@ -59,7 +59,7 @@ testcases:
 
     decap:
       filename: decap.yml
-      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-52, t0-56, t0-64, t0-116, t0-120]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-52, t0-56, t0-64, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
@@ -67,7 +67,7 @@ testcases:
 
     dhcp_relay:
       filename: dhcp_relay.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
@@ -85,7 +85,7 @@ testcases:
     fast-reboot:
       filename: fast-reboot.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -93,7 +93,7 @@ testcases:
     warm-reboot:
       filename: warm-reboot.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -101,7 +101,7 @@ testcases:
     warm-reboot-sad:
       filename: warm-reboot-sad.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -109,14 +109,14 @@ testcases:
     warm-reboot-multi-sad:
       filename: warm-reboot-multi-sad.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           vm_hosts:
 
     warm-reboot-multi-sad-inboot:
       filename: warm-reboot-multi-sad-inboot.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -124,7 +124,7 @@ testcases:
     warm-reboot-sad-bgp:
       filename: warm-reboot-sad-bgp.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -132,7 +132,7 @@ testcases:
     warm-reboot-sad-lag:
       filename: warm-reboot-sad-lag.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -140,7 +140,7 @@ testcases:
     warm-reboot-sad-lag-member:
       filename: warm-reboot-sad-lag-member.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -148,21 +148,21 @@ testcases:
     warm-reboot-sad-vlan-port:
       filename: warm-reboot-sad-vlan-port.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
 
     fib:
       filename: simple-fib.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
 
     hash:
       filename: hash.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
@@ -170,21 +170,21 @@ testcases:
     warm-reboot-fib:
       filename: warm-reboot-fib.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
 
     fdb:
       filename: fdb.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
 
     fdb_mac_expire:
       filename: fdb_mac_expire.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-52]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-52]
       required_vars:
           fdb_aging_time:
           ptf_host:
@@ -192,31 +192,31 @@ testcases:
 
     dir_bcast:
       filename: dir_bcast.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
 
     lag_2:
       filename: lag_2.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
 
     lldp:
       filename: lldp.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-116, t0-120, t0-64-32, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-116, t0-118, t0-120, t0-64-32, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     link_flap:
       filename: link_flap.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     continuous_link_flap:
       filename: continuous_link_flap.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     mtu:
       filename: mtu.yml
@@ -233,81 +233,81 @@ testcases:
 
     neighbour_mac_noptf:
       filename: neighbour-mac-noptf.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     ntp:
       filename: ntp.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     pfc_wd:
       filename: pfc_wd.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     portstat:
       filename: portstat.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-116, t0-120, t1]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-116, t0-118, t0-120, t1]
 
     port_toggle:
       filename: port_toggle.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     qos_sai:
       filename: qos_sai.yml
-      topologies: [ptf32, ptf64, t1, t1-lag, t0, t0-64, t0-116, t0-120]
+      topologies: [ptf32, ptf64, t1, t1-lag, t0, t0-64, t0-116, t0-118, t0-120]
 
     reboot:
       filename: reboot.yml
-      topologies: [dualtor, dualtor-64-breakout, dualtor-aa-64-breakout, t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-28-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [dualtor, dualtor-64-breakout, dualtor-aa-64-breakout, t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-28-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     repeat_harness:
       filename: repeat_harness.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     restart_swss:
       filename: run_config_cleanup.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     restart_swss_service:
       filename: restart_swss.yml
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     restart_syncd:
       filename: restart_syncd.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     sensors:
       filename: sensors_check.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     service_acl:
       filename: service_acl.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     snmp:
       filename: snmp.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     syslog:
       filename: syslog.yml
-      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     vlan:
       filename: vlantb.yml
-      topologies: [t0, t0-16, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
 
     crm:
       filename: crm.yml
-      topologies: [t1, t1-lag, t0, t0-52, t0-56, t0-64, t0-116, t0-120]
+      topologies: [t1, t1-lag, t0, t0-52, t0-56, t0-64, t0-116, t0-118, t0-120]
 
     dip_sip:
       filename: dip_sip.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
@@ -315,27 +315,27 @@ testcases:
     vxlan_decap:
       filename: vxlan-decap.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
     wr_arp:
       filename: wr_arp.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
     vnet_vxlan:
       filename: vnet_vxlan.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
     warm_reboot_vnet:
       filename: warm-reboot-vnet.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
@@ -345,7 +345,7 @@ testcases:
 
     iface_mode:
       filename: iface_naming_mode.yml
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, ptf32, ptf64]
       required_vars:
           testbed_type:
 

--- a/ansible/testbed-new.yaml
+++ b/ansible/testbed-new.yaml
@@ -230,7 +230,7 @@ veos_groups:
     servers:
         children: [server_1, server_2]                      # source: sonic-mgmt/veos
         vars:
-            topologies: ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag', 't0', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']  # source: sonic-mgmt/veos
+            topologies: ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag', 't0', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116', 't0-118']  # source: sonic-mgmt/veos
     server_1:
         children: [vm_host_1, vms_1]                        # source: sonic-mgmt/veos
         vars:

--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -63,17 +63,14 @@ def pause_arp_update(duthosts):
 
 
 @pytest.fixture(params=['IPv4', 'IPv6'])
-def neighbor_ip(request, mux_config):       # noqa F811
-    """
-    Provide the neighbor IP used for testing
-
-    Randomly select an IP from the server IPs configured in the config DB MUX_CABLE table
-    """
+def selected_mux_port(request, mux_config):       # noqa F811
+    """Randomly select a mux port for testing."""
     ip_version = request.param
     selected_intf = random.choice(list(mux_config.values()))
     neigh_ip = ip_interface(selected_intf["SERVER"][ip_version]).ip
+    cable_type = selected_intf["SERVER"].get("cable_type", "active-standby")
     logger.info("Using {} as neighbor IP".format(neigh_ip))
-    return neigh_ip
+    return selected_intf, neigh_ip, cable_type
 
 
 @pytest.fixture
@@ -135,7 +132,7 @@ def test_proxy_arp_for_standby_neighbor(proxy_arp_enabled, ip_and_intf_info, res
 
 
 def test_arp_update_for_failed_standby_neighbor(
-    config_dualtor_arp_responder, neighbor_ip, clear_neighbor_table,                        # noqa F811
+    config_dualtor_arp_responder, selected_mux_port, clear_neighbor_table,                  # noqa F811
     toggle_all_simulator_ports_to_rand_selected_tor, rand_selected_dut, rand_unselected_dut # noqa F811
 ):
     """
@@ -149,6 +146,11 @@ def test_arp_update_for_failed_standby_neighbor(
     4. Run `arp_update` on the active ToR
     5. Verify the incomplete entry is now reachable
     """
+    _, neighbor_ip, cable_type = selected_mux_port
+
+    if cable_type == "active-active":
+        pytest.skip("Skip as the testcase is designed for active-standby mux port.")
+
     if ip_address(neighbor_ip).version == 6 and rand_unselected_dut.facts["asic_type"] == "vs":
         pytest.skip("Temporarily skipped to let the sonic-swss submodule be updated.")
     # We only use ping to trigger an ARP request from the kernel, so exit early to save time
@@ -181,8 +183,9 @@ def test_arp_update_for_failed_standby_neighbor(
 
 
 def test_standby_unsolicited_neigh_learning(
-    config_dualtor_arp_responder, neighbor_ip, clear_neighbor_table,                        # noqa F811
-    toggle_all_simulator_ports_to_rand_selected_tor, rand_selected_dut, rand_unselected_dut # noqa F811
+    config_dualtor_arp_responder, selected_mux_port, clear_neighbor_table,                      # noqa F811
+    toggle_all_simulator_ports_to_rand_selected_tor, rand_selected_dut, rand_unselected_dut,    # noqa F811
+    setup_standby_ports_on_rand_unselected_tor                                                  # noqa F811
 ):
     """
     Test the standby ToR's ability to perform unsolicited neighbor learning (GARP and unsolicited NA)
@@ -192,6 +195,7 @@ def test_standby_unsolicited_neigh_learning(
     2. Run arp_update on the active ToR
     3. Confirm that the standby ToR learned the entry and it is REACHABLE
     """
+    neighbor_ip = selected_mux_port[1]
     if ip_address(neighbor_ip).version == 6 and rand_unselected_dut.facts["asic_type"] == "vs":
         pytest.skip("Temporarily skipped to let the sonic-swss submodule be updated.")
     ping_cmd = "timeout 0.2 ping -c1 -W1 -i0.2 -n -q {}".format(neighbor_ip)

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -48,6 +48,7 @@ __all__ = ['tor_mux_intf', 'tor_mux_intfs', 'ptf_server_intf', 't1_upper_tor_int
            'setup_standby_ports_on_rand_selected_tor',
            'setup_standby_ports_on_rand_unselected_tor',
            'setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m',
+           'setup_standby_ports_on_non_enum_rand_one_per_hwsku_host_m',
            'setup_standby_ports_on_rand_unselected_tor_unconditionally',
            'setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally',
            ]
@@ -1899,6 +1900,23 @@ def setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m(
 ):
     if active_active_ports:
         active_tor = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        standby_tor = upper_tor_host if active_tor == lower_tor_host else lower_tor_host
+        config_active_active_dualtor_active_standby(active_tor, standby_tor, active_active_ports)
+    return
+
+
+@pytest.fixture
+def setup_standby_ports_on_non_enum_rand_one_per_hwsku_host_m(
+    active_active_ports,                                                   # noqa F811
+    enum_rand_one_per_hwsku_hostname,
+    config_active_active_dualtor_active_standby,
+    validate_active_active_dualtor_setup,
+    upper_tor_host,
+    lower_tor_host,
+    duthosts
+):
+    if active_active_ports:
+        active_tor = duthosts[enum_rand_one_per_hwsku_hostname]
         standby_tor = upper_tor_host if active_tor == lower_tor_host else lower_tor_host
         config_active_active_dualtor_active_standby(active_tor, standby_tor, active_active_ports)
     return

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -725,6 +725,38 @@ def toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m(
 
 
 @pytest.fixture
+def toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_host_m(
+    duthosts, enum_rand_one_per_hwsku_hostname, mux_server_url, tbinfo, active_standby_ports               # noqa F811
+):
+    """
+    A function level fixture to toggle all ports to enum_rand_one_per_hwsku_frontend_hostname.
+
+    Before toggling, this fixture firstly sets all muxcables to 'manual' mode on all ToRs.
+    After test is done, restore all mux cables to 'auto' mode on all ToRs in teardown phase.
+    """
+    # Skip on non dualtor testbed
+    if 'dualtor' not in tbinfo['topo']['name'] or not active_standby_ports:
+        yield
+        return
+
+    logger.info('Set all muxcable to manual mode on all ToRs')
+    duthosts.shell('config muxcable mode manual all')
+
+    _toggle_all_simulator_ports_to_target_dut(
+        enum_rand_one_per_hwsku_hostname, duthosts, mux_server_url, tbinfo
+    )
+
+    yield
+
+    logger.info('Set all muxcable to auto mode on all ToRs')
+    duthosts.shell('config muxcable mode auto all')
+    # NOTE: If a fixture is executed after this one, and that fixture setup does a config
+    # save, the mux manual config will be kept in the config_db.json.
+    # So let's do a config save here.
+    duthosts.shell('config save -y')
+
+
+@pytest.fixture
 def toggle_all_simulator_ports_to_random_side(active_standby_ports, duthosts, mux_server_url, tbinfo, mux_config):    # noqa F811
     """
     A function level fixture to toggle all ports to a random side.

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -211,12 +211,15 @@ def parallel_run(
                 p_exception = process['exception'][0]
                 p_traceback = process['exception'][1]
                 p_exitcode = process['exit_code']
-            pt_assert(
-                False,
-                'Processes "{}" failed with exit code "{}"\nException:\n{}\nTraceback:\n{}'.format(
-                    list(failed_processes.keys()), p_exitcode, p_exception, p_traceback
+            # For analyzed matched syslog, don't need to log the traceback
+            if "analyze_logs" in process_name and "Match Messages" in str(p_exception):
+                failure_message = 'Got matched syslog in processes "{}" exit code:"{}"\n{}'.format(
+                    process_name, p_exitcode, p_exception
                 )
-            )
+            else:
+                failure_message = 'Processes "{}" failed with exit code "{}"\nException:\n{}\nTraceback:\n{}'.format(
+                    list(failed_processes.keys()), p_exitcode, p_exception, p_traceback)
+            pt_assert(False, failure_message)
 
     logger.info(
         'Completed running processes for target "{}" in {} seconds'.format(

--- a/tests/common/helpers/tacacs/tacacs_helper.py
+++ b/tests/common/helpers/tacacs/tacacs_helper.py
@@ -170,9 +170,12 @@ def setup_tacacs_server(ptfhost, tacacs_creds, duthost):
     if 'ansible_ssh_user' in dut_options and 'ansible_ssh_pass' in dut_options:
         duthost_ssh_user = dut_options['ansible_ssh_user']
         duthost_ssh_passwd = dut_options['ansible_ssh_pass']
-        logger.debug("setup_tacacs_server: update extra_vars with ansible_ssh_user and ansible_ssh_pass.")
-        extra_vars['duthost_ssh_user'] = duthost_ssh_user
-        extra_vars['duthost_ssh_passwd'] = crypt.crypt(duthost_ssh_passwd, 'abc')
+        if not duthost_ssh_user == extra_vars['duthost_admin_user']:
+            logger.debug("setup_tacacs_server: update extra_vars with ansible_ssh_user and ansible_ssh_pass.")
+            extra_vars['duthost_ssh_user'] = duthost_ssh_user
+            extra_vars['duthost_ssh_passwd'] = crypt.crypt(duthost_ssh_passwd, 'abc')
+        else:
+            logger.debug("setup_tacacs_server: duthost_admin_user and ansible_ssh_user are the same.")
     else:
         logger.debug("setup_tacacs_server: duthost options does not contains config for ansible_ssh_user.")
 

--- a/tests/common/platform/warmboot_sad_cases.py
+++ b/tests/common/platform/warmboot_sad_cases.py
@@ -59,7 +59,7 @@ def get_sad_case_list(duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_t
                 # (1 each)
                 NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(3),
                                    PhyPropsPortSelector(duthost, lagMemberCnt)),
-            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-64-32'] else []),
+            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-118', 't0-64-32'] else []),
 
         "sad_bgp": [
                 'neigh_bgp_down:2',     # Shutdown single BGP session on 2 remote devices (VMs) before reboot DUT
@@ -81,7 +81,7 @@ def get_sad_case_list(duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_t
                 # (1 each)
                 NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(3),
                                    PhyPropsPortSelector(duthost, lagMemberCnt)),
-            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-64-32'] else []),
+            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-118', 't0-64-32'] else []),
 
         "sad_lag": [
                 'dut_lag_down:2',               # Shutdown 2 LAG sessions on DUT brefore rebooting it

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -188,7 +188,7 @@ bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot:
     conditions_logical_operator: or
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56'] and https://github.com/sonic-net/sonic-mgmt/issues/9201"
-      - "'backend' in topo_name or 'mgmttor' in topo_name"
+      - "'backend' in topo_name or 'mgmttor' in topo_name or 'isolated' in topo_name"
 
 bgp/test_bgp_speaker.py:
   skip:
@@ -270,7 +270,7 @@ copp/test_copp.py:
   skip:
     reason: "Topology not supported by COPP tests"
     conditions:
-      - "(topo_name not in ['dualtor-aa', 'dualtor-aa-64-breakout', 'ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
+      - "(topo_name not in ['dualtor-aa', 'dualtor-aa-64-breakout', 'ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_add_new_trap:
   skip:
@@ -278,7 +278,7 @@ copp/test_copp.py::TestCOPP::test_add_new_trap:
     conditions_logical_operator: or
     conditions:
       - "is_multi_asic==True"
-      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
+      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_remove_trap:
   skip:
@@ -286,7 +286,7 @@ copp/test_copp.py::TestCOPP::test_remove_trap:
     conditions_logical_operator: or
     conditions:
       - "is_multi_asic==True"
-      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
+      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
   skip:
@@ -296,14 +296,14 @@ copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
       - "is_multi_asic==True"
       - "build_version.split('.')[0].isdigit() and int(build_version.split('.')[0]) == 20220531 and int(build_version.split('.')[1]) > 27 and hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Arista-7060CX-32S-C32-T1']"
       - "build_version.split('.')[0].isdigit() and int(build_version.split('.')[0]) > 20220531 and hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Arista-7060CX-32S-C32-T1']"
-      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
+      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_trap_neighbor_miss:
   skip:
     reason: "Copp test_trap_neighbor_miss is not supported on broadcom platforms or non-TOR topologies"
     conditions_logical_operator: or
     conditions:
-      - "(topo_name not in ['t0', 't0-64', 't0-52', 't0-116'])"
+      - "(topo_name not in ['t0', 't0-64', 't0-52', 't0-116', 't0-118'])"
       - "(asic_type in ['broadcom'] and release in ['202411'])"
 
 #######################################
@@ -995,7 +995,7 @@ generic_config_updater/test_eth_interface.py::test_replace_fec:
              / generic_config_updater is not a supported feature for T2'
     conditions_logical_operator: "OR"
     conditions:
-      - "hwsku in ['Arista-7260CX3-D108C8', 'Arista-7260CX3-Q64', 'Mellanox-SN3800-D112C8'] and https://github.com/sonic-net/sonic-mgmt/issues/11237"
+      - "hwsku in ['Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Arista-7260CX3-Q64', 'Mellanox-SN3800-D112C8'] and https://github.com/sonic-net/sonic-mgmt/issues/11237"
       - "'t2' in topo_name"
 
 generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym:
@@ -1023,14 +1023,7 @@ generic_config_updater/test_incremental_qos.py:
     conditions:
       - "'dualtor' in topo_name"
       - "'t2' in topo_name"
-
-generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates:
-  skip:
-    reason: "This test is not run on this hwsku/asic type or version or topology currently"
-    conditions_logical_operator: "OR"
-    conditions:
       - "not any(i in hwsku for i in ['2700', 'Arista-7170-64C', 'montara', 'newport']) and asic_type in ['broadcom', 'cisco-8000'] and release in ['202211']"
-      - "'t2' in topo_name"
 
 generic_config_updater/test_mmu_dynamic_threshold_config_update.py::test_dynamic_th_config_updates:
   skip:
@@ -1259,6 +1252,10 @@ hash/test_generic_hash.py::test_nexthop_flap:
       - "asic_gen == 'spc1'"
       - "asic_type in ['broadcom']"
       - https://github.com/sonic-net/sonic-mgmt/issues/13919
+  xfail:
+    reason: "Flaky hashing behavior using specific combination of hash field and algorithm."
+    conditions:
+      - "'isolated' in topo_name"
 
 hash/test_generic_hash.py::test_nexthop_flap[CRC-INNER_IP_PROTOCOL:
   skip:
@@ -1687,11 +1684,7 @@ pfcwd/test_pfcwd_warm_reboot.py:
         - "topo_type in ['m0', 'mx']"
         - "release in ['202412']"
         - "asic_type in ['cisco-8000']"
-   xfail:
-     reason: "Warm Reboot is not supported in dualtor and has a known issue on 202305 branch"
-     conditions:
-        - "'dualtor' in topo_name"
-        - https://github.com/sonic-net/sonic-mgmt/issues/8400
+        - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-mgmt/issues/8400"
 
 pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm:
    skip:
@@ -1802,7 +1795,7 @@ qos/test_qos_sai.py::TestQosSai:
     reason: "Unsupported testbed type. / M0/MX topo does not support qos"
     conditions_logical_operator: or
     conditions:
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
       - "topo_type in ['m0', 'mx']"
 
 qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping:
@@ -1813,7 +1806,7 @@ qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping:
       - "asic_type in ['mellanox']"
       - https://github.com/sonic-net/sonic-mgmt/issues/12906
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
   skip:
@@ -1822,7 +1815,7 @@ qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
     conditions:
       - "asic_type in ['cisco-8000']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark:
   skip:
@@ -1831,7 +1824,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark:
     conditions:
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-arista_7800r3_48cq2_lc', 'x86_64-arista_7800r3_48cqm2_lc', 'x86_64-arista_7800r3a_36d2_lc', 'x86_64-arista_7800r3a_36dm2_lc','x86_64-arista_7800r3ak_36dm2_lc']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping:
   skip:
@@ -1840,7 +1833,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping:
     conditions:
       - "'backend' not in topo_name"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping:
   skip:
@@ -1849,7 +1842,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping:
     conditions:
       - "'backend' not in topo_name"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:
   skip:
@@ -1858,7 +1851,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:
     conditions:
       - "'backend' in topo_name"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping:
   skip:
@@ -1867,7 +1860,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping:
     conditions:
       - "'backend' in topo_name"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange:
   skip:
@@ -1876,7 +1869,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange:
     conditions:
       - "asic_type in ['mellanox']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiFullMeshTrafficSanity:
   skip:
@@ -1885,7 +1878,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiFullMeshTrafficSanity:
     conditions:
       - "asic_type not in ['cisco-8000'] or topo_name not in ['ptf64']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
   skip:
@@ -1893,10 +1886,10 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
     conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100']
-      and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
+      and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
       and asic_type in ['cisco-8000']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
       - "'t2' in topo_name and asic_subtype in ['broadcom-dnx']"
       - "asic_type in ['vs']"
 
@@ -1909,11 +1902,11 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
          and asic_type in ['cisco-8000']
          and https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
   xfail:
     reason: "Headroom pool size not supported."
     conditions:
-      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
+      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
   skip:
@@ -1922,7 +1915,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq:
   skip:
@@ -1931,7 +1924,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc:
   skip:
@@ -1940,7 +1933,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop:
   skip:
@@ -1949,7 +1942,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
   skip:
@@ -1958,7 +1951,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
     conditions:
       - "asic_type in ['cisco-8000'] and not platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[None-wm_pg_shared_lossy]:
   xfail:
@@ -1973,7 +1966,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts:
     conditions:
       - "asic_type not in ['cisco-8000']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
   skip:
@@ -1982,7 +1975,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
       - "asic_type in ['vs']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis:
@@ -2562,12 +2555,6 @@ vxlan/test_vnet_bgp_route_precedence.py:
     conditions:
       - "asic_type not in ['cisco-8000', 'mellanox']"
       - "release in ['202411']"
-
-vxlan/test_vnet_decap.py:
-  skip:
-    reason: "test_vnet_decap are not ready to run on Cisco-8000 with branch 202411"
-    conditions:
-      - "(asic_type in ['cisco-8000'] and release in ['202411'])"
 
 vxlan/test_vnet_route_leak.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1307,7 +1307,7 @@ platform_tests/test_sensors.py::test_sensors:
   xfail:
     reason: "Case failed and waiting for fix on Arista platform"
     conditions:
-      - "hwsku in ['Arista-7050QX32S-Q32', 'Arista-7060CX-32S-D48C8', 'Arista-7260CX3-D108C8', 'Arista-7060CX-32S-C32', 'Arista-7260CX3-C64']"
+      - "hwsku in ['Arista-7050QX32S-Q32', 'Arista-7060CX-32S-D48C8', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Arista-7060CX-32S-C32', 'Arista-7260CX3-C64']"
       - "release in ['202205']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8437
 

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1035,11 +1035,11 @@ def recover_acl_rule(duthost, data_acl):
 
 def get_ipv4_loopback_ip(duthost):
     """
-    Get ipv4 loopback ip address
+    Get the first valid ipv4 loopback ip address
     """
     config_facts = duthost.get_running_config_facts()
     los = config_facts.get("LOOPBACK_INTERFACE", {})
-    loopback_ip = None
+    selected_loopback_ip = None
 
     for key, _ in los.items():
         if "Loopback" in key:
@@ -1047,10 +1047,12 @@ def get_ipv4_loopback_ip(duthost):
             for ip_str, _ in loopback_ips.items():
                 ip = ip_str.split("/")[0]
                 if is_ipv4_address(ip):
-                    loopback_ip = ip
+                    selected_loopback_ip = ip
                     break
+        if selected_loopback_ip is not None:
+            break
 
-    return loopback_ip
+    return selected_loopback_ip
 
 
 def get_dscp_to_queue_value(dscp_value, dscp_to_tc_map, tc_to_queue_map):
@@ -1407,3 +1409,22 @@ def get_iface_ip(mg_facts, ifacename):
         if loopback['name'] == ifacename and ipaddress.ip_address(loopback['addr']).version == 4:
             return loopback['addr']
     return None
+
+
+def get_vlan_from_port(duthost, member_port):
+    '''
+    Returns the name of the VLAN that has the given member port.
+    If no VLAN or appropriate member found, returns None.
+    '''
+    mg_facts = duthost.get_extended_minigraph_facts()
+    if 'minigraph_vlans' not in mg_facts:
+        return None
+    vlan_name = None
+    for vlan in mg_facts['minigraph_vlans']:
+        for member in mg_facts['minigraph_vlans'][vlan]['members']:
+            if member == member_port:
+                vlan_name = vlan
+                break
+        if vlan_name is not None:
+            break
+    return vlan_name

--- a/tests/dualtor_io/conftest.py
+++ b/tests/dualtor_io/conftest.py
@@ -35,10 +35,17 @@ def pytest_generate_tests(metafunc):
 def setup_loganalyzer(loganalyzer):
     """Fixture to allow customize loganalyzer behaviors."""
 
-    def _setup_loganalyzer(duthost, collect_only):
+    KERNEL_BOOTUP_SYSLOG = "kernel: [    0.000000] Linux version"
+
+    def _setup_loganalyzer(duthost, collect_only=False, collect_from_bootup=False):
         if collect_only:
             loganalyzer[duthost.hostname].match_regex = []
             loganalyzer[duthost.hostname].expect_regex = []
             loganalyzer[duthost.hostname].ignore_regex = []
+
+        if collect_from_bootup:
+            loganalyzer[duthost.hostname].start_marker = KERNEL_BOOTUP_SYSLOG
+            loganalyzer[duthost.hostname].ansible_loganalyzer.start_marker = \
+                KERNEL_BOOTUP_SYSLOG
 
     return _setup_loganalyzer

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -421,17 +421,17 @@ def test_active_link_admin_down_config_reload_downstream(
             upper_tor_host.shell("config save -y")
 
 
-@pytest.mark.disable_loganalyzer
 @pytest.mark.enable_active_active
 @pytest.mark.skip_active_standby
 def test_active_link_admin_down_config_reload_link_up_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
-    cable_type, active_active_ports                                     # noqa F811
+    cable_type, active_active_ports, setup_loganalyzer                  # noqa F811
 ):
     """
     Send traffic from server to T1 and unshut the active-active mux ports.
     Verify switchover and disruption.
     """
+    setup_loganalyzer(upper_tor_host, collect_only=True)
     if cable_type == CableType.active_active:
         try:
             config_interface_admin_status(upper_tor_host, active_active_ports, "down")
@@ -474,17 +474,17 @@ def test_active_link_admin_down_config_reload_link_up_upstream(
             upper_tor_host.shell("config save -y")
 
 
-@pytest.mark.disable_loganalyzer
 @pytest.mark.enable_active_active
 @pytest.mark.skip_active_standby
 def test_active_link_admin_down_config_reload_link_up_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
-    cable_type, active_active_ports                                     # noqa F811
+    cable_type, active_active_ports, setup_loganalyzer                  # noqa F811
 ):
     """
     Send traffic from T1 to standby ToR and unshut the active-active mux ports.
     Verify switchover and disruption.
     """
+    setup_loganalyzer(upper_tor_host, collect_only=True)
     if cable_type == CableType.active_active:
         try:
             config_interface_admin_status(upper_tor_host, active_active_ports, "down")

--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -56,117 +56,109 @@ def toggle_lower_tor_pdu(lower_tor_host, get_pdu_controller):       # noqa F811
 
 
 @pytest.mark.enable_active_active
-@pytest.mark.disable_loganalyzer
 def test_active_tor_reboot_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_upper_tor_pdu,      # noqa F811
     wait_for_device_reachable, wait_for_mux_container, cable_type,      # noqa F811
-    wait_for_pmon_container                                             # noqa F811
+    wait_for_pmon_container, setup_loganalyzer                          # noqa F811
 ):
     """
     Send upstream traffic and reboot the active ToR. Confirm switchover
     occurred and disruption lasts < 1 second
     """
-    with LogAnalyzer(ansible_host=lower_tor_host,
-                     marker_prefix="test_active_tor_reboot_upstream"):
-        send_server_to_t1_with_action(
-            upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=toggle_upper_tor_pdu, stop_after=60
+    setup_loganalyzer(upper_tor_host, collect_only=True, collect_from_bootup=True)
+    send_server_to_t1_with_action(
+        upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        action=toggle_upper_tor_pdu, stop_after=60
+    )
+    wait_for_device_reachable(upper_tor_host)
+    wait_for_mux_container(upper_tor_host)
+    wait_for_pmon_container(upper_tor_host)
+
+    if cable_type == CableType.active_standby:
+        verify_tor_states(
+            expected_active_host=lower_tor_host,
+            expected_standby_host=upper_tor_host
         )
-        wait_for_device_reachable(upper_tor_host)
-        wait_for_mux_container(upper_tor_host)
-        wait_for_pmon_container(upper_tor_host)
-
-        if cable_type == CableType.active_standby:
-            verify_tor_states(
-                expected_active_host=lower_tor_host,
-                expected_standby_host=upper_tor_host
-            )
-        elif cable_type == CableType.active_active:
-            verify_tor_states(
-                expected_active_host=[upper_tor_host, lower_tor_host],
-                expected_standby_host=None,
-                cable_type=cable_type,
-                verify_db_timeout=60
-            )
+    elif cable_type == CableType.active_active:
+        verify_tor_states(
+            expected_active_host=[upper_tor_host, lower_tor_host],
+            expected_standby_host=None,
+            cable_type=cable_type,
+            verify_db_timeout=60
+        )
 
 
-@pytest.mark.disable_loganalyzer
 def test_active_tor_reboot_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_upper_tor_pdu,      # noqa F811
     wait_for_device_reachable, wait_for_mux_container,                  # noqa F811
-    wait_for_pmon_container                                             # noqa F811
+    wait_for_pmon_container, setup_loganalyzer                          # noqa F811
 ):
     """
     Send downstream traffic to the standby ToR and reboot the active ToR.
     Confirm switchover occurred and disruption lasts < 1 second
     """
-    with LogAnalyzer(ansible_host=lower_tor_host,
-                     marker_prefix="test_active_tor_reboot_downstream_standby"):
-        send_t1_to_server_with_action(
-            lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            action=toggle_upper_tor_pdu, stop_after=60
-        )
-        wait_for_device_reachable(upper_tor_host)
-        wait_for_mux_container(upper_tor_host)
-        wait_for_pmon_container(upper_tor_host)
-        verify_tor_states(
-            expected_active_host=lower_tor_host,
-            expected_standby_host=upper_tor_host
-        )
+    setup_loganalyzer(upper_tor_host, collect_only=True, collect_from_bootup=True)
+    send_t1_to_server_with_action(
+        lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
+        action=toggle_upper_tor_pdu, stop_after=60
+    )
+    wait_for_device_reachable(upper_tor_host)
+    wait_for_mux_container(upper_tor_host)
+    wait_for_pmon_container(upper_tor_host)
+    verify_tor_states(
+        expected_active_host=lower_tor_host,
+        expected_standby_host=upper_tor_host
+    )
 
 
-@pytest.mark.disable_loganalyzer
 def test_standby_tor_reboot_upstream(
     upper_tor_host, lower_tor_host, send_server_to_t1_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_lower_tor_pdu,      # noqa F811
     wait_for_device_reachable, wait_for_mux_container,                  # noqa F811
-    wait_for_pmon_container                                             # noqa F811
+    wait_for_pmon_container, setup_loganalyzer                          # noqa F811
 ):
     """
     Send upstream traffic and reboot the standby ToR. Confirm no switchover
     occurred and no disruption
     """
-    with LogAnalyzer(ansible_host=upper_tor_host,
-                     marker_prefix="test_standby_tor_reboot_upstream"):
-        send_server_to_t1_with_action(
-            upper_tor_host, verify=True,
-            action=toggle_lower_tor_pdu, stop_after=60
-        )
-        wait_for_device_reachable(lower_tor_host)
-        wait_for_mux_container(lower_tor_host)
-        wait_for_pmon_container(lower_tor_host)
-        verify_tor_states(
-            expected_active_host=upper_tor_host,
-            expected_standby_host=lower_tor_host
-        )
+    setup_loganalyzer(lower_tor_host, collect_only=True, collect_from_bootup=True)
+    send_server_to_t1_with_action(
+        upper_tor_host, verify=True,
+        action=toggle_lower_tor_pdu, stop_after=60
+    )
+    wait_for_device_reachable(lower_tor_host)
+    wait_for_mux_container(lower_tor_host)
+    wait_for_pmon_container(lower_tor_host)
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host
+    )
 
 
-@pytest.mark.disable_loganalyzer
 def test_standby_tor_reboot_downstream_active(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
     toggle_all_simulator_ports_to_upper_tor, toggle_lower_tor_pdu,      # noqa F811
     wait_for_device_reachable, wait_for_mux_container,                  # noqa F811
-    wait_for_pmon_container                                             # noqa F811
+    wait_for_pmon_container, setup_loganalyzer                          # noqa F811
 ):
     """
     Send downstream traffic to the active ToR and reboot the standby ToR.
     Confirm no switchover occurred and no disruption
     """
-    with LogAnalyzer(ansible_host=upper_tor_host,
-                     marker_prefix="test_standby_tor_reboot_downstream_active"):
-        send_t1_to_server_with_action(
-            upper_tor_host, verify=True,
-            action=toggle_lower_tor_pdu, stop_after=60
-        )
-        wait_for_device_reachable(lower_tor_host)
-        wait_for_mux_container(lower_tor_host)
-        wait_for_pmon_container(lower_tor_host)
-        verify_tor_states(
-            expected_active_host=upper_tor_host,
-            expected_standby_host=lower_tor_host
-        )
+    setup_loganalyzer(lower_tor_host, collect_only=True, collect_from_bootup=True)
+    send_t1_to_server_with_action(
+        upper_tor_host, verify=True,
+        action=toggle_lower_tor_pdu, stop_after=60
+    )
+    wait_for_device_reachable(lower_tor_host)
+    wait_for_mux_container(lower_tor_host)
+    wait_for_pmon_container(lower_tor_host)
+    verify_tor_states(
+        expected_active_host=upper_tor_host,
+        expected_standby_host=lower_tor_host
+    )
 
 
 @pytest.mark.enable_active_active

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -685,7 +685,9 @@ class BaseEverflowTest(object):
                 command += " --stage {}".format(self.acl_stage())
 
             if bind_ports_list:
-                command += " -p {}".format(",".join(bind_ports_list))
+                filtered_ports = [p for p in bind_ports_list if p and p != "Not Applicable"]
+                if filtered_ports:
+                    command += " -p {}".format(",".join(filtered_ports))
 
         elif config_method == CONFIG_MODE_CONFIGLET:
             pass

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -92,7 +92,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         yield direction
 
     @pytest.fixture(scope='function', autouse=True)
-    def background_traffic(self, ptfadapter, everflow_direction, setup_info, everflow_dut):  # noqa F811
+    def background_traffic(self, ptfadapter, everflow_direction, setup_info, everflow_dut,  # noqa F811
+                           setup_standby_ports_on_rand_unselected_tor_unconditionally):     # noqa F811
         stop_thread = threading.Event()
         src_port = EverflowIPv6Tests.rx_port_ptf_id
 
@@ -141,7 +142,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                             exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
                             exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
                             exp_pkt.set_do_not_care_packet(scapy.IPv6, "hlim")
-                            testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=ptfadapter.ptf_port_set)
+                            testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=ptfadapter.ptf_port_set,
+                                                             timeout=5)
                     count += 1
 
             background_traffic(run_count=1)

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -57,7 +57,7 @@ def get_dummay_mac_count(tbinfo, duthosts, rand_one_dut_hostname):
 
     # t0-116 will take 90m with DUMMY_MAC_COUNT, so use DUMMY_MAC_COUNT_SLIM for t0-116 to reduce running time
     # Use DUMMY_MAC_COUNT_SLIM on dualtor-64 to reduce running time
-    REQUIRED_TOPO = ["t0-116", "dualtor-64", "dualtor-120",
+    REQUIRED_TOPO = ["t0-116", "t0-118", "dualtor-64", "dualtor-120",
                      "t0-standalone-64", "t0-standalone-128", "t0-standalone-256", "t0-standalone-512"]
     if tbinfo["topo"]["name"] in REQUIRED_TOPO:
         # To reduce the case running time

--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -8,7 +8,6 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.ptf_runner import ptf_runner
 from .utils import fdb_table_has_dummy_mac_for_interface
-from tests.common.helpers.ptf_tests_helper import upstream_links    # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 
 
@@ -36,8 +35,6 @@ class TestFdbMacLearning:
     """
     TestFdbMacLearning verifies that stale MAC entries are not present in MAC table after doing sonic-clear fdb all
     -shut down all ports
-    -config save
-    -config reload
     -bring up 1 port. populate fdb
     -bring up 3 more ports. populate fdb.
     -shut down 3 ports added in last step
@@ -123,7 +120,7 @@ class TestFdbMacLearning:
         """
             Select DUT ports which will be used for the testcase
             Get a mapping of selected DUT ports and ptf ports
-            shut down all DUT ports, congit save and config reload the DUT before starting the testcases
+            shut down all DUT ports
 
             Args:
                 duthosts: Devices under test
@@ -173,9 +170,23 @@ class TestFdbMacLearning:
         logging.info("shutdown all interfaces on DUT")
         for port in dut_ports:
             duthost.shell("sudo config interface shutdown {}".format(port))
-        duthost.command('sudo config save -y')
-        config_reload(duthost, config_source='config_db', safe_reload=True)
+
         yield target_ports_to_ptf_mapping, ptf_ports_available_in_topo, conf_facts
+
+        logging.info("reload device %s to recover", duthost.hostname)
+        config_reload(duthost, config_source='running_golden_config', safe_reload=True)
+
+    @pytest.fixture(autouse=True)
+    def cleanup_arp_fdb(self, duthosts, rand_one_dut_hostname):
+        """Cleanup fdb and arp on the selected target DUT."""
+        duthost = duthosts[rand_one_dut_hostname]
+        duthost.shell("sonic-clear arp")
+        duthost.shell("sonic-clear fdb all")
+
+        yield
+
+        duthost.shell("sonic-clear arp")
+        duthost.shell("sonic-clear fdb all")
 
     def dynamic_fdb_oper(self, duthost, tbinfo, ptfhost, dut_ptf_ports):
         """function to populate fdb for given dut/ptf ports"""
@@ -205,44 +216,13 @@ class TestFdbMacLearning:
         """
         Make sure interfaces are ready for sending traffic.
         """
-        if "dualtor-aa" in tbinfo['topo']['name']:
-            pytest_assert(wait_until(300, 5, 0, self.check_mux_status_consistency, duthost, ports))
-        else:
-            time.sleep(30)
-
-    def bringup_uplink_ports(self, duthost, upstream_links): # noqa F811
-        """
-        For active-active dualtor NIC simulator doesn't install OVS flows for downlink ports until the link status
-        becomes consistent which can happen in this case only if upstream connectivity is restored.
-        """
-        # Get one upstream port
-        uplink_intf = list(upstream_links.keys())[0]
-        # Check if it's a LAG member
-        config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
-        portChannels = config_facts['PORTCHANNEL_MEMBER']
-        portChannel = None
-        members = None
-        for intf in portChannels:
-            if uplink_intf in portChannels[intf]:
-                portChannel = intf
-                members = list(portChannels[intf].keys())
-                break
-        if portChannel:
-            min_links = int(config_facts['PORTCHANNEL'][portChannel]['min_links'])
-            # Bringup minimum ports for this port channel to be up
-            for i in range(min_links):
-                duthost.shell("sudo config interface startup {}".format(members[i]))
-        else:
-            duthost.shell("sudo config interface startup {}".format(uplink_intf))
+        time.sleep(30)
 
     def testFdbMacLearning(self, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request, prepare_test,
-                           upstream_links, setup_standby_ports_on_rand_unselected_tor_unconditionally,                  # noqa F811
                            toggle_all_simulator_ports_to_rand_selected_tor_m):                                          # noqa F811
         """
             TestFdbMacLearning verifies stale MAC entries are not present in MAC table after doing sonic-clear fdb all
             -shut down all ports
-            -config save
-            -config reload
             -bring up 1 port. populate fdb
             -bring up 3 more ports. populate fdb.
             -shut down 3 ports added in last step
@@ -260,10 +240,7 @@ class TestFdbMacLearning:
             res = ptfhost.shell('cat /sys/class/net/{}/address'.format(ptf_port))
             ptf_interfaces_mac_addresses.append(res['stdout'].upper())
 
-        # Bringup uplink connectivity for muxcable status consistency to happen.
         duthost = duthosts[rand_one_dut_hostname]
-        if "dualtor-aa" in tbinfo['topo']['name']:
-            self.bringup_uplink_ports(duthost, upstream_links)
 
         # unshut 1 port and populate fdb for that port. make sure fdb entry is populated in mac table
         target_ports = [target_ports_to_ptf_mapping[0][0]]
@@ -330,9 +307,11 @@ class TestFdbMacLearning:
         try:
             self.configureInterfaceIp(duthost, dut_interface, action="add")
             self.configureNeighborIp(ptfhost, ptf_ports_available_in_topo[ptf_port_index], action="add")
+            time.sleep(2)
             ptfhost.shell("ping {} -c 3 -I {}".format(self.DUT_INTF_IP, self.PTF_HOST_IP), module_ignore_errors=True)
-
-        finally:
+            int_ip_found = any((dut_interface in line and self.DUT_INTF_IP in line)
+                               for line in duthost.command("show ip interface")["stdout_lines"])
+            pytest_assert(int_ip_found, "%s is not configured on %s" % (self.DUT_INTF_IP, dut_interface))
             show_arp = duthost.command('show arp')
             arp_found = False
             for arp_entry in show_arp['stdout_lines']:
@@ -342,5 +321,6 @@ class TestFdbMacLearning:
                     pytest_assert(items[2] == dut_interface, "ARP entry for ip address {}"
                                   " is incomplete. Interface is missing".format(self.PTF_HOST_IP))
             pytest_assert(arp_found, "ARP entry not found for ip address {}".format(self.PTF_HOST_IP))
+        finally:
             self.configureInterfaceIp(duthost, dut_interface, action="remove")
             self.configureNeighborIp(ptfhost, ptf_ports_available_in_topo[ptf_port_index], action="del")

--- a/tests/hash/generic_hash_helper.py
+++ b/tests/hash/generic_hash_helper.py
@@ -88,46 +88,46 @@ def get_supported_hash_algorithms(request):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def skip_vs_setups(duthost):
+def skip_vs_setups(rand_selected_dut):
     """ Fixture to skip the test on vs setups. """
-    if duthost.facts['asic_type'] in ["vs"]:
+    if rand_selected_dut.facts['asic_type'] in ["vs"]:
         pytest.skip("Generic hash test only runs on physical setups.")
 
 
 @pytest.fixture(scope="module")
-def mg_facts(duthost, tbinfo):
+def mg_facts(rand_selected_dut, tbinfo):
     """ Fixture to get the extended minigraph facts """
-    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     return mg_facts
 
 
 @pytest.fixture(scope='function', autouse=True)
-def restore_init_hash_config(duthost):
+def restore_init_hash_config(rand_selected_dut):
     """ Fixture to restore the initial generic hash configurations after the test. """
     logger.info("Store the initial generic hash configurations")
     init_ecmp_hash_fields, init_ecmp_hash_algo, init_lag_hash_fields, init_lag_hash_algo = \
-        get_global_hash_config(duthost)
+        get_global_hash_config(rand_selected_dut)
     yield
     if init_ecmp_hash_fields:
-        duthost.set_switch_hash_global('ecmp', init_ecmp_hash_fields)
+        rand_selected_dut.set_switch_hash_global('ecmp', init_ecmp_hash_fields)
     if init_lag_hash_fields:
-        duthost.set_switch_hash_global('lag', init_lag_hash_fields)
+        rand_selected_dut.set_switch_hash_global('lag', init_lag_hash_fields)
     if init_ecmp_hash_algo and init_ecmp_hash_algo != 'N/A':
-        duthost.set_switch_hash_global_algorithm('ecmp', init_ecmp_hash_algo)
+        rand_selected_dut.set_switch_hash_global_algorithm('ecmp', init_ecmp_hash_algo)
     if init_lag_hash_algo and init_lag_hash_algo != 'N/A':
-        duthost.set_switch_hash_global_algorithm('lag', init_lag_hash_algo)
+        rand_selected_dut.set_switch_hash_global_algorithm('lag', init_lag_hash_algo)
     logger.info("The initial generic hash configurations have been restored.")
 
 
 @pytest.fixture(scope='function')
-def reload(duthost):
+def reload(rand_selected_dut):
     """ Fixture to do the config reload after the test. """
     yield
-    config_reload(duthost, safe_reload=True)
+    config_reload(rand_selected_dut, safe_reload=True)
 
 
 @pytest.fixture(scope='function')
-def restore_configuration(duthost):
+def restore_configuration(rand_selected_dut):
     """ Fixture to restore the interface and vlan configurations after the L2 test.
         The configurations are restored from the global variables. """
 
@@ -137,18 +137,18 @@ def restore_configuration(duthost):
         # Remove vlans
         for vlan in vlans_to_remove:
             for interface in l2_ports:
-                duthost.shell(f'config vlan member del {vlan} {interface}')
-            duthost.shell(f'config vlan del {vlan}')
+                rand_selected_dut.shell(f'config vlan member del {vlan} {interface}')
+            rand_selected_dut.shell(f'config vlan del {vlan}')
         # Re-config ip interface
         for ip_interface in ip_interface_to_restore:
             formatted_ip_addr = format_ip_mask(f"{ip_interface['addr']}/{ip_interface['mask']}")
-            duthost.shell(f"config interface ip add {ip_interface['attachto']} {formatted_ip_addr.upper()}")
+            rand_selected_dut.shell(f"config interface ip add {ip_interface['attachto']} {formatted_ip_addr.upper()}")
         # Re-config vlan interface
         if vlan_member_to_restore:
-            duthost.shell(f"config vlan member add {vlan_member_to_restore['vlan_id']} "
-                          f"{vlan_member_to_restore['interface']} --untagged")
+            rand_selected_dut.shell(f"config vlan member add {vlan_member_to_restore['vlan_id']} "
+                                    f"{vlan_member_to_restore['interface']} --untagged")
     except Exception as err:
-        config_reload(duthost, safe_reload=True)
+        config_reload(rand_selected_dut, safe_reload=True)
         logger.info("Exception occurred when restoring the configuration.")
         raise err
     finally:
@@ -159,45 +159,45 @@ def restore_configuration(duthost):
 
 
 @pytest.fixture(scope='function')
-def restore_interfaces(duthost):
+def restore_interfaces(rand_selected_dut):
     """ Fixture to startup interfaces after the flap test in case the test fails and some
         interfaces are shutdown during the test. The interfaces to start are from a global variable """
 
     yield
     logger.info("Startup the interfaces which were shutdown during the test")
     if interfaces_to_startup:
-        duthost.no_shutdown_multiple(interfaces_to_startup)
+        rand_selected_dut.no_shutdown_multiple(interfaces_to_startup)
     try:
         for interface in interfaces_to_startup:
-            pytest_assert(wait_until(30, 5, 0, duthost.check_intf_link_state, interface),
+            pytest_assert(wait_until(30, 5, 0, rand_selected_dut.check_intf_link_state, interface),
                           "Not all interfaces are restored to up after the flap test.")
     finally:
         del interfaces_to_startup[:]
 
 
 @pytest.fixture(scope='function')
-def restore_vxlan_port(duthost):
+def restore_vxlan_port(rand_selected_dut):
     """ Fixture to restore the vxlan port to default 4789 """
     global restore_vxlan
     yield
     if restore_vxlan:
         vxlan_ecmp_utils.Constants['DEBUG'] = False
         vxlan_ecmp_utils.Constants['KEEP_TEMP_FILES'] = False
-        vxlan_ecmp_utils.configure_vxlan_switch(duthost, 4789, duthost.facts['router_mac'])
+        vxlan_ecmp_utils.configure_vxlan_switch(rand_selected_dut, 4789, rand_selected_dut.facts['router_mac'])
         restore_vxlan = False
 
 
 @pytest.fixture(scope='module')
-def global_hash_capabilities(duthost):
+def global_hash_capabilities(rand_selected_dut):
     """
     Get the generic hash capabilities.
     Args:
-        duthost (AnsibleHost): Device Under Test (DUT)
+        rand_selected_dut (AnsibleHost): Device Under Test (DUT)
     Returns:
         ecmp_hash_fields: a list of supported ecmp hash fields
         lag_hash_fields: a list of supported lag hash fields
     """
-    global_hash_capabilities = duthost.get_switch_hash_capabilities()
+    global_hash_capabilities = rand_selected_dut.get_switch_hash_capabilities()
     return {'ecmp': global_hash_capabilities['ecmp'], 'ecmp_algo': global_hash_capabilities['ecmp_algo'],
             'lag': global_hash_capabilities['lag'], 'lag_algo': global_hash_capabilities['lag_algo']}
 

--- a/tests/hash/test_generic_hash.py
+++ b/tests/hash/test_generic_hash.py
@@ -19,6 +19,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.reboot import reboot
 from tests.common.config_reload import config_reload
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
+from tests.common.dualtor.dual_tor_utils import toggle_all_aa_ports_to_rand_selected_tor  # noqa F401
 
 DEFAULT_VXLAN_PORT = 4789
 PTF_LOG_PATH = "/tmp/generic_hash_test.GenericHashTest.log"
@@ -129,12 +130,12 @@ def test_hash_capability(duthost, global_hash_capabilities):  # noqa:F811
                       'The lag hash capability is not as expected.')
 
 
-def test_ecmp_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, global_hash_capabilities,   # noqa:F811
-                   restore_vxlan_port, toggle_all_simulator_ports_to_upper_tor):                # noqa:F811
+def test_ecmp_hash(rand_selected_dut, tbinfo, ptfhost, fine_params, mg_facts, global_hash_capabilities,  # noqa:F811
+                   restore_vxlan_port, toggle_all_aa_ports_to_rand_selected_tor):                        # noqa:F811
     """
     Test case to validate the ecmp hash. The hash field to test is randomly chosen from the supported hash fields.
     Args:
-        duthost (AnsibleHost): Device Under Test (DUT)
+        rand_selected_dut (AnsibleHost): Device Under Test (DUT)
         ptfhost (AnsibleHost): Packet Test Framework (PTF)
         mg_facts: minigraph facts
         hash_algorithm: randomly generated hash algorithm
@@ -152,26 +153,27 @@ def test_ecmp_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, global_hash_
         lag_hash_fields = lag_hash_fields[:]
         lag_hash_fields.remove(ecmp_test_hash_field) if ecmp_test_hash_field in lag_hash_fields else None
         # Config the hash fields
-        duthost.set_switch_hash_global('ecmp', [ecmp_test_hash_field])
-        duthost.set_switch_hash_global('lag', lag_hash_fields)
+        rand_selected_dut.set_switch_hash_global('ecmp', [ecmp_test_hash_field])
+        rand_selected_dut.set_switch_hash_global('lag', lag_hash_fields)
     with allure.step(f'Configure ecmp hash algorithm: {hash_algorithm}'):
-        duthost.set_switch_hash_global_algorithm('ecmp', hash_algorithm)
+        rand_selected_dut.set_switch_hash_global_algorithm('ecmp', hash_algorithm)
     with allure.step("Check the config result"):
         check_global_hash_config(
-            duthost, ecmp_hash_fields=[ecmp_test_hash_field], lag_hash_fields=lag_hash_fields)
-        check_global_hash_algorithm(duthost, hash_algorithm)
+            rand_selected_dut, ecmp_hash_fields=[ecmp_test_hash_field], lag_hash_fields=lag_hash_fields)
+        check_global_hash_algorithm(rand_selected_dut, hash_algorithm)
     with allure.step('Prepare test parameters'):
         # Get the interfaces for the test, downlink interface is selected randomly
-        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(duthost, mg_facts, ecmp_test_hash_field)
+        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(rand_selected_dut, mg_facts,
+                                                                         ecmp_test_hash_field)
         ptf_params = generate_test_params(
-            duthost, tbinfo, mg_facts, ecmp_test_hash_field, ipver, inner_ipver, encap_type, uplink_interfaces,
-            downlink_interfaces, ecmp_hash=True, lag_hash=False)
+            rand_selected_dut, tbinfo, mg_facts, ecmp_test_hash_field, ipver, inner_ipver, encap_type,
+            uplink_interfaces, downlink_interfaces, ecmp_hash=True, lag_hash=False)
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
-            config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
+            config_custom_vxlan_port(rand_selected_dut, ptf_params['vxlan_port'])
 
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         # Check the default route before the ptf test
-        pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
+        pytest_assert(check_default_route(rand_selected_dut, uplink_interfaces.keys()),
                       'The default route is not available or some nexthops are missing.')
         ptf_runner(
             ptfhost,
@@ -186,14 +188,13 @@ def test_ecmp_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, global_hash_
         )
 
 
-def test_lag_hash(duthost, ptfhost, tbinfo, fine_params, mg_facts, restore_configuration,   # noqa:F811
-                  restore_vxlan_port, global_hash_capabilities,                             # noqa F811
-                  toggle_all_simulator_ports_to_upper_tor):                                 # noqa:F811
+def test_lag_hash(rand_selected_dut, ptfhost, tbinfo, fine_params, mg_facts, restore_configuration,         # noqa:F811
+                  restore_vxlan_port, global_hash_capabilities, toggle_all_aa_ports_to_rand_selected_tor):  # noqa:F811
     """
     Test case to validate the lag hash. The hash field to test is randomly chosen from the supported hash fields.
     When hash field is in [DST_MAC, ETHERTYPE, VLAN_ID], need to re-configure the dut for L2 traffic.
     Args:
-        duthost (AnsibleHost): Device Under Test (DUT)
+        rand_selected_dut (AnsibleHost): Device Under Test (DUT)
         ptfhost (AnsibleHost): Packet Test Framework (PTF)
         mg_facts: minigraph facts
         tbinfo: testbed info fixture
@@ -212,18 +213,19 @@ def test_lag_hash(duthost, ptfhost, tbinfo, fine_params, mg_facts, restore_confi
         ecmp_hash_fields = ecmp_hash_fields[:]
         ecmp_hash_fields.remove(lag_test_hash_field) if lag_test_hash_field in ecmp_hash_fields else None
         # Get the interfaces for the test, downlink interface is selected randomly
-        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(duthost, mg_facts, lag_test_hash_field)
+        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(rand_selected_dut, mg_facts,
+                                                                         lag_test_hash_field)
         # If the uplinks are not multi-member portchannels, skip the test
         skip_single_member_lag_topology(uplink_interfaces, lag_test_hash_field, encap_type)
         # Config the hash fields
-        duthost.set_switch_hash_global('ecmp', ecmp_hash_fields)
-        duthost.set_switch_hash_global('lag', [lag_test_hash_field])
+        rand_selected_dut.set_switch_hash_global('ecmp', ecmp_hash_fields)
+        rand_selected_dut.set_switch_hash_global('lag', [lag_test_hash_field])
     with allure.step(f'Configure lag hash algorithm: {hash_algorithm}'):
-        duthost.set_switch_hash_global_algorithm('lag', hash_algorithm)
+        rand_selected_dut.set_switch_hash_global_algorithm('lag', hash_algorithm)
     with allure.step("Check the config result"):
         check_global_hash_config(
-            duthost, ecmp_hash_fields=ecmp_hash_fields, lag_hash_fields=[lag_test_hash_field])
-        check_global_hash_algorithm(duthost, lag_hash_algo=hash_algorithm)
+            rand_selected_dut, ecmp_hash_fields=ecmp_hash_fields, lag_hash_fields=[lag_test_hash_field])
+        check_global_hash_algorithm(rand_selected_dut, lag_hash_algo=hash_algorithm)
     with allure.step('Change topology for L2 test if hash field in DST_MAC, ETHERTYPE, VLAN_ID'):
         # Need to send l2 traffic to validate SRC_MAC, DST_MAC, ETHERTYPE, VLAN_ID keys, changing topology is required
         is_l2_test = False
@@ -233,17 +235,17 @@ def test_lag_hash(duthost, ptfhost, tbinfo, fine_params, mg_facts, restore_confi
             for _ in range(len(uplink_interfaces) - 1):
                 uplink_interfaces.popitem()
             remove_ip_interface_and_config_vlan(
-                duthost, mg_facts, tbinfo, downlink_interfaces[0], uplink_interfaces, lag_test_hash_field)
+                rand_selected_dut, mg_facts, tbinfo, downlink_interfaces[0], uplink_interfaces, lag_test_hash_field)
     with allure.step('Prepare test parameters'):
         ptf_params = generate_test_params(
-            duthost, tbinfo, mg_facts, lag_test_hash_field, ipver, inner_ipver, encap_type, uplink_interfaces,
+            rand_selected_dut, tbinfo, mg_facts, lag_test_hash_field, ipver, inner_ipver, encap_type, uplink_interfaces,
             downlink_interfaces, ecmp_hash=False, lag_hash=True, is_l2_test=is_l2_test)
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
-            config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
+            config_custom_vxlan_port(rand_selected_dut, ptf_params['vxlan_port'])
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         # Check the default route before the ptf test
         if not is_l2_test:
-            pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
+            pytest_assert(check_default_route(rand_selected_dut, uplink_interfaces.keys()),
                           'The default route is not available or some nexthops are missing.')
         ptf_runner(
             ptfhost,
@@ -268,14 +270,14 @@ def config_all_hash_algorithm(duthost, ecmp_algorithm, lag_algorithm):  # noqa:F
     duthost.set_switch_hash_global_algorithm('lag', lag_algorithm)
 
 
-def test_ecmp_and_lag_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, global_hash_capabilities,  # noqa:F811
-                           restore_vxlan_port, get_supported_hash_algorithms,  # noqa:F811
-                           toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+def test_ecmp_and_lag_hash(rand_selected_dut, tbinfo, ptfhost, fine_params, mg_facts,                     # noqa:F811
+                           global_hash_capabilities,  restore_vxlan_port, get_supported_hash_algorithms,  # noqa:F811
+                           toggle_all_aa_ports_to_rand_selected_tor):                                     # noqa:F811
     """
     Test case to validate the hash behavior when both ecmp and lag hash are configured with a same field.
     The hash field to test is randomly chosen from the supported hash fields.
     Args:
-        duthost (AnsibleHost): Device Under Test (DUT)
+        rand_selected_dut (AnsibleHost): Device Under Test (DUT)
         ptfhost (AnsibleHost): Packet Test Framework (PTF)
         mg_facts: minigraph facts
         ecmp_algorithm: randomly generated ecmp hash algorithm
@@ -290,24 +292,25 @@ def test_ecmp_and_lag_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, glob
     skip_unsupported_field_for_ecmp_test(ecmp_test_hash_field, encap_type)
     with allure.step('Randomly select an ecmp hash field to test '
                      'and configure all supported fields to the global ecmp and lag hash'):
-        config_all_hash_fields(duthost, global_hash_capabilities)
+        config_all_hash_fields(rand_selected_dut, global_hash_capabilities)
         lag_algorithm = get_diff_hash_algorithm(ecmp_algorithm, get_supported_hash_algorithms)
     with allure.step(f'Configure ecmp hash algorithm: {ecmp_algorithm} - lag hash algorithm: {lag_algorithm}'):
-        config_all_hash_algorithm(duthost, ecmp_algorithm, lag_algorithm)
+        config_all_hash_algorithm(rand_selected_dut, ecmp_algorithm, lag_algorithm)
     with allure.step("Check the config result"):
-        check_global_hash_config(duthost, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
-        check_global_hash_algorithm(duthost, ecmp_algorithm, lag_algorithm)
+        check_global_hash_config(rand_selected_dut, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
+        check_global_hash_algorithm(rand_selected_dut, ecmp_algorithm, lag_algorithm)
     with allure.step('Prepare test parameters'):
         # Get the interfaces for the test, downlink interface is selected randomly
-        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(duthost, mg_facts, ecmp_test_hash_field)
+        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(rand_selected_dut, mg_facts,
+                                                                         ecmp_test_hash_field)
         ptf_params = generate_test_params(
-            duthost, tbinfo, mg_facts, ecmp_test_hash_field, ipver, inner_ipver, encap_type, uplink_interfaces,
-            downlink_interfaces, ecmp_hash=True, lag_hash=True)
+            rand_selected_dut, tbinfo, mg_facts, ecmp_test_hash_field, ipver, inner_ipver, encap_type,
+            uplink_interfaces, downlink_interfaces, ecmp_hash=True, lag_hash=True)
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
-            config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
+            config_custom_vxlan_port(rand_selected_dut, ptf_params['vxlan_port'])
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         # Check the default route before the ptf test
-        pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
+        pytest_assert(check_default_route(rand_selected_dut, uplink_interfaces.keys()),
                       'The default route is not available or some nexthops are missing.')
         ptf_runner(
             ptfhost,
@@ -322,14 +325,14 @@ def test_ecmp_and_lag_hash(duthost, tbinfo, ptfhost, fine_params, mg_facts, glob
         )
 
 
-def test_nexthop_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_interfaces,  # noqa:F811
-                      restore_vxlan_port, global_hash_capabilities, get_supported_hash_algorithms,  # noqa:F811
-                      toggle_all_simulator_ports_to_upper_tor):  # noqa:F811
+def test_nexthop_flap(rand_selected_dut, tbinfo, ptfhost, fine_params, mg_facts, restore_interfaces,  # noqa:F811
+                      restore_vxlan_port, global_hash_capabilities, get_supported_hash_algorithms,    # noqa:F811
+                      toggle_all_aa_ports_to_rand_selected_tor):                                      # noqa:F811
     """
     Test case to validate the ecmp hash when there is nexthop flapping.
     The hash field to test is randomly chosen from the supported hash fields.
     Args:
-        duthost (AnsibleHost): Device Under Test (DUT)
+        rand_selected_dut (AnsibleHost): Device Under Test (DUT)
         ptfhost (AnsibleHost): Packet Test Framework (PTF)
         mg_facts: minigraph facts
         restore_interfaces: fixture to restore the interfaces used in the test
@@ -345,24 +348,25 @@ def test_nexthop_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_i
     skip_unsupported_field_for_ecmp_test(ecmp_test_hash_field, encap_type)
     with allure.step('Randomly select an ecmp hash field to test '
                      'and configure all supported fields to the global ecmp and lag hash'):
-        config_all_hash_fields(duthost, global_hash_capabilities)
+        config_all_hash_fields(rand_selected_dut, global_hash_capabilities)
         lag_algorithm = get_diff_hash_algorithm(ecmp_algorithm, get_supported_hash_algorithms)
     with allure.step(f'Configure ecmp hash algorithm: {ecmp_algorithm} - lag hash algorithm: {lag_algorithm}'):
-        config_all_hash_algorithm(duthost, ecmp_algorithm, lag_algorithm)
+        config_all_hash_algorithm(rand_selected_dut, ecmp_algorithm, lag_algorithm)
     with allure.step("Check the config result"):
-        check_global_hash_config(duthost, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
-        check_global_hash_algorithm(duthost, ecmp_algorithm, lag_algorithm)
+        check_global_hash_config(rand_selected_dut, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
+        check_global_hash_algorithm(rand_selected_dut, ecmp_algorithm, lag_algorithm)
     with allure.step('Prepare test parameters'):
         # Get the interfaces for the test, downlink interface is selected randomly
-        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(duthost, mg_facts, ecmp_test_hash_field)
+        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(rand_selected_dut, mg_facts,
+                                                                         ecmp_test_hash_field)
         ptf_params = generate_test_params(
-            duthost, tbinfo, mg_facts, ecmp_test_hash_field, ipver, inner_ipver, encap_type, uplink_interfaces,
-            downlink_interfaces, ecmp_hash=True, lag_hash=True)
+            rand_selected_dut, tbinfo, mg_facts, ecmp_test_hash_field, ipver, inner_ipver, encap_type,
+            uplink_interfaces, downlink_interfaces, ecmp_hash=True, lag_hash=True)
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
-            config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
+            config_custom_vxlan_port(rand_selected_dut, ptf_params['vxlan_port'])
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         # Check the default route before the ptf test
-        pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
+        pytest_assert(check_default_route(rand_selected_dut, uplink_interfaces.keys()),
                       'The default route is not available or some nexthops are missing.')
         ptf_runner(
             ptfhost,
@@ -382,7 +386,7 @@ def test_nexthop_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_i
         origin_ptf_expected_port_groups = ptf_params['expected_port_groups']
         _, ptf_params['expected_port_groups'] = get_ptf_port_indices(
             mg_facts, downlink_interfaces=[], uplink_interfaces=remaining_uplink_interfaces)
-        shutdown_interface(duthost, interface)
+        shutdown_interface(rand_selected_dut, interface)
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         ptf_runner(
             ptfhost,
@@ -396,9 +400,9 @@ def test_nexthop_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_i
             is_python3=True
         )
     with allure.step('Startup the interface, and then flap it 3 more times'):
-        startup_interface(duthost, interface)
-        flap_interfaces(duthost, [interface], times=3)
-        pytest_assert(wait_until(10, 2, 0, check_default_route, duthost, uplink_interfaces.keys()),
+        startup_interface(rand_selected_dut, interface)
+        flap_interfaces(rand_selected_dut, [interface], times=3)
+        pytest_assert(wait_until(10, 2, 0, check_default_route, rand_selected_dut, uplink_interfaces.keys()),
                       'The default route is not restored after the flapping.')
         ptf_params['expected_port_groups'] = origin_ptf_expected_port_groups
     with allure.step('Start the ptf test, send traffic and check the balancing'):
@@ -415,15 +419,15 @@ def test_nexthop_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_i
         )
 
 
-def test_lag_member_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_configuration,    # noqa F811
-                         restore_interfaces, global_hash_capabilities, restore_vxlan_port,          # noqa F811
-                         get_supported_hash_algorithms, toggle_all_simulator_ports_to_upper_tor):   # noqa F811
+def test_lag_member_flap(rand_selected_dut, tbinfo, ptfhost, fine_params, mg_facts, restore_configuration,  # noqa:F811
+                         restore_interfaces, global_hash_capabilities, restore_vxlan_port,                  # noqa:F811
+                         get_supported_hash_algorithms, toggle_all_aa_ports_to_rand_selected_tor):          # noqa:F811
     """
     Test case to validate the lag hash when there is lag member flapping.
     The hash field to test is randomly chosen from the supported hash fields.
     When hash field is in [DST_MAC, ETHERTYPE, VLAN_ID], need to re-configure the dut for L2 traffic.
     Args:
-        duthost (AnsibleHost): Device Under Test (DUT)
+        rand_selected_dut (AnsibleHost): Device Under Test (DUT)
         ptfhost (AnsibleHost): Packet Test Framework (PTF)
         tbinfo: testbed info fixture
         mg_facts: minigraph facts
@@ -441,16 +445,17 @@ def test_lag_member_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restor
     with allure.step('Randomly select an lag hash field to test '
                      'and configure all supported fields to the global ecmp and lag hash'):
         # Get the interfaces for the test, downlink interface is selected randomly
-        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(duthost, mg_facts, lag_test_hash_field)
+        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(rand_selected_dut, mg_facts,
+                                                                         lag_test_hash_field)
         # If the uplinks are not multi-member portchannels, skip the test
         skip_single_member_lag_topology(uplink_interfaces, lag_test_hash_field, encap_type)
-        config_all_hash_fields(duthost, global_hash_capabilities)
+        config_all_hash_fields(rand_selected_dut, global_hash_capabilities)
         lag_algorithm = get_diff_hash_algorithm(ecmp_algorithm, get_supported_hash_algorithms)
     with allure.step(f'Configure ecmp hash algorithm: {ecmp_algorithm} - lag hash algorithm: {lag_algorithm}'):
-        config_all_hash_algorithm(duthost, ecmp_algorithm, lag_algorithm)
+        config_all_hash_algorithm(rand_selected_dut, ecmp_algorithm, lag_algorithm)
     with allure.step("Check the config result"):
-        check_global_hash_config(duthost, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
-        check_global_hash_algorithm(duthost, ecmp_algorithm, lag_algorithm)
+        check_global_hash_config(rand_selected_dut, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
+        check_global_hash_algorithm(rand_selected_dut, ecmp_algorithm, lag_algorithm)
     with allure.step('Change topology for L2 test if hash field in DST_MAC, ETHERTYPE, VLAN_ID'):
         # Need to send l2 traffic to validate SRC_MAC, DST_MAC, ETHERTYPE, VLAN_ID fields, changing topology is required
         is_l2_test = False
@@ -460,19 +465,19 @@ def test_lag_member_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restor
                 is_l2_test = True
                 for _ in range(len(uplink_interfaces) - 1):
                     uplink_interfaces.popitem()
-                remove_ip_interface_and_config_vlan(duthost, mg_facts, tbinfo, downlink_interfaces[0],
+                remove_ip_interface_and_config_vlan(rand_selected_dut, mg_facts, tbinfo, downlink_interfaces[0],
                                                     uplink_interfaces,
                                                     lag_test_hash_field)
     with allure.step('Prepare test parameters'):
         ptf_params = generate_test_params(
-            duthost, tbinfo, mg_facts, lag_test_hash_field, ipver, inner_ipver, encap_type, uplink_interfaces,
+            rand_selected_dut, tbinfo, mg_facts, lag_test_hash_field, ipver, inner_ipver, encap_type, uplink_interfaces,
             downlink_interfaces, ecmp_hash=True, lag_hash=True, is_l2_test=is_l2_test)
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
-            config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
+            config_custom_vxlan_port(rand_selected_dut, ptf_params['vxlan_port'])
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         # Check the default route before the ptf test
         if not is_l2_test:
-            pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
+            pytest_assert(check_default_route(rand_selected_dut, uplink_interfaces.keys()),
                           'The default route is not available or some nexthops are missing.')
         ptf_runner(
             ptfhost,
@@ -493,11 +498,11 @@ def test_lag_member_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restor
             interface = random.choice(uplink_interfaces[portchannel])
             interfaces.append(interface)
         # Flap the members 3 more times
-        flap_interfaces(duthost, interfaces, uplink_interfaces.keys(), times=3)
+        flap_interfaces(rand_selected_dut, interfaces, uplink_interfaces.keys(), times=3)
 
     if not is_l2_test:
         with allure.step('Wait for the default route to recover'):
-            pytest_assert(wait_until(30, 5, 0, check_default_route, duthost, uplink_interfaces.keys()),
+            pytest_assert(wait_until(30, 5, 0, check_default_route, rand_selected_dut, uplink_interfaces.keys()),
                           'The default route is not available or some nexthops are missing.')
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         ptf_runner(
@@ -513,16 +518,17 @@ def test_lag_member_flap(duthost, tbinfo, ptfhost, fine_params, mg_facts, restor
         )
 
 
-def test_lag_member_remove_add(duthost, tbinfo, ptfhost, fine_params, mg_facts, restore_configuration,      # noqa F811
-                               restore_interfaces, global_hash_capabilities, restore_vxlan_port,            # noqa F811
-                               get_supported_hash_algorithms, toggle_all_simulator_ports_to_upper_tor):     # noqa F811
+def test_lag_member_remove_add(rand_selected_dut, tbinfo, ptfhost, fine_params, mg_facts,                 # noqa:F811
+                               restore_configuration, restore_interfaces,                                 # noqa:F811
+                               global_hash_capabilities, restore_vxlan_port,                              # noqa:F811
+                               get_supported_hash_algorithms, toggle_all_aa_ports_to_rand_selected_tor):  # noqa:F811
     """
     Test case to validate the lag hash when a lag member is removed from the lag and added back for
     a few times.
     The hash field to test is randomly chosen from the supported hash fields.
     When hash field is in [DST_MAC, ETHERTYPE, VLAN_ID], need to re-configure the dut for L2 traffic.
     Args:
-        duthost (AnsibleHost): Device Under Test (DUT)
+        rand_selected_dut (AnsibleHost): Device Under Test (DUT)
         ptfhost (AnsibleHost): Packet Test Framework (PTF)
         tbinfo: testbed info fixture
         mg_facts: minigraph facts
@@ -540,16 +546,17 @@ def test_lag_member_remove_add(duthost, tbinfo, ptfhost, fine_params, mg_facts, 
     with allure.step('Randomly select an lag hash field to test '
                      'and configure all supported fields to the global ecmp and lag hash'):
         # Get the interfaces for the test, downlink interface is selected randomly
-        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(duthost, mg_facts, lag_test_hash_field)
+        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(rand_selected_dut, mg_facts,
+                                                                         lag_test_hash_field)
         # If the uplinks are not multi-member portchannels, skip the test
         skip_single_member_lag_topology(uplink_interfaces, lag_test_hash_field, encap_type)
-        config_all_hash_fields(duthost, global_hash_capabilities)
+        config_all_hash_fields(rand_selected_dut, global_hash_capabilities)
         lag_algorithm = get_diff_hash_algorithm(ecmp_algorithm, get_supported_hash_algorithms)
     with allure.step(f'Configure ecmp hash algorithm: {ecmp_algorithm} - lag hash algorithm: {lag_algorithm}'):
-        config_all_hash_algorithm(duthost, ecmp_algorithm, lag_algorithm)
+        config_all_hash_algorithm(rand_selected_dut, ecmp_algorithm, lag_algorithm)
     with allure.step("Check the config result"):
-        check_global_hash_config(duthost, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
-        check_global_hash_algorithm(duthost, ecmp_algorithm, lag_algorithm)
+        check_global_hash_config(rand_selected_dut, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
+        check_global_hash_algorithm(rand_selected_dut, ecmp_algorithm, lag_algorithm)
     with allure.step('Change topology for L2 test if hash field in DST_MAC, ETHERTYPE, VLAN_ID'):
         # Need to send l2 traffic to validate SRC_MAC, DST_MAC, ETHERTYPE, VLAN_ID fields, changing topology is required
         is_l2_test = False
@@ -559,19 +566,19 @@ def test_lag_member_remove_add(duthost, tbinfo, ptfhost, fine_params, mg_facts, 
                 is_l2_test = True
                 for _ in range(len(uplink_interfaces) - 1):
                     uplink_interfaces.popitem()
-                remove_ip_interface_and_config_vlan(duthost, mg_facts, tbinfo, downlink_interfaces[0],
+                remove_ip_interface_and_config_vlan(rand_selected_dut, mg_facts, tbinfo, downlink_interfaces[0],
                                                     uplink_interfaces,
                                                     lag_test_hash_field)
     with allure.step('Prepare test parameters'):
         ptf_params = generate_test_params(
-            duthost, tbinfo, mg_facts, lag_test_hash_field, ipver, inner_ipver, encap_type, uplink_interfaces,
+            rand_selected_dut, tbinfo, mg_facts, lag_test_hash_field, ipver, inner_ipver, encap_type, uplink_interfaces,
             downlink_interfaces, ecmp_hash=True, lag_hash=True, is_l2_test=is_l2_test)
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
-            config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
+            config_custom_vxlan_port(rand_selected_dut, ptf_params['vxlan_port'])
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         # Check the default route before the ptf test
         if not is_l2_test:
-            pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
+            pytest_assert(check_default_route(rand_selected_dut, uplink_interfaces.keys()),
                           'The default route is not available or some nexthops are missing.')
         ptf_runner(
             ptfhost,
@@ -589,11 +596,11 @@ def test_lag_member_remove_add(duthost, tbinfo, ptfhost, fine_params, mg_facts, 
         # Randomly choose the members to remove/add
         for portchannel in uplink_interfaces:
             interface = random.choice(uplink_interfaces[portchannel])
-            remove_add_portchannel_member(duthost, interface, portchannel)
+            remove_add_portchannel_member(rand_selected_dut, interface, portchannel)
 
     if not is_l2_test:
         with allure.step('Wait for the default route to recover'):
-            pytest_assert(wait_until(30, 5, 0, check_default_route, duthost, uplink_interfaces.keys()),
+            pytest_assert(wait_until(30, 5, 0, check_default_route, rand_selected_dut, uplink_interfaces.keys()),
                           'The default route is not available or some nexthops are missing.')
 
     with allure.step('Start the ptf test, send traffic and check the balancing'):
@@ -611,14 +618,14 @@ def test_lag_member_remove_add(duthost, tbinfo, ptfhost, fine_params, mg_facts, 
 
 
 @pytest.mark.disable_loganalyzer
-def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, restore_vxlan_port,     # noqa F811
-                global_hash_capabilities, reboot_type, get_supported_hash_algorithms,               # noqa F811
-                toggle_all_simulator_ports_to_upper_tor):                                           # noqa F811
+def test_reboot(rand_selected_dut, tbinfo, ptfhost, localhost, fine_params, mg_facts, restore_vxlan_port,  # noqa:F811
+                global_hash_capabilities, reboot_type, get_supported_hash_algorithms,                      # noqa:F811
+                toggle_all_aa_ports_to_rand_selected_tor):                                                 # noqa:F811
     """
     Test case to validate the hash behavior after fast/warm/cold reboot.
     The hash field to test is randomly chosen from the supported hash fields.
     Args:
-        duthost (AnsibleHost): Device Under Test (DUT)
+        rand_selected_dut (AnsibleHost): Device Under Test (DUT)
         ptfhost (AnsibleHost): Packet Test Framework (PTF)
         mg_facts: minigraph facts
         localhost: local host object
@@ -634,24 +641,25 @@ def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, rest
     skip_unsupported_field_for_ecmp_test(ecmp_test_hash_field, encap_type)
     with allure.step('Randomly select an ecmp hash field to test '
                      'and configure all supported fields to the global ecmp and lag hash'):
-        config_all_hash_fields(duthost, global_hash_capabilities)
+        config_all_hash_fields(rand_selected_dut, global_hash_capabilities)
         lag_algorithm = get_diff_hash_algorithm(ecmp_algorithm, get_supported_hash_algorithms)
     with allure.step(f'Configure ecmp hash algorithm: {ecmp_algorithm} - lag hash algorithm: {lag_algorithm}'):
-        config_all_hash_algorithm(duthost, ecmp_algorithm, lag_algorithm)
+        config_all_hash_algorithm(rand_selected_dut, ecmp_algorithm, lag_algorithm)
     with allure.step("Check the config result"):
-        check_global_hash_config(duthost, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
-        check_global_hash_algorithm(duthost, ecmp_algorithm, lag_algorithm)
+        check_global_hash_config(rand_selected_dut, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
+        check_global_hash_algorithm(rand_selected_dut, ecmp_algorithm, lag_algorithm)
     with allure.step('Prepare test parameters'):
         # Get the interfaces for the test, downlink interface is selected randomly
-        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(duthost, mg_facts, ecmp_test_hash_field)
+        uplink_interfaces, downlink_interfaces = get_interfaces_for_test(rand_selected_dut, mg_facts,
+                                                                         ecmp_test_hash_field)
         ptf_params = generate_test_params(
-            duthost, tbinfo, mg_facts, ecmp_test_hash_field, ipver, inner_ipver, encap_type, uplink_interfaces,
-            downlink_interfaces, ecmp_hash=True, lag_hash=True)
+            rand_selected_dut, tbinfo, mg_facts, ecmp_test_hash_field, ipver, inner_ipver, encap_type,
+            uplink_interfaces, downlink_interfaces, ecmp_hash=True, lag_hash=True)
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
-            config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
+            config_custom_vxlan_port(rand_selected_dut, ptf_params['vxlan_port'])
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         # Check the default route before the ptf test
-        pytest_assert(check_default_route(duthost, uplink_interfaces.keys()),
+        pytest_assert(check_default_route(rand_selected_dut, uplink_interfaces.keys()),
                       'The default route is not available or some nexthops are missing.')
         ptf_runner(
             ptfhost,
@@ -668,21 +676,21 @@ def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, rest
     with allure.step(f'Randomly choose a reboot type: {reboot_type}, and reboot'):
         # Save config if reboot type is config reload or cold reboot
         if reboot_type in ['cold', 'reload', 'warm']:
-            duthost.shell('config save -y')
+            rand_selected_dut.shell('config save -y')
         # Reload/Reboot the dut
         if reboot_type == 'reload':
-            config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+            config_reload(rand_selected_dut, safe_reload=True, check_intf_up_ports=True)
         else:
-            reboot(duthost, localhost, reboot_type=reboot_type)
+            reboot(rand_selected_dut, localhost, reboot_type=reboot_type)
         # Wait for the dut to recover
-        pytest_assert(wait_until(300, 20, 0, duthost.critical_services_fully_started),
+        pytest_assert(wait_until(300, 20, 0, rand_selected_dut.critical_services_fully_started),
                       "Not all critical services are fully started.")
     with allure.step('Check the generic hash config after the reboot'):
-        check_global_hash_config(duthost, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
+        check_global_hash_config(rand_selected_dut, global_hash_capabilities['ecmp'], global_hash_capabilities['lag'])
         if ptf_params.get('vxlan_port') and ptf_params['vxlan_port'] != DEFAULT_VXLAN_PORT:
-            config_custom_vxlan_port(duthost, ptf_params['vxlan_port'])
+            config_custom_vxlan_port(rand_selected_dut, ptf_params['vxlan_port'])
     with allure.step('Check the route is established'):
-        pytest_assert(wait_until(60, 10, 0, check_default_route, duthost, uplink_interfaces.keys()),
+        pytest_assert(wait_until(60, 10, 0, check_default_route, rand_selected_dut, uplink_interfaces.keys()),
                       "The default route is not established after the cold reboot.")
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         ptf_runner(

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -1233,6 +1233,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     def test_pfcwd_no_traffic(
             self, request, setup_pfc_test, setup_dut_test_params, enum_fanout_graph_facts,  # noqa F811
             ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_hostname, fanouthosts,
+            setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,         # noqa F811
+            toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,                      # noqa F811
             set_pfc_time_cisco_8000): # noqa F811
         """
         Verify the pfcwd is not triggered when no traffic is sent, even when pfc storm is active.

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -826,11 +826,11 @@ class QosParamCisco(object):
                 sq_occupancies_mb = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 4]
                 params_1 = {"packet_size": packet_size,
                             "ecn": 1,
-                            "dscps":  [3, 4, 3, 4, 3, 4, 3, 4, 3, 3, 3],
-                            "pgs":    [3, 4, 3, 4, 3, 4, 3, 4, 3, 3, 3],
-                            "queues": [3, 4, 3, 4, 3, 4, 3, 4, 3, 3, 3],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 5, 6],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+                            "dscps":      [3, 4, 3, 4, 3,  4,  3,  4,  3,  4,  3],
+                            "pgs":        [3, 4, 3, 4, 3,  4,  3,  4,  3,  4,  3],
+                            "queues":     [3, 4, 3, 4, 3,  4,  3,  4,  3,  4,  3],
+                            "src_port_i": [0, 0, 1, 1, 2,  2,  3,  3,  4,  4,  5],
+                            "dst_port_i": [7, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_1", params_1)
 
@@ -841,8 +841,8 @@ class QosParamCisco(object):
                             "dscps":      [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "pgs":        [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "queues":     [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+                            "src_port_i": [0, 0, 1, 1, 2,  2,  3,  3,  4,  4,  5,  5,  6,  6],
+                            "dst_port_i": [7, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_2", params_2)
 
@@ -857,8 +857,8 @@ class QosParamCisco(object):
                                            self.dscp_queue1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "pgs":        [3, 0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "queues":     [3, 1, 0, 1, 0, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+                            "src_port_i": [0, 0, 1, 1, 2,  2,  3,  3,  4,  4,  5,  5,  6,  6,  9,  9],
+                            "dst_port_i": [7, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_3", params_3)
 
@@ -873,8 +873,8 @@ class QosParamCisco(object):
                                            self.dscp_queue1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "pgs":        [3, 0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4],
                             "queues":     [3, 1, 0, 1, 0, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11, 11],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8,  8],
+                            "src_port_i": [0, 0, 1, 1, 2, 2, 3,  3,  4,  4,  5,  5,  6,  6,  9,  9,  10, 10, 11, 11],
+                            "dst_port_i": [7, 8, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_4", params_4)
 
@@ -888,9 +888,10 @@ class QosParamCisco(object):
                                            self.dscp_queue1, self.dscp_queue0,
                                            self.dscp_queue1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "pgs":        [0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3,  4,  3,  4,  3,  4],
-                            "queues":     [1, 0, 1, 0, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3,  4,  3,  4,  3,  4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11, 11, 12],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8,  8,  8],
+                            "queues":     [1, 0, 1, 0, 1, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4,  3,  4,  3,  4,  3,  4],
+                            "src_port_i": [0, 0, 1, 1, 2, 2, 2, 3, 3,  4,  4,  5,  5,  6,  6,  9,  9,  10, 10, 11, 11],
+                            "dst_port_i": [7, 8, 12, 12, 13, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17,
+                                           18, 18, 19, 19, 20, 20],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_5", params_5)
 
@@ -904,8 +905,8 @@ class QosParamCisco(object):
                                            4, 3, 4, 3, 4],
                             "pgs":        [3, 4, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "queues":     [3, 4, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+                            "src_port_i": [0, 0, 1, 1, 1, 2,  2,  3,  3,  4,  4,  5,  5,  6,  6],
+                            "dst_port_i": [7, 8, 9, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_6", params_6)
 
@@ -917,7 +918,8 @@ class QosParamCisco(object):
                             "pgs":        [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4],
                             "queues":     [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4],
                             "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11, 11, 12, 12],
-                            "dst_port_i": [7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8,  8,  8,  8],
+                            "dst_port_i": [7, 7, 8, 8, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18,
+                                           18, 19, 19, 20, 20, 21, 21],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_7", params_7)
 
@@ -929,7 +931,8 @@ class QosParamCisco(object):
                             "pgs":        [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4],
                             "queues":     [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4],
                             "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11, 11, 12, 12],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8,  8,  8,  8],
+                            "dst_port_i": [7, 8, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19,
+                                           19, 20, 20, 21, 21, 22, 22],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_8", params_8)
 
@@ -944,8 +947,8 @@ class QosParamCisco(object):
                                            3, 4, 3, 4, 3, 4],
                             "pgs":        [0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3,  4,  3,  4],
                             "queues":     [1, 0, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3,  4,  3,  4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11],
-                            "dst_port_i": [7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8],
+                            "src_port_i": [0, 0, 1,  1,  1,  2,  2,  3,  3,  4,  4,  5,  5,  6,  6,  9,  9,  10, 10],
+                            "dst_port_i": [7, 8, 11, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_9", params_9)
 

--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -2959,6 +2959,9 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
     # no lossless traffic on DPU NPU ports, so skip them for the test
     dpu_npu_port_list = get_dpu_npu_ports_from_hwsku(duthost)
     configdb_ports = list(set(configdb_ports) - set(dpu_npu_port_list))
+
+    configdb_ports = [port for port in configdb_ports if duthost.shell(
+        f'redis-cli -n 4 hget "PORT|{port}" "admin_status"')['stdout'] == 'up']
     logging.info(f"test ports is {configdb_ports}")
     profiles_checked = {}
     lossless_pool_oid = None

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -15,7 +15,7 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.helpers.ptf_tests_helper import downstream_links, upstream_links, select_random_link,\
     get_stream_ptf_ports, get_dut_pair_port_from_ptf_port, apply_dscp_cfg_setup, apply_dscp_cfg_teardown # noqa F401
 from tests.common.utilities import get_ipv4_loopback_ip, get_dscp_to_queue_value, find_egress_queue,\
-    get_egress_queue_pkt_count_all_prio, wait_until
+    get_egress_queue_pkt_count_all_prio, wait_until, get_vlan_from_port
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.duthost_utils import dut_qos_maps_module # noqa F401
 
@@ -153,11 +153,15 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
     """
     def _setup_test_params(self,
                            duthost,
+                           tbinfo,
                            downstream_links, # noqa F811
                            upstream_links, # noqa F811
                            decap_mode):
         """
         Set up test parameters for the DSCP to Queue mapping test for IP-IP packets.
+
+        Destination mac returned will prioritize the VLAN mac address and fallback to the router mac
+        if no VLAN is found.
 
         Args:
             duthost (fixture): DUT fixture
@@ -169,7 +173,19 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         downlink = select_random_link(downstream_links)
         uplink_ptf_ports = get_stream_ptf_ports(upstream_links)
         loopback_ip = get_ipv4_loopback_ip(duthost)
-        router_mac = duthost.facts["router_mac"]
+        ptf_downlink_port_id = downlink.get("ptf_port_id")
+
+        src_port_name = get_dut_pair_port_from_ptf_port(duthost, tbinfo, ptf_downlink_port_id)
+        pytest_assert(src_port_name, "No port on DUT found for ptf downlink port {}".format(ptf_downlink_port_id))
+        vlan_name = get_vlan_from_port(duthost, src_port_name)
+        logger.debug("Found VLAN {} on port {}".format(vlan_name, src_port_name))
+        vlan_mac = None if vlan_name is None else duthost.get_dut_iface_mac(vlan_name)
+        if vlan_mac is not None:
+            logger.info("Using VLAN mac {} instead of router mac".format(vlan_mac))
+            dst_mac = vlan_mac
+        else:
+            logger.info("VLAN mac not found, falling back to router mac")
+            dst_mac = duthost.facts["router_mac"]
 
         # Setup DSCP decap config on DUT
         apply_dscp_cfg_setup(duthost, decap_mode)
@@ -177,13 +193,13 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         pytest_assert(downlink is not None, "No downlink found")
         pytest_assert(uplink_ptf_ports is not None, "No uplink found")
         pytest_assert(loopback_ip is not None, "No loopback IP found")
-        pytest_assert(router_mac is not None, "No router MAC found")
+        pytest_assert(dst_mac is not None, "No router/vlan MAC found")
 
-        test_params["ptf_downlink_port"] = downlink.get("ptf_port_id")
+        test_params["ptf_downlink_port"] = ptf_downlink_port_id
         test_params["ptf_uplink_ports"] = uplink_ptf_ports
         test_params["outer_src_ip"] = '8.8.8.8'
         test_params["outer_dst_ip"] = loopback_ip
-        test_params["router_mac"] = router_mac
+        test_params["dst_mac"] = dst_mac
 
         return test_params
 
@@ -213,7 +229,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             pytest.skip("Dscp-queue mapping is not supported on {}".format(tbinfo["topo"]["type"]))
 
         asic_type = duthost.facts['asic_type']
-        router_mac = test_params['router_mac']
+        dst_mac = test_params['dst_mac']
         ptf_src_port_id = test_params['ptf_downlink_port']
         ptf_dst_port_ids = test_params['ptf_uplink_ports']
         outer_dst_pkt_ip = test_params['outer_dst_ip']
@@ -229,7 +245,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         logger.info("Inner Pkt Src IP: {}".format(inner_src_pkt_ip))
         logger.info("Inner Pkt Dst IP: {}".format(inner_dst_pkt_ip))
         logger.info("Pkt Src MAC: {}".format(ptf_src_mac))
-        logger.info("Pkt Dst MAC: {}".format(router_mac))
+        logger.info("Pkt Dst MAC: {}".format(dst_mac))
 
         pytest_assert(dut_qos_maps_module.get("dscp_to_tc_map") and dut_qos_maps_module.get("tc_to_queue_map"),
                       "No QoS map found on DUT")
@@ -244,8 +260,9 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                 inner_dscp = rotating_dscp
                 logger.info("Pipe mode: outer_dscp = {}, inner_dscp = {}".format(outer_dscp, inner_dscp))
 
+            # The dst_mac used may be the VLAN mac instead of the router mac depending on the topology.
             pkt, exp_pkt = create_ipip_packet(outer_src_mac=ptf_src_mac,
-                                              outer_dst_mac=router_mac,
+                                              outer_dst_mac=dst_mac,
                                               outer_src_pkt_ip=outer_src_pkt_ip,
                                               outer_dst_pkt_ip=outer_dst_pkt_ip,
                                               outer_dscp=outer_dscp,
@@ -346,7 +363,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             Test QoS SAI DSCP to queue mapping for IP-IP packets in DSCP "pipe" mode
         """
         duthost = rand_selected_dut
-        test_params = self._setup_test_params(duthost, downstream_links, upstream_links, "pipe")
+        test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links, "pipe")
         self._run_test(ptfadapter, duthost, tbinfo, test_params, dut_qos_maps_module, "pipe")
         self._teardown_test(duthost)
 
@@ -358,6 +375,6 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             Test QoS SAI DSCP to queue mapping for IP-IP packets in DSCP "uniform" mode
         """
         duthost = rand_selected_dut
-        test_params = self._setup_test_params(duthost, downstream_links, upstream_links, "uniform")
+        test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links, "uniform")
         self._run_test(ptfadapter, duthost, tbinfo, test_params, dut_qos_maps_module, "uniform")
         self._teardown_test(duthost)

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -180,6 +180,7 @@ class TestQosSai(QosSaiBase):
         'Arista-7060CX-32S-C32',
         'Celestica-DX010-C32',
         'Arista-7260CX3-D108C8',
+        'Arista-7260CX3-D108C10',
         'Force10-S6100',
         'Arista-7260CX3-Q64',
         'Arista-7050CX3-32S-C32',

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -13,6 +13,8 @@ from tests.common.fixtures.ptfhost_utils import ptf_portmap_file_module   # noqa
 from tests.common.fixtures.duthost_utils import dut_qos_maps_module       # noqa F401
 from tests.common.fixtures.duthost_utils import separated_dscp_to_tc_map_on_uplink
 from tests.common.helpers.assertions import pytest_require, pytest_assert
+from tests.common.snappi_tests.qos_fixtures import get_pfcwd_config, reapply_pfcwd
+from tests.common.snappi_tests.common_helpers import stop_pfcwd
 
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_lower_tor,\
     toggle_all_simulator_ports_to_rand_selected_tor, toggle_all_simulator_ports_to_rand_unselected_tor  # noqa F401
@@ -63,6 +65,18 @@ def check_running_condition(tbinfo, duthost):
     # Check tunnel_qos_remap is enabled
     pytest_require(is_tunnel_qos_remap_enabled(duthost),
                    "Only run when tunnel_qos_remap is enabled", True)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def disable_pfcwd(duthosts):
+    pfcwd_value = {}
+    for duthost in duthosts:
+        pfcwd_value[duthost.hostname] = get_pfcwd_config(duthost)
+        stop_pfcwd(duthost)
+    yield
+    for duthost in duthosts:
+        reapply_pfcwd(duthost, pfcwd_value[duthost.hostname])
+    return
 
 
 def _last_port_in_last_lag(lags):
@@ -552,6 +566,7 @@ def test_pfc_watermark_extra_lossless_standby(ptfhost, fanouthosts, rand_selecte
     active_tor_mac = rand_unselected_dut.facts['router_mac']
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     ptfadapter.dataplane.flush()
+    failures = []
     for inner_dscp, outer_dscp, prio, queue in TEST_DATA:
         wmk_stat_queue = queue
         if "cisco-8000" in dut_config["asic_type"]:
@@ -612,9 +627,14 @@ def test_pfc_watermark_extra_lossless_standby(ptfhost, fanouthosts, rand_selecte
         logger.info(("Congested queue watermark on {}|{} is {}, increased by {}," +
                      "minimum required increase is {}").format(
             actual_port_name, wmk_stat_queue, queue_wmk, queue_wmk - base_queue_wmk, required_wmk_inc_bytes))
-        assert queue_wmk > required_wmk_bytes, \
-            "Failed to detect congestion due to PFC pause, failed check {} > {}".format(
+        if queue_wmk <= required_wmk_bytes:
+            msg = "For inner_dscp, outer_dscp, prio, queue = ({}, {}, {}, {}):\n".format(
+                inner_dscp, outer_dscp, prio, queue)
+            msg += "  Failed to detect congestion due to PFC pause, failed check {} > {}".format(
                 queue_wmk, required_wmk_bytes)
+            logger.info(msg)
+            failures.append(msg)
+    assert len(failures) == 0, "Watermark failures were found:\n{}".format("\n".join(failures))
 
 
 def test_pfc_watermark_extra_lossless_active(ptfhost, fanouthosts, rand_selected_dut, rand_unselected_dut,
@@ -645,6 +665,7 @@ def test_pfc_watermark_extra_lossless_active(ptfhost, fanouthosts, rand_selected
     active_tor_mac = rand_selected_dut.facts['router_mac']
     mg_facts = rand_unselected_dut.get_extended_minigraph_facts(tbinfo)
     ptfadapter.dataplane.flush()
+    failures = []
     for inner_dscp, outer_dscp, prio, queue in TEST_DATA:
         pkt, tunnel_pkt = build_testing_packet(src_ip=DUMMY_IP,
                                                dst_ip=dualtor_meta['target_server_ip'],
@@ -703,9 +724,14 @@ def test_pfc_watermark_extra_lossless_active(ptfhost, fanouthosts, rand_selected
                      "minimum required increase is {}").format(
             dualtor_meta['selected_port'], queue, queue_wmk,
             queue_wmk - base_queue_wmk, required_wmk_inc_bytes))
-        assert queue_wmk > required_wmk_bytes, \
-            "Failed to detect congestion due to PFC pause, failed check {} > {}".format(
-                queue_wmk, base_queue_wmk)
+        if queue_wmk <= required_wmk_bytes:
+            msg = "For inner_dscp, outer_dscp, prio, queue = ({}, {}, {}, {}):\n".format(
+                inner_dscp, outer_dscp, prio, queue)
+            msg += "  Failed to detect congestion due to PFC pause, failed check {} > {}".format(
+                queue_wmk, required_wmk_bytes)
+            logger.info(msg)
+            failures.append(msg)
+    assert len(failures) == 0, "Watermark failures were found:\n{}".format("\n".join(failures))
 
 
 @pytest.mark.disable_loganalyzer

--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -178,8 +178,14 @@ def tunnel_qos_maps(rand_selected_dut, dut_qos_maps_module): # noqa F811
     # inner_dscp_to_outer_dscp_map, a map for rewriting DSCP in the encapsulated packets
     ret['inner_dscp_to_outer_dscp_map'] = {}
     if 'cisco-8000' in asic_type:
+        dscps_present = []
         for k, v in list(maps['TC_TO_DSCP_MAP'][TUNNEL_MAP_NAME].items()):
             ret['inner_dscp_to_outer_dscp_map'][int(k)] = int(v)
+            dscps_present.append(int(k))
+        # Fill in default-values in the map to be 1-1
+        for dscp in range(64):
+            if dscp not in dscps_present:
+                ret['inner_dscp_to_outer_dscp_map'][dscp] = dscp
     else:
         for k, v in list(maps['DSCP_TO_TC_MAP'][MAP_NAME].items()):
             ret['inner_dscp_to_outer_dscp_map'][int(k)] = int(
@@ -311,7 +317,7 @@ def qos_config(rand_selected_dut, tbinfo, dut_config):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def disable_packet_aging(rand_selected_dut, duthosts):
+def disable_packet_aging(duthosts):
     """
         For Nvidia(Mellanox) platforms, packets in buffer will be aged after a timeout. Need to disable this
         before any buffer tests.
@@ -329,9 +335,11 @@ def disable_packet_aging(rand_selected_dut, duthosts):
     for duthost in duthosts:
         asic = duthost.get_asic_name()
         if 'spc' in asic:
+            # Ignore errors if the script is not found in syncd container as it may be removed
+            # by swap_syncd
             logger.info("Enable Mellanox packet aging")
-            duthost.command("docker exec syncd python /packets_aging.py enable")
-            duthost.command("docker exec syncd rm -rf /packets_aging.py")
+            duthost.command("docker exec syncd python /packets_aging.py enable", module_ignore_errors=True)
+            duthost.command("docker exec syncd rm -rf /packets_aging.py", module_ignore_errors=True)
 
 
 def _create_ssh_tunnel_to_syncd_rpc(duthost):
@@ -394,12 +402,24 @@ def update_docker_services(rand_selected_dut, swap_syncd, disable_container_auto
     for service in SERVICES:
         _update_docker_service(rand_selected_dut, action="stop", **service)
 
+    asic = rand_selected_dut.get_asic_name()
+    if 'spc' in asic:
+        logger.info("Disable Mellanox packet aging")
+        rand_selected_dut.copy(src="qos/files/mellanox/packets_aging.py", dest="/tmp")
+        rand_selected_dut.command("docker cp /tmp/packets_aging.py syncd:/")
+        rand_selected_dut.command("docker exec syncd python /packets_aging.py disable")
+
     yield
 
     enable_container_autorestart(
         rand_selected_dut, testcase="test_tunnel_qos_remap", feature_list=feature_list)
     for service in SERVICES:
         _update_docker_service(rand_selected_dut, action="start", **service)
+
+    if 'spc' in asic:
+        logger.info("Enable Mellanox packet aging")
+        rand_selected_dut.command("docker exec syncd python /packets_aging.py enable")
+        rand_selected_dut.command("docker exec syncd rm -rf /packets_aging.py")
 
 
 def _update_mux_feature(duthost, state):
@@ -498,6 +518,8 @@ def stop_pfc_storm(storm_handler):
     Stop sending PFC pause frames from fanout switch
     """
     storm_handler.stop_storm()
+    # Wait for PFC pause to stop
+    time.sleep(2)
 
 
 def run_ptf_test(ptfhost, test_case='', test_params={}):

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2925,7 +2925,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         self.src_port_macs = [self.dataplane.get_mac(
             0, ptid) for ptid in self.src_port_ids]
 
-        if self.testbed_type in ['dualtor', 'dualtor-56', 't0', 't0-28', 't0-64', 't0-116', 't0-120']:
+        if self.testbed_type in ['dualtor', 'dualtor-56', 't0', 't0-28', 't0-64', 't0-116', 't0-118', 't0-120']:
             # populate ARP
             # sender's MAC address is corresponding PTF port's MAC address
             # sender's IP address is caculated in tests/qos/qos_sai_base.py::QosSaiBase::__assignTestPortIps()
@@ -3163,6 +3163,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
             upper_bound = 2 * margin + 1
             if (hwsku == 'Arista-7260CX3-D108C8' and self.testbed_type in ('t0-116', 'dualtor-120')) \
+                    or (hwsku == 'Arista-7260CX3-D108C10' and self.testbed_type in ('t0-118')) \
                     or (hwsku == 'Arista-7260CX3-C64' and self.testbed_type in ('dualtor-aa-56', 't1-64-lag')):
                 upper_bound = 2 * margin + self.pgs_num
             if self.wm_multiplier:

--- a/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
@@ -75,14 +75,19 @@ def run_pfcwd_multi_node_test(api,
     pfcwd_to_be_configured = set()
 
     rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
-    rx_port_id_list = [rx_port["port_id"]]
     egress_duthost = rx_port['duthost']
     # Add the port to the set of ports to be configured for PFC
     pfcwd_to_be_configured.add((egress_duthost, rx_port['asic_value']))
 
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
-    tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
+    if pattern == 'all to all':
+        tx_port_id_list = [rx_port["port_id"], tx_port[0]["port_id"], tx_port[1]["port_id"]]
+        rx_port_id_list = [rx_port["port_id"], tx_port[0]["port_id"], tx_port[1]["port_id"]]
+        pfcwd_to_be_configured.add((rx_port['duthost'], rx_port['asic_value']))
+    elif pattern == 'many to one':
+        tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
+        rx_port_id_list = [rx_port["port_id"]]
     # add ingress DUT into the set
     pfcwd_to_be_configured.add((tx_port[0]['duthost'], tx_port[0]['asic_value']))
     pfcwd_to_be_configured.add((tx_port[1]['duthost'], tx_port[1]['asic_value']))

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -7,6 +7,7 @@ from telemetry_utils import skip_201911_and_older
 from events.event_utils import event_publish_tool
 from events.event_utils import reset_event_counters, read_event_counters
 from events.event_utils import verify_counter_increase, restart_eventd
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_host_m    # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -35,7 +36,8 @@ def validate_yang(duthost, op_file="", yang_file=""):
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 @pytest.mark.disable_loganalyzer
 def test_events(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, ptfadapter, setup_streaming_telemetry, gnxi_path,
-                test_eventd_healthy):
+                test_eventd_healthy, toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_host_m, # noqa F811
+                setup_standby_ports_on_non_enum_rand_one_per_hwsku_host_m): # noqa F811
     """ Run series of events inside duthost and validate that output is correct
     and conforms to YANG schema"""
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -60,6 +60,8 @@ import copy
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts    # noqa F401
+from tests.common.config_reload import config_reload
 from tests.common.utilities import wait_until
 from tests.ptf_runner import ptf_runner
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
@@ -140,7 +142,8 @@ def fixture_setUp(duthosts,
                   rand_one_dut_hostname,
                   minigraph_facts,
                   tbinfo,
-                  encap_type):
+                  encap_type,
+                  backup_and_restore_config_db_on_duts):        # noqa F811
     '''
         Setup for the entire script.
         The basic steps in VxLAN configs are:
@@ -337,6 +340,14 @@ def fixture_setUp(duthosts,
         ecmp_utils.stop_bfd_responder(data['ptfhost'])
 
     setup_crm_interval(data['duthost'], int(data['original_crm_interval']))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def restore_config_by_config_reload(duthosts, rand_one_dut_hostname, localhost):
+    yield
+    duthost = duthosts[rand_one_dut_hostname]
+
+    config_reload(duthost, safe_reload=True)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Code sync sonic-net/sonic-mgmt:202411 => 202503
```
*   6b59eaa54 (HEAD -> sync/202503, origin/sync/202503) Merge remote-tracking branch 'pub_upstream/202411' into sync/202503
|\
| * c6a94a078 (pub_upstream/202411) Revert "[dualtor_io] Allow duplications for link down downstream I/O (#17909)" (#18192)
| * de454d5bf [testARPCompleted] Cleanup ptf ip after test failure (#18170)
| * 4a3d1d96b [dualtor] Refine `fdb_mac_learning_test.py` (#18092)
| * 5964a7818 [dualtor_io] Fix the start marker not found issue (#18096)
| * ce40816ea Extend LACP time multiplier for advanced-reboot tests with cEOS peers (#17964)
| * 0e70ba32f adjust port selection in case testQosSaiXonHysteresis for Cisco-8101 (#18130)
| * 8bb720348 [202411] Restore disable packet aging fixture 202411 (#18103)
| * 8f6d1a323 Filter out Not Applicable values in command line (#18006)
| * 9d5de5c46 Backport t0-118 test configs to 202411 (#17983)
| * e758401df mark xfail on generic hash test for isolated topo (#18071)
| * c65ceabd6 [202411][dualtor] Skip pfcwd warm reboot on dualtor (#18072)
| * c50900647 Improve disabling packet aging to support swap_syncd (#17728) (#17739)
| * 9dc2244c3 [202411][dualtor-aa] Fix test_arp_dualtor on active-active dualtor (#18073)
| * cf12a33e2 fixed tacacs duplicate user issue (#18068)
| * 330a89399 Fix telemetry/test_events.py for dualtor (#18025)
| * dc6fee868 Remove admin down ports in BUFFER PG check logic (#17505)
| * 805d538ec Update generic hash test to support dualtor active active topology (#16217)
| * 7c31e4649 [dualtor_io] Allow duplications for link down downstream I/O (#17909)
| * a7f50c6c4 Fix vlan vs router mac issue with test_qos_dscp_mapping.py (#17846) (#18003)
| * 9ab1e7a74 Skip test_incremental_qos on Mellanox dualtor (#17406) (#18048)
| * f42afd0cb Force eos default creds to be string (#18026)
| * be542b057 Restore config after vxlan_crm from vxlan_ecmp. (#17767)
| * f0718b9ad [Fix for Issue #17413] Modified the Tx Rx port id list selection for all to all scenario (#17919)
| * 3eb4ed422 [dualtor_io] Collect syslog to debug (#17722)
| * d5bd99588 Disable PFC-WD during PCBB and some wmk test improvements (#17889)
| * 2f512aaa2 Update outer UDP sport range to exclude port 53 (#17570) (#17798)
| * 980b37374 skip test_bgp_slb advanced reboot for isolated topo (#17470)
| * 408bf9e02 Default the inner dscp to outer dscp map to be 1-1. (#17860)
| * 37495a1d6 Add dualtor fixtures to no_traffic test. (#17916)
| * a13b5999d Only print the matched syslog in loganalzyer teardown check, no traceback info printed (#17926)
| * 6127f2980 Revert "Skip test_vnet_decap on Cisco-8000 with 202411 (#17776)" (#17941) (#17942)
| * 60274dbe7 Increase timeout to 5 in verify_packet_any_port for background traffic (#17904)
```