### PR TITLE
[202412] Code sync sonic-net/sonic-mgmt:202411 => 202412

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -12,7 +12,7 @@ broadcom_hwskus: [ "Force10-S6000", "Accton-AS7712-32X", "Celestica-DX010-C32", 
 broadcom_td2_hwskus: ['Force10-S6000', 'Force10-S6000-Q24S32', 'Arista-7050-QX32', 'Arista-7050-QX-32S', 'Arista-7050QX32S-Q32']
 broadcom_td3_hwskus: ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']
 broadcom_th_hwskus: ['Force10-S6100', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-C32-T1', 'Arista-7060CX-32S-D48C8', 'Celestica-DX010-C32', "Seastone-DX010" ]
-broadcom_th2_hwskus: ['Arista-7260CX3-D108C8',  'Arista-7260CX3-C64', 'Arista-7260CX3-Q64']
+broadcom_th2_hwskus: ['Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Arista-7260CX3-C64', 'Arista-7260CX3-Q64']
 broadcom_th3_hwskus: ['DellEMC-Z9332f-M-O16C64',  'DellEMC-Z9332f-O32']
 broadcom_th4_hwskus: ['Arista-7060DX5-32', 'Arista-7060DX5-64S']
 broadcom_th5_hwskus: ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16', 'Arista-7060X6-16PE-384C-O128S2']

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -259,8 +259,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             if hwsku == "Arista-7260CX3-D108C10":
                 # The first 2 ports are 100G
                 s100G_ports.extend([x for x in range(1, 3)])
-
-            if hwsku == "Arista-7260CX3-D108C8-AILAB":
+            elif hwsku == "Arista-7260CX3-D108C8-AILAB":
                 s100G_ports = [x for x in range(45, 53)]
             elif hwsku == "Arista-7260CX3-D108C8-CSI":
                 # Treat 40G port as 100G ports

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1392,6 +1392,10 @@ class ReloadTest(BaseTest):
         self.assertTrue(is_good, errors)
 
     def runTest(self):
+        # Set LACP timer multiplier to 5 for cEOS peers
+        if self.test_params['neighbor_type'] == "eos":
+            self.ceos_set_lacp_all_neighs(5)
+
         self.pre_reboot_test_setup()
         try:
             self.log("Check that device is alive and pinging")
@@ -1445,7 +1449,28 @@ class ReloadTest(BaseTest):
             traceback_msg = traceback.format_exc()
             self.fails['dut'].add(traceback_msg)
         finally:
+            # Restore cEOS LACP timer multiplier to default (3)
+            if self.test_params['neighbor_type'] == "eos":
+                self.ceos_set_lacp_all_neighs(3)
+
             self.handle_post_reboot_test_reports()
+
+    def ceos_set_lacp_all_neighs(self, multiplier):
+        for neigh in self.ssh_targets:
+            self.neigh_handle = HostDevice.getHostDeviceInstance(
+                                    self.test_params['neighbor_type'], neigh, None, self.test_params)
+            self.neigh_handle.connect()
+
+            raw_json = self.neigh_handle.do_cmd("show lacp interface | json")
+            neigh_int_json = json.loads(raw_json[raw_json.find("{"):raw_json.rfind("}")+1])
+
+            self.neigh_handle.do_cmd("config")
+            for lag in neigh_int_json["portChannels"]:
+                for neigh_int in neigh_int_json["portChannels"][lag]['interfaces']:
+                    self.neigh_handle.do_cmd(f"interface {neigh_int}")
+                    self.neigh_handle.do_cmd(f"lacp timer multiplier {multiplier}")
+
+            self.neigh_handle.disconnect()
 
     def neigh_lag_status_check(self):
         """
@@ -1698,9 +1723,7 @@ class ReloadTest(BaseTest):
 
         # in the list of all LACPDUs received by T1, find the largest time gap between two consecutive LACPDUs
         max_lacp_session_wait = None
-        max_allowed_lacp_session_wait = 90
-        if self.test_params['neighbor_type'] == "sonic":
-            max_allowed_lacp_session_wait = 150
+        max_allowed_lacp_session_wait = 150
         if lacp_pdu_all_times and len(lacp_pdu_all_times) > 1:
             lacp_pdu_all_times.sort()
             max_lacp_session_wait = 0

--- a/ansible/roles/test/files/ptftests/py3/fdb_mac_learning_test.py
+++ b/ansible/roles/test/files/ptftests/py3/fdb_mac_learning_test.py
@@ -1,6 +1,6 @@
 import ptf
 from ptf.base_tests import BaseTest
-from ptf.testutils import send, simple_eth_packet, test_params_get
+from ptf.testutils import send, simple_arp_packet, test_params_get
 
 
 class FdbMacLearningTest(BaseTest):
@@ -20,10 +20,9 @@ class FdbMacLearningTest(BaseTest):
     def populateFdbForInterface(self):
         for dut_port, ptf_port in self.dut_ptf_ports:
             mac = self.dummy_mac_prefix + ":" + "{:02X}".format(ptf_port)
-            pkt = simple_eth_packet(eth_dst=self.router_mac,        # noqa: F405
-                                    eth_src=mac,
-                                    eth_type=0x1234)
-            send(self, ptf_port, pkt)
+            pkt = simple_arp_packet(eth_dst=self.router_mac,        # noqa: F405
+                                    eth_src=mac)
+            send(self, ptf_port, pkt, count=10)
             self.mac_table.append((ptf_port, mac))
 
     # --------------------------------------------------------------------------

--- a/ansible/roles/test/tasks/dir_bcast.yml
+++ b/ansible/roles/test/tasks/dir_bcast.yml
@@ -7,7 +7,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is invalid."
-  when: testbed_type not in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116']
+  when: testbed_type not in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116', 't0-118']
 
 - include_vars: "vars/topo_{{testbed_type}}.yml"
 

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -2,7 +2,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{test_type}} is invalid"
-  when: testbed_type not in ['t0', 't0-64', 't0-116', 't0-52']
+  when: testbed_type not in ['t0', 't0-64', 't0-116', 't0-118', 't0-52']
 
 - name: Gather minigraph facts about the device
   minigraph_facts: host={{inventory_hostname}}

--- a/ansible/roles/test/tasks/fdb_mac_expire.yml
+++ b/ansible/roles/test/tasks/fdb_mac_expire.yml
@@ -2,7 +2,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{test_type}} is invalid"
-  when: testbed_type not in ['t0', 't0-64', 't0-64-32', 't0-116', 't0-52']
+  when: testbed_type not in ['t0', 't0-64', 't0-64-32', 't0-116', 't0-118', 't0-52']
 
 - name: set fdb_aging_time to default if no user input
   set_fact:

--- a/ansible/roles/test/tasks/pfc_wd/choose_test_port.yml
+++ b/ansible/roles/test/tasks/pfc_wd/choose_test_port.yml
@@ -23,27 +23,27 @@
 
 - set_fact:
     random_seed: "{{range(4) | list | shuffle}}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_test_portchannel: "{{minigraph_portchannel_interfaces[0].attachto}}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_rx_portchannel: "{%for p in minigraph_portchannel_interfaces if p['attachto']!=pfc_wd_test_portchannel %}{%if loop.first %}{{p['attachto']}}{%endif%}{%endfor%}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_test_port: "{{minigraph_portchannels[pfc_wd_test_portchannel]['members'][0]}}"
     pfc_wd_rx_port: "{{minigraph_portchannels[pfc_wd_rx_portchannel]['members'][0]}}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_test_port_addr: "{%for p in minigraph_portchannel_interfaces%}{%if p['attachto']==pfc_wd_test_portchannel and p['addr']|ipv4%}{{p['addr']}}{%endif %}{%endfor%}"
     pfc_wd_rx_port_addr: "{%for p in minigraph_portchannel_interfaces%}{%if p['attachto']==pfc_wd_rx_portchannel and p['addr']|ipv4%}{{p['addr']}}{%endif %}{%endfor%}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_test_port_id: "{{minigraph_port_indices[pfc_wd_test_port]}}"
     pfc_wd_rx_port_id: "{{minigraph_port_indices[pfc_wd_rx_port]}}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]

--- a/ansible/roles/test/tasks/pfc_wd/iterate_portchannels.yml
+++ b/ansible/roles/test/tasks/pfc_wd/iterate_portchannels.yml
@@ -46,11 +46,11 @@
 
 - set_fact:
     p: "{{pfc_wd_test_port[1]}}"
-  when: rx_pc_port is defined and test_pc_port is defined and testbed_type in ['t0-64', 't0-116', 't1-lag']
+  when: rx_pc_port is defined and test_pc_port is defined and testbed_type in ['t0-64', 't0-116', 't0-118', 't1-lag']
 
 - set_fact:
     test_ports: "{{ test_ports | combine( {p:{'test_neighbor_addr':pfc_wd_test_neighbor_addr, 'rx_port':pfc_wd_rx_port, 'rx_neighbor_addr': pfc_wd_rx_neighbor_addr, 'peer_device':neighbors[p]['peerdevice'], 'test_port_id': minigraph_port_indices[p], 'rx_port_id': pfc_wd_rx_port_id.split(' ') | list, 'test_portchannel_members': pfc_wd_test_port_id.split(' ') | list, 'test_port_type':'portchannel' }})  }}"
-  when: rx_pc_port is defined and test_pc_port is defined and testbed_type in ['t0-64', 't0-116', 't1-lag']
+  when: rx_pc_port is defined and test_pc_port is defined and testbed_type in ['t0-64', 't0-116', 't0-118', 't1-lag']
 
 - set_fact:
     p: "{{pfc_wd_rx_port[0]}}"
@@ -62,11 +62,11 @@
 
 - set_fact:
     p: "{{pfc_wd_rx_port[1]}}"
-  when: first_pair and testbed_type in ['t0-64', 't0-116']
+  when: first_pair and testbed_type in ['t0-64', 't0-116', 't0-118']
 
 - set_fact:
     test_ports: "{{ test_ports | combine( {p:{'test_neighbor_addr':pfc_wd_rx_neighbor_addr, 'rx_port':pfc_wd_test_port, 'rx_neighbor_addr': pfc_wd_test_neighbor_addr, 'peer_device':neighbors[p]['peerdevice'], 'test_port_id': minigraph_port_indices[p], 'rx_port_id': pfc_wd_test_port_id.split(' ') | list , 'test_portchannel_members': pfc_wd_rx_port_id.split(' ') | list, 'test_port_type':'portchannel' }})  }}"
-  when: first_pair and testbed_type in ['t0-64', 't0-116']
+  when: first_pair and testbed_type in ['t0-64', 't0-116', 't0-118']
 
 - set_fact:
     used: false

--- a/ansible/roles/test/tasks/qos_sai.yml
+++ b/ansible/roles/test/tasks/qos_sai.yml
@@ -117,7 +117,7 @@
     - name: Init PTF base test parameters
       set_fact:
         ptf_base_params:
-        - router_mac={% if testbed_type not in ['t0', 't0-64', 't0-116'] %}'{{ansible_Ethernet0['macaddress']}}'{% else %}''{% endif %}
+        - router_mac={% if testbed_type not in ['t0', 't0-64', 't0-116', 't0-118'] %}'{{ansible_Ethernet0['macaddress']}}'{% else %}''{% endif %}
         - server='{{ansible_host}}'
         - port_map_file='/root/{{ptf_portmap | basename}}'
         - sonic_asic_type='{{sonic_asic_type}}'
@@ -151,7 +151,7 @@
         - dst_port_3_ip='{{dst_port_3_ip}}'
         - src_port_id='{{src_port_id}}'
         - src_port_ip='{{src_port_ip}}'
-      when: testbed_type in ['t0', 't0-64', 't0-116'] or arp_entries.stdout.find('incomplete') == -1
+      when: testbed_type in ['t0', 't0-64', 't0-116', 't0-118'] or arp_entries.stdout.find('incomplete') == -1
 
     - include_tasks: qos_sai_ptf.yml
       vars:
@@ -268,7 +268,7 @@
         - pkts_num_hdrm_full={{qp_sc.hdrm_pool_size.pkts_num_hdrm_full}}
         - pkts_num_hdrm_partial={{qp_sc.hdrm_pool_size.pkts_num_hdrm_partial}}
       when: minigraph_hwsku is defined and
-            minigraph_hwsku in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64']
+            minigraph_hwsku in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64']
 
     # Lossy queue
     - include_tasks: qos_sai_ptf.yml
@@ -348,11 +348,11 @@
         - packet_size='{{qp.wm_pg_shared_lossless.packet_size}}'
         - cell_size='{{qp.wm_pg_shared_lossless.cell_size}}'
       when: minigraph_hwsku is defined and
-            (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8'])
+            (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10'])
     - debug:
         var: out.stdout_lines
       when: minigraph_hwsku is defined and
-            (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8'])
+            (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10'])
 
     # Clear all watermarks before each watermark test
     # because of the clear on read polling mode
@@ -378,11 +378,11 @@
         - packet_size='{{qp.wm_pg_shared_lossy.packet_size}}'
         - cell_size='{{qp.wm_pg_shared_lossy.cell_size}}'
       when: minigraph_hwsku is defined and
-            minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8']
+            minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10']
     - debug:
         var: out.stdout_lines
       when: minigraph_hwsku is defined and
-            minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8']
+            minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10']
 
     # Clear all watermarks before each watermark test
     # because of the clear on read polling mode

--- a/ansible/roles/test/tasks/shared-fib.yml
+++ b/ansible/roles/test/tasks/shared-fib.yml
@@ -18,7 +18,7 @@
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['common']}}"
-  when: testbed_type in ['t0',  't0-52', 't0-56', 't0-64', 't0-64-32', 't0-116']
+  when: testbed_type in ['t0',  't0-52', 't0-56', 't0-64', 't0-64-32', 't0-116', 't0-118']
 
 - name: Expand ToR properties into props
   set_fact: props_tor="{{configuration_properties['tor']}}"

--- a/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
+++ b/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
@@ -12,7 +12,7 @@
 - name: Add all lag member down case
   set_fact:
       pre_list: "{{ pre_list + ['dut_lag_member_down:2:{{ lag_memb_cnt }}', 'neigh_lag_member_down:3:{{ lag_memb_cnt }}']}}"
-  when: testbed_type in ['t0-64', 't0-116', 't0-64-32']
+  when: testbed_type in ['t0-64', 't0-116', 't0-118', 't0-64-32']
 
 - name: set default values vnet variables
   set_fact:

--- a/ansible/roles/test/tasks/warm-reboot-sad-lag-member.yml
+++ b/ansible/roles/test/tasks/warm-reboot-sad-lag-member.yml
@@ -12,7 +12,7 @@
 - name: Add all lag member down case
   set_fact:
       pre_list: "{{ pre_list + ['dut_lag_member_down:2:{{ lag_memb_cnt }}', 'neigh_lag_member_down:3:{{ lag_memb_cnt }}']}}"
-  when: testbed_type in ['t0-64', 't0-116', 't0-64-32']
+  when: testbed_type in ['t0-64', 't0-116', 't0-118', 't0-64-32']
 
 - name: set default values vnet variables
   set_fact:

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -19,6 +19,9 @@
 {% elif testbed_type == 't0-116' %}
 0.0.0.0/0 [24 25] [26 27] [28 29] [30 31]
 ::/0 [24 25] [26 27] [28 29] [30 31]
+{% elif testbed_type == 't0-118' %}
+0.0.0.0/0 [22 23] [24 25] [26 27] [28 29]
+::/0 [22 23] [24 25] [26 27] [28 29]
 {% endif %}
 {#routes to uplink#}
 {#Limit the number of podsets and subnets to be covered to limit script execution time#}
@@ -61,7 +64,7 @@
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
 {% endif %}
-{% elif testbed_type == 't0-116' %}
+{% elif (testbed_type == 't0-116') or (testbed_type == 't0-118') %}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (subnet * props.tor_subnet_size) ) %}

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -26,7 +26,7 @@ testcases:
 
     bgp_fact:
       filename: bgp_fact.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     bgp_multipath_relax:
       filename: bgp_multipath_relax.yml
@@ -37,19 +37,19 @@ testcases:
 
     bgp_speaker:
       filename: bgp_speaker.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
 
     config:
         filename: config.yml
-        topologies: [t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-64, t0-116, t0-120]
+        topologies: [t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-64, t0-116, t0-118, t0-120]
 
     continuous_reboot:
       filename: continuous_reboot.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-56-o8v48, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t1-28-lag]
+      topologies: [t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-56-o8v48, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t1-28-lag]
 
     copp:
       filename: copp.yml
@@ -59,7 +59,7 @@ testcases:
 
     decap:
       filename: decap.yml
-      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-52, t0-56, t0-64, t0-116, t0-120]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-52, t0-56, t0-64, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
@@ -67,7 +67,7 @@ testcases:
 
     dhcp_relay:
       filename: dhcp_relay.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
@@ -85,7 +85,7 @@ testcases:
     fast-reboot:
       filename: fast-reboot.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -93,7 +93,7 @@ testcases:
     warm-reboot:
       filename: warm-reboot.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -101,7 +101,7 @@ testcases:
     warm-reboot-sad:
       filename: warm-reboot-sad.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -109,14 +109,14 @@ testcases:
     warm-reboot-multi-sad:
       filename: warm-reboot-multi-sad.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           vm_hosts:
 
     warm-reboot-multi-sad-inboot:
       filename: warm-reboot-multi-sad-inboot.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -124,7 +124,7 @@ testcases:
     warm-reboot-sad-bgp:
       filename: warm-reboot-sad-bgp.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -132,7 +132,7 @@ testcases:
     warm-reboot-sad-lag:
       filename: warm-reboot-sad-lag.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -140,7 +140,7 @@ testcases:
     warm-reboot-sad-lag-member:
       filename: warm-reboot-sad-lag-member.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -148,21 +148,21 @@ testcases:
     warm-reboot-sad-vlan-port:
       filename: warm-reboot-sad-vlan-port.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
 
     fib:
       filename: simple-fib.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
 
     hash:
       filename: hash.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
@@ -170,21 +170,21 @@ testcases:
     warm-reboot-fib:
       filename: warm-reboot-fib.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
 
     fdb:
       filename: fdb.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
 
     fdb_mac_expire:
       filename: fdb_mac_expire.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-52]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-52]
       required_vars:
           fdb_aging_time:
           ptf_host:
@@ -192,31 +192,31 @@ testcases:
 
     dir_bcast:
       filename: dir_bcast.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
 
     lag_2:
       filename: lag_2.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
 
     lldp:
       filename: lldp.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-116, t0-120, t0-64-32, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-116, t0-118, t0-120, t0-64-32, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     link_flap:
       filename: link_flap.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     continuous_link_flap:
       filename: continuous_link_flap.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     mtu:
       filename: mtu.yml
@@ -233,81 +233,81 @@ testcases:
 
     neighbour_mac_noptf:
       filename: neighbour-mac-noptf.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     ntp:
       filename: ntp.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     pfc_wd:
       filename: pfc_wd.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     portstat:
       filename: portstat.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-116, t0-120, t1]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-116, t0-118, t0-120, t1]
 
     port_toggle:
       filename: port_toggle.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     qos_sai:
       filename: qos_sai.yml
-      topologies: [ptf32, ptf64, t1, t1-lag, t0, t0-64, t0-116, t0-120]
+      topologies: [ptf32, ptf64, t1, t1-lag, t0, t0-64, t0-116, t0-118, t0-120]
 
     reboot:
       filename: reboot.yml
-      topologies: [dualtor, dualtor-64-breakout, dualtor-aa-64-breakout, t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-28-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [dualtor, dualtor-64-breakout, dualtor-aa-64-breakout, t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-28-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     repeat_harness:
       filename: repeat_harness.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     restart_swss:
       filename: run_config_cleanup.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     restart_swss_service:
       filename: restart_swss.yml
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     restart_syncd:
       filename: restart_syncd.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     sensors:
       filename: sensors_check.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     service_acl:
       filename: service_acl.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     snmp:
       filename: snmp.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     syslog:
       filename: syslog.yml
-      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     vlan:
       filename: vlantb.yml
-      topologies: [t0, t0-16, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
 
     crm:
       filename: crm.yml
-      topologies: [t1, t1-lag, t0, t0-52, t0-56, t0-64, t0-116, t0-120]
+      topologies: [t1, t1-lag, t0, t0-52, t0-56, t0-64, t0-116, t0-118, t0-120]
 
     dip_sip:
       filename: dip_sip.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
@@ -315,27 +315,27 @@ testcases:
     vxlan_decap:
       filename: vxlan-decap.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
     wr_arp:
       filename: wr_arp.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
     vnet_vxlan:
       filename: vnet_vxlan.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
     warm_reboot_vnet:
       filename: warm-reboot-vnet.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
@@ -345,7 +345,7 @@ testcases:
 
     iface_mode:
       filename: iface_naming_mode.yml
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, ptf32, ptf64]
       required_vars:
           testbed_type:
 

--- a/ansible/testbed-new.yaml
+++ b/ansible/testbed-new.yaml
@@ -230,7 +230,7 @@ veos_groups:
     servers:
         children: [server_1, server_2]                      # source: sonic-mgmt/veos
         vars:
-            topologies: ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag', 't0', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']  # source: sonic-mgmt/veos
+            topologies: ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag', 't0', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116', 't0-118']  # source: sonic-mgmt/veos
     server_1:
         children: [vm_host_1, vms_1]                        # source: sonic-mgmt/veos
         vars:

--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -41,8 +41,7 @@ def arp_setup(ptfhost):
 
 
 def validate_traffic_results(tor_IO, allowed_disruption, delay,
-                             allow_disruption_before_traffic=False,
-                             allowed_duplication=None):
+                             allow_disruption_before_traffic=False):
     """
     Generates a report (dictionary) of I/O metrics that were calculated as part
     of the dataplane test. This report is to be used by testcases to verify the
@@ -108,12 +107,7 @@ def validate_traffic_results(tor_IO, allowed_disruption, delay,
                             "Maximum allowed disruption: {}s"
                             .format(server_ip, longest_disruption, delay))
 
-        # NOTE: Not all testcases set the allowed duplication threshold and the duplication check
-        # uses the allowed disruption threshold here.q So let's set the allowed duplication to
-        # allowed disruption if the allowed duplication is provided here.
-        if allowed_duplication is None:
-            allowed_duplication = allowed_disruption
-        if total_duplications > allowed_duplication:
+        if total_duplications > allowed_disruption:
             failures.append("Traffic to server {} was duplicated {} times. "
                             "Allowed number of duplications: {}"
                             .format(server_ip, total_duplications, allowed_disruption))
@@ -156,12 +150,11 @@ def _validate_long_disruption(disruptions, allowed_disruption, delay):
 
 
 def verify_and_report(tor_IO, verify, delay, allowed_disruption,
-                      allow_disruption_before_traffic=False, allowed_duplication=None):
+                      allow_disruption_before_traffic=False):
     # Wait for the IO to complete before doing checks
     if verify:
         validate_traffic_results(tor_IO, allowed_disruption=allowed_disruption, delay=delay,
-                                 allow_disruption_before_traffic=allow_disruption_before_traffic,
-                                 allowed_duplication=allowed_duplication)
+                                 allow_disruption_before_traffic=allow_disruption_before_traffic)
     return tor_IO.get_test_results()
 
 
@@ -274,8 +267,7 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
     def t1_to_server_io_test(activehost, tor_vlan_port=None,
                              delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.1,
-                             stop_after=None, allow_disruption_before_traffic=False,
-                             allowed_duplication=None):
+                             stop_after=None, allow_disruption_before_traffic=False):
         """
         Helper method for `send_t1_to_server_with_action`.
         Starts sender and sniffer before performing the action on the tor host.
@@ -310,8 +302,7 @@ def send_t1_to_server_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
         if delay and not allowed_disruption:
             allowed_disruption = 1
 
-        return verify_and_report(tor_IO, verify, delay, allowed_disruption, allow_disruption_before_traffic,
-                                 allowed_duplication=allowed_duplication)
+        return verify_and_report(tor_IO, verify, delay, allowed_disruption, allow_disruption_before_traffic)
 
     yield t1_to_server_io_test
 
@@ -425,7 +416,7 @@ def send_t1_to_soc_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
 
     def t1_to_soc_io_test(activehost, tor_vlan_port=None,
                           delay=0, allowed_disruption=0, action=None, verify=False, send_interval=0.01,
-                          stop_after=None, allowed_duplication=None):
+                          stop_after=None):
 
         tor_IO = run_test(duthosts, activehost, ptfhost, ptfadapter, vmhost,
                           action, tbinfo, tor_vlan_port, send_interval,
@@ -441,8 +432,7 @@ def send_t1_to_soc_with_action(duthosts, ptfhost, ptfadapter, tbinfo,
         if asic_type == "vs":
             logging.info("Skipping verify on VS platform")
             return
-        return verify_and_report(tor_IO, verify, delay, allowed_disruption,
-                                 allowed_duplication=allowed_duplication)
+        return verify_and_report(tor_IO, verify, delay, allowed_disruption)
 
     yield t1_to_soc_io_test
 

--- a/tests/common/dualtor/dual_tor_io.py
+++ b/tests/common/dualtor/dual_tor_io.py
@@ -11,6 +11,7 @@ import os
 import six
 import scapy.all as scapyall
 import ptf.testutils as testutils
+from operator import itemgetter
 from itertools import groupby
 
 from tests.common.dualtor.dual_tor_common import CableType
@@ -792,37 +793,16 @@ class DualTorIO:
             logger.error("Sniffer failed to filter any traffic from DUT")
         else:
             # Find ranges of consecutive packets that have been duplicated
-            # All consecutive packets with the same payload will be grouped as one
-            # duplication group.
-            # For example, for the duplication list as the following:
-            # [(70, 1744253633.499116), (70, 1744253633.499151), (70, 1744253633.499186),
-            #  (81, 1744253635.49922), (81, 1744253635.499255)]
-            # two duplications will be reported:
-            # "duplications": [
-            #     {
-            #         "start_time": 1744253633.499116,
-            #         "end_time": 1744253633.499186,
-            #         "start_id": 70,
-            #         "end_id": 70,
-            #         "duplication_count": 3
-            #     },
-            #     {
-            #         "start_time": 1744253635.49922,
-            #         "end_time": 1744253635.499255,
-            #         "start_id": 81,
-            #         "end_id": 81,
-            #         "duplication_count": 2
-            #     }
-            # ]
-            for _, grouper in groupby(duplicate_packet_list, lambda d: d[0]):
-                duplicates = list(grouper)
-                duplicate_start, duplicate_end = duplicates[0], duplicates[-1]
+            # All packets within the same consecutive range will have the same
+            # difference between the packet index and the sequence number
+            for _, grouper in groupby(enumerate(duplicate_packet_list), lambda t: t[0] - t[1][0]):
+                group = list(map(itemgetter(1), grouper))
+                duplicate_start, duplicate_end = group[0], group[-1]
                 duplicate_dict = {
                     'start_time': duplicate_start[1],
                     'end_time': duplicate_end[1],
                     'start_id': duplicate_start[0],
-                    'end_id': duplicate_end[0],
-                    'duplication_count': len(duplicates)
+                    'end_id': duplicate_end[0]
                 }
                 duplicate_ranges.append(duplicate_dict)
 

--- a/tests/common/platform/warmboot_sad_cases.py
+++ b/tests/common/platform/warmboot_sad_cases.py
@@ -59,7 +59,7 @@ def get_sad_case_list(duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_t
                 # (1 each)
                 NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(3),
                                    PhyPropsPortSelector(duthost, lagMemberCnt)),
-            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-64-32'] else []),
+            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-118', 't0-64-32'] else []),
 
         "sad_bgp": [
                 'neigh_bgp_down:2',     # Shutdown single BGP session on 2 remote devices (VMs) before reboot DUT
@@ -81,7 +81,7 @@ def get_sad_case_list(duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_t
                 # (1 each)
                 NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(3),
                                    PhyPropsPortSelector(duthost, lagMemberCnt)),
-            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-64-32'] else []),
+            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-118', 't0-64-32'] else []),
 
         "sad_lag": [
                 'dut_lag_down:2',               # Shutdown 2 LAG sessions on DUT brefore rebooting it

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -276,7 +276,7 @@ copp/test_copp.py:
   skip:
     reason: "Topology not supported by COPP tests"
     conditions:
-      - "(topo_name not in ['dualtor-aa', 'dualtor-aa-64-breakout', 'ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
+      - "(topo_name not in ['dualtor-aa', 'dualtor-aa-64-breakout', 'ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_add_new_trap:
   skip:
@@ -284,7 +284,7 @@ copp/test_copp.py::TestCOPP::test_add_new_trap:
     conditions_logical_operator: or
     conditions:
       - "is_multi_asic==True"
-      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
+      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_remove_trap:
   skip:
@@ -292,7 +292,7 @@ copp/test_copp.py::TestCOPP::test_remove_trap:
     conditions_logical_operator: or
     conditions:
       - "is_multi_asic==True"
-      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
+      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
   skip:
@@ -302,14 +302,14 @@ copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
       - "is_multi_asic==True"
       - "build_version.split('.')[0].isdigit() and int(build_version.split('.')[0]) == 20220531 and int(build_version.split('.')[1]) > 27 and hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Arista-7060CX-32S-C32-T1']"
       - "build_version.split('.')[0].isdigit() and int(build_version.split('.')[0]) > 20220531 and hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Arista-7060CX-32S-C32-T1']"
-      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
+      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_trap_neighbor_miss:
   skip:
     reason: "Copp test_trap_neighbor_miss is not supported on broadcom platforms or non-TOR topologies"
     conditions_logical_operator: or
     conditions:
-      - "(topo_name not in ['t0', 't0-64', 't0-52', 't0-116'])"
+      - "(topo_name not in ['t0', 't0-64', 't0-52', 't0-116', 't0-118'])"
       - "(asic_type in ['broadcom'] and release in ['202411'])"
 
 #######################################
@@ -1001,7 +1001,7 @@ generic_config_updater/test_eth_interface.py::test_replace_fec:
              / generic_config_updater is not a supported feature for T2'
     conditions_logical_operator: "OR"
     conditions:
-      - "hwsku in ['Arista-7260CX3-D108C8', 'Arista-7260CX3-Q64', 'Mellanox-SN3800-D112C8'] and https://github.com/sonic-net/sonic-mgmt/issues/11237"
+      - "hwsku in ['Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Arista-7260CX3-Q64', 'Mellanox-SN3800-D112C8'] and https://github.com/sonic-net/sonic-mgmt/issues/11237"
       - "'t2' in topo_name"
 
 generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym:
@@ -1801,7 +1801,7 @@ qos/test_qos_sai.py::TestQosSai:
     reason: "Unsupported testbed type. / M0/MX topo does not support qos"
     conditions_logical_operator: or
     conditions:
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
       - "topo_type in ['m0', 'mx']"
 
 qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping:
@@ -1812,7 +1812,7 @@ qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping:
       - "asic_type in ['mellanox']"
       - https://github.com/sonic-net/sonic-mgmt/issues/12906
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
   skip:
@@ -1821,7 +1821,7 @@ qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
     conditions:
       - "asic_type in ['cisco-8000']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark:
   skip:
@@ -1830,7 +1830,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark:
     conditions:
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-arista_7800r3_48cq2_lc', 'x86_64-arista_7800r3_48cqm2_lc', 'x86_64-arista_7800r3a_36d2_lc', 'x86_64-arista_7800r3a_36dm2_lc','x86_64-arista_7800r3ak_36dm2_lc']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping:
   skip:
@@ -1839,7 +1839,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping:
     conditions:
       - "'backend' not in topo_name"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping:
   skip:
@@ -1848,7 +1848,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping:
     conditions:
       - "'backend' not in topo_name"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:
   skip:
@@ -1857,7 +1857,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:
     conditions:
       - "'backend' in topo_name"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping:
   skip:
@@ -1866,7 +1866,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping:
     conditions:
       - "'backend' in topo_name"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange:
   skip:
@@ -1875,7 +1875,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange:
     conditions:
       - "asic_type in ['mellanox']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiFullMeshTrafficSanity:
   skip:
@@ -1884,7 +1884,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiFullMeshTrafficSanity:
     conditions:
       - "asic_type not in ['cisco-8000'] or topo_name not in ['ptf64']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
   skip:
@@ -1892,10 +1892,10 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
     conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100']
-      and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
+      and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
       and asic_type in ['cisco-8000']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
       - "'t2' in topo_name and asic_subtype in ['broadcom-dnx']"
       - "asic_type in ['vs']"
 
@@ -1908,11 +1908,11 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
          and asic_type in ['cisco-8000']
          and https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
   xfail:
     reason: "Headroom pool size not supported."
     conditions:
-      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
+      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
   skip:
@@ -1921,7 +1921,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq:
   skip:
@@ -1930,7 +1930,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc:
   skip:
@@ -1939,7 +1939,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop:
   skip:
@@ -1948,7 +1948,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
   skip:
@@ -1957,7 +1957,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
     conditions:
       - "asic_type in ['cisco-8000'] and not platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[None-wm_pg_shared_lossy]:
   xfail:
@@ -1972,7 +1972,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts:
     conditions:
       - "asic_type not in ['cisco-8000']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
   skip:
@@ -1981,7 +1981,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
       - "asic_type in ['vs']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1307,7 +1307,7 @@ platform_tests/test_sensors.py::test_sensors:
   xfail:
     reason: "Case failed and waiting for fix on Arista platform"
     conditions:
-      - "hwsku in ['Arista-7050QX32S-Q32', 'Arista-7060CX-32S-D48C8', 'Arista-7260CX3-D108C8', 'Arista-7060CX-32S-C32', 'Arista-7260CX3-C64']"
+      - "hwsku in ['Arista-7050QX32S-Q32', 'Arista-7060CX-32S-D48C8', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Arista-7060CX-32S-C32', 'Arista-7260CX3-C64']"
       - "release in ['202205']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8437
 

--- a/tests/dualtor_io/conftest.py
+++ b/tests/dualtor_io/conftest.py
@@ -35,10 +35,17 @@ def pytest_generate_tests(metafunc):
 def setup_loganalyzer(loganalyzer):
     """Fixture to allow customize loganalyzer behaviors."""
 
-    def _setup_loganalyzer(duthost, collect_only):
+    KERNEL_BOOTUP_SYSLOG = "kernel: [    0.000000] Linux version"
+
+    def _setup_loganalyzer(duthost, collect_only=False, collect_from_bootup=False):
         if collect_only:
             loganalyzer[duthost.hostname].match_regex = []
             loganalyzer[duthost.hostname].expect_regex = []
             loganalyzer[duthost.hostname].ignore_regex = []
+
+        if collect_from_bootup:
+            loganalyzer[duthost.hostname].start_marker = KERNEL_BOOTUP_SYSLOG
+            loganalyzer[duthost.hostname].ansible_loganalyzer.start_marker = \
+                KERNEL_BOOTUP_SYSLOG
 
     return _setup_loganalyzer

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -84,8 +84,7 @@ def test_active_link_down_downstream_active(
     if cable_type == CableType.active_active:
         send_t1_to_server_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=1, allowed_duplication=1,
-            action=shutdown_fanout_upper_tor_intfs
+            allowed_disruption=1, action=shutdown_fanout_upper_tor_intfs
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,
@@ -333,8 +332,7 @@ def test_active_link_down_downstream_active_soc(
     if cable_type == CableType.active_active:
         send_t1_to_soc_with_action(
             upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
-            allowed_disruption=1, allowed_duplication=1,
-            action=shutdown_fanout_upper_tor_intfs
+            allowed_disruption=1, action=shutdown_fanout_upper_tor_intfs
         )
         verify_tor_states(
             expected_active_host=lower_tor_host,

--- a/tests/dualtor_io/test_tor_failure.py
+++ b/tests/dualtor_io/test_tor_failure.py
@@ -66,7 +66,7 @@ def test_active_tor_reboot_upstream(
     Send upstream traffic and reboot the active ToR. Confirm switchover
     occurred and disruption lasts < 1 second
     """
-    setup_loganalyzer(upper_tor_host, collect_only=True)
+    setup_loganalyzer(upper_tor_host, collect_only=True, collect_from_bootup=True)
     send_server_to_t1_with_action(
         upper_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         action=toggle_upper_tor_pdu, stop_after=60
@@ -99,7 +99,7 @@ def test_active_tor_reboot_downstream_standby(
     Send downstream traffic to the standby ToR and reboot the active ToR.
     Confirm switchover occurred and disruption lasts < 1 second
     """
-    setup_loganalyzer(upper_tor_host, collect_only=True)
+    setup_loganalyzer(upper_tor_host, collect_only=True, collect_from_bootup=True)
     send_t1_to_server_with_action(
         lower_tor_host, verify=True, delay=MUX_SIM_ALLOWED_DISRUPTION_SEC,
         action=toggle_upper_tor_pdu, stop_after=60
@@ -123,7 +123,7 @@ def test_standby_tor_reboot_upstream(
     Send upstream traffic and reboot the standby ToR. Confirm no switchover
     occurred and no disruption
     """
-    setup_loganalyzer(lower_tor_host, collect_only=True)
+    setup_loganalyzer(lower_tor_host, collect_only=True, collect_from_bootup=True)
     send_server_to_t1_with_action(
         upper_tor_host, verify=True,
         action=toggle_lower_tor_pdu, stop_after=60
@@ -147,7 +147,7 @@ def test_standby_tor_reboot_downstream_active(
     Send downstream traffic to the active ToR and reboot the standby ToR.
     Confirm no switchover occurred and no disruption
     """
-    setup_loganalyzer(lower_tor_host, collect_only=True)
+    setup_loganalyzer(lower_tor_host, collect_only=True, collect_from_bootup=True)
     send_t1_to_server_with_action(
         upper_tor_host, verify=True,
         action=toggle_lower_tor_pdu, stop_after=60

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -682,7 +682,9 @@ class BaseEverflowTest(object):
                 command += " --stage {}".format(self.acl_stage())
 
             if bind_ports_list:
-                command += " -p {}".format(",".join(bind_ports_list))
+                filtered_ports = [p for p in bind_ports_list if p and p != "Not Applicable"]
+                if filtered_ports:
+                    command += " -p {}".format(",".join(filtered_ports))
 
         elif config_method == CONFIG_MODE_CONFIGLET:
             pass

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -57,7 +57,7 @@ def get_dummay_mac_count(tbinfo, duthosts, rand_one_dut_hostname):
 
     # t0-116 will take 90m with DUMMY_MAC_COUNT, so use DUMMY_MAC_COUNT_SLIM for t0-116 to reduce running time
     # Use DUMMY_MAC_COUNT_SLIM on dualtor-64 to reduce running time
-    REQUIRED_TOPO = ["t0-116", "dualtor-64", "dualtor-120",
+    REQUIRED_TOPO = ["t0-116", "t0-118", "dualtor-64", "dualtor-120",
                      "t0-standalone-64", "t0-standalone-128", "t0-standalone-256", "t0-standalone-512"]
     if tbinfo["topo"]["name"] in REQUIRED_TOPO:
         # To reduce the case running time

--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -8,7 +8,6 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.ptf_runner import ptf_runner
 from .utils import fdb_table_has_dummy_mac_for_interface
-from tests.common.helpers.ptf_tests_helper import upstream_links    # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 
 
@@ -36,8 +35,6 @@ class TestFdbMacLearning:
     """
     TestFdbMacLearning verifies that stale MAC entries are not present in MAC table after doing sonic-clear fdb all
     -shut down all ports
-    -config save
-    -config reload
     -bring up 1 port. populate fdb
     -bring up 3 more ports. populate fdb.
     -shut down 3 ports added in last step
@@ -123,7 +120,7 @@ class TestFdbMacLearning:
         """
             Select DUT ports which will be used for the testcase
             Get a mapping of selected DUT ports and ptf ports
-            shut down all DUT ports, congit save and config reload the DUT before starting the testcases
+            shut down all DUT ports
 
             Args:
                 duthosts: Devices under test
@@ -173,9 +170,23 @@ class TestFdbMacLearning:
         logging.info("shutdown all interfaces on DUT")
         for port in dut_ports:
             duthost.shell("sudo config interface shutdown {}".format(port))
-        duthost.command('sudo config save -y')
-        config_reload(duthost, config_source='config_db', safe_reload=True)
+
         yield target_ports_to_ptf_mapping, ptf_ports_available_in_topo, conf_facts
+
+        logging.info("reload device %s to recover", duthost.hostname)
+        config_reload(duthost, config_source='running_golden_config', safe_reload=True)
+
+    @pytest.fixture(autouse=True)
+    def cleanup_arp_fdb(self, duthosts, rand_one_dut_hostname):
+        """Cleanup fdb and arp on the selected target DUT."""
+        duthost = duthosts[rand_one_dut_hostname]
+        duthost.shell("sonic-clear arp")
+        duthost.shell("sonic-clear fdb all")
+
+        yield
+
+        duthost.shell("sonic-clear arp")
+        duthost.shell("sonic-clear fdb all")
 
     def dynamic_fdb_oper(self, duthost, tbinfo, ptfhost, dut_ptf_ports):
         """function to populate fdb for given dut/ptf ports"""
@@ -205,44 +216,13 @@ class TestFdbMacLearning:
         """
         Make sure interfaces are ready for sending traffic.
         """
-        if "dualtor-aa" in tbinfo['topo']['name']:
-            pytest_assert(wait_until(300, 5, 0, self.check_mux_status_consistency, duthost, ports))
-        else:
-            time.sleep(30)
-
-    def bringup_uplink_ports(self, duthost, upstream_links): # noqa F811
-        """
-        For active-active dualtor NIC simulator doesn't install OVS flows for downlink ports until the link status
-        becomes consistent which can happen in this case only if upstream connectivity is restored.
-        """
-        # Get one upstream port
-        uplink_intf = list(upstream_links.keys())[0]
-        # Check if it's a LAG member
-        config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
-        portChannels = config_facts['PORTCHANNEL_MEMBER']
-        portChannel = None
-        members = None
-        for intf in portChannels:
-            if uplink_intf in portChannels[intf]:
-                portChannel = intf
-                members = list(portChannels[intf].keys())
-                break
-        if portChannel:
-            min_links = int(config_facts['PORTCHANNEL'][portChannel]['min_links'])
-            # Bringup minimum ports for this port channel to be up
-            for i in range(min_links):
-                duthost.shell("sudo config interface startup {}".format(members[i]))
-        else:
-            duthost.shell("sudo config interface startup {}".format(uplink_intf))
+        time.sleep(30)
 
     def testFdbMacLearning(self, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request, prepare_test,
-                           upstream_links, setup_standby_ports_on_rand_unselected_tor_unconditionally,                  # noqa F811
                            toggle_all_simulator_ports_to_rand_selected_tor_m):                                          # noqa F811
         """
             TestFdbMacLearning verifies stale MAC entries are not present in MAC table after doing sonic-clear fdb all
             -shut down all ports
-            -config save
-            -config reload
             -bring up 1 port. populate fdb
             -bring up 3 more ports. populate fdb.
             -shut down 3 ports added in last step
@@ -260,10 +240,7 @@ class TestFdbMacLearning:
             res = ptfhost.shell('cat /sys/class/net/{}/address'.format(ptf_port))
             ptf_interfaces_mac_addresses.append(res['stdout'].upper())
 
-        # Bringup uplink connectivity for muxcable status consistency to happen.
         duthost = duthosts[rand_one_dut_hostname]
-        if "dualtor-aa" in tbinfo['topo']['name']:
-            self.bringup_uplink_ports(duthost, upstream_links)
 
         # unshut 1 port and populate fdb for that port. make sure fdb entry is populated in mac table
         target_ports = [target_ports_to_ptf_mapping[0][0]]
@@ -330,9 +307,11 @@ class TestFdbMacLearning:
         try:
             self.configureInterfaceIp(duthost, dut_interface, action="add")
             self.configureNeighborIp(ptfhost, ptf_ports_available_in_topo[ptf_port_index], action="add")
+            time.sleep(2)
             ptfhost.shell("ping {} -c 3 -I {}".format(self.DUT_INTF_IP, self.PTF_HOST_IP), module_ignore_errors=True)
-
-        finally:
+            int_ip_found = any((dut_interface in line and self.DUT_INTF_IP in line)
+                               for line in duthost.command("show ip interface")["stdout_lines"])
+            pytest_assert(int_ip_found, "%s is not configured on %s" % (self.DUT_INTF_IP, dut_interface))
             show_arp = duthost.command('show arp')
             arp_found = False
             for arp_entry in show_arp['stdout_lines']:
@@ -342,5 +321,6 @@ class TestFdbMacLearning:
                     pytest_assert(items[2] == dut_interface, "ARP entry for ip address {}"
                                   " is incomplete. Interface is missing".format(self.PTF_HOST_IP))
             pytest_assert(arp_found, "ARP entry not found for ip address {}".format(self.PTF_HOST_IP))
+        finally:
             self.configureInterfaceIp(duthost, dut_interface, action="remove")
             self.configureNeighborIp(ptfhost, ptf_ports_available_in_topo[ptf_port_index], action="del")

--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -826,11 +826,11 @@ class QosParamCisco(object):
                 sq_occupancies_mb = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 4]
                 params_1 = {"packet_size": packet_size,
                             "ecn": 1,
-                            "dscps":  [3, 4, 3, 4, 3, 4, 3, 4, 3, 3, 3],
-                            "pgs":    [3, 4, 3, 4, 3, 4, 3, 4, 3, 3, 3],
-                            "queues": [3, 4, 3, 4, 3, 4, 3, 4, 3, 3, 3],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 5, 6],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+                            "dscps":      [3, 4, 3, 4, 3,  4,  3,  4,  3,  4,  3],
+                            "pgs":        [3, 4, 3, 4, 3,  4,  3,  4,  3,  4,  3],
+                            "queues":     [3, 4, 3, 4, 3,  4,  3,  4,  3,  4,  3],
+                            "src_port_i": [0, 0, 1, 1, 2,  2,  3,  3,  4,  4,  5],
+                            "dst_port_i": [7, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_1", params_1)
 
@@ -841,8 +841,8 @@ class QosParamCisco(object):
                             "dscps":      [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "pgs":        [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "queues":     [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+                            "src_port_i": [0, 0, 1, 1, 2,  2,  3,  3,  4,  4,  5,  5,  6,  6],
+                            "dst_port_i": [7, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_2", params_2)
 
@@ -857,8 +857,8 @@ class QosParamCisco(object):
                                            self.dscp_queue1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "pgs":        [3, 0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "queues":     [3, 1, 0, 1, 0, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+                            "src_port_i": [0, 0, 1, 1, 2,  2,  3,  3,  4,  4,  5,  5,  6,  6,  9,  9],
+                            "dst_port_i": [7, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_3", params_3)
 
@@ -873,8 +873,8 @@ class QosParamCisco(object):
                                            self.dscp_queue1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "pgs":        [3, 0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4],
                             "queues":     [3, 1, 0, 1, 0, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11, 11],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8,  8],
+                            "src_port_i": [0, 0, 1, 1, 2, 2, 3,  3,  4,  4,  5,  5,  6,  6,  9,  9,  10, 10, 11, 11],
+                            "dst_port_i": [7, 8, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_4", params_4)
 
@@ -888,9 +888,10 @@ class QosParamCisco(object):
                                            self.dscp_queue1, self.dscp_queue0,
                                            self.dscp_queue1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "pgs":        [0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3,  4,  3,  4,  3,  4],
-                            "queues":     [1, 0, 1, 0, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3,  4,  3,  4,  3,  4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11, 11, 12],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8,  8,  8],
+                            "queues":     [1, 0, 1, 0, 1, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4,  3,  4,  3,  4,  3,  4],
+                            "src_port_i": [0, 0, 1, 1, 2, 2, 2, 3, 3,  4,  4,  5,  5,  6,  6,  9,  9,  10, 10, 11, 11],
+                            "dst_port_i": [7, 8, 12, 12, 13, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17,
+                                           18, 18, 19, 19, 20, 20],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_5", params_5)
 
@@ -904,8 +905,8 @@ class QosParamCisco(object):
                                            4, 3, 4, 3, 4],
                             "pgs":        [3, 4, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "queues":     [3, 4, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+                            "src_port_i": [0, 0, 1, 1, 1, 2,  2,  3,  3,  4,  4,  5,  5,  6,  6],
+                            "dst_port_i": [7, 8, 9, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_6", params_6)
 
@@ -917,7 +918,8 @@ class QosParamCisco(object):
                             "pgs":        [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4],
                             "queues":     [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4],
                             "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11, 11, 12, 12],
-                            "dst_port_i": [7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8,  8,  8,  8],
+                            "dst_port_i": [7, 7, 8, 8, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18,
+                                           18, 19, 19, 20, 20, 21, 21],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_7", params_7)
 
@@ -929,7 +931,8 @@ class QosParamCisco(object):
                             "pgs":        [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4],
                             "queues":     [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4],
                             "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11, 11, 12, 12],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8,  8,  8,  8],
+                            "dst_port_i": [7, 8, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19,
+                                           19, 20, 20, 21, 21, 22, 22],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_8", params_8)
 
@@ -944,8 +947,8 @@ class QosParamCisco(object):
                                            3, 4, 3, 4, 3, 4],
                             "pgs":        [0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3,  4,  3,  4],
                             "queues":     [1, 0, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3,  4,  3,  4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11],
-                            "dst_port_i": [7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8],
+                            "src_port_i": [0, 0, 1,  1,  1,  2,  2,  3,  3,  4,  4,  5,  5,  6,  6,  9,  9,  10, 10],
+                            "dst_port_i": [7, 8, 11, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_9", params_9)
 

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -185,6 +185,7 @@ class TestQosSai(QosSaiBase):
         'Arista-7060CX-32S-C32',
         'Celestica-DX010-C32',
         'Arista-7260CX3-D108C8',
+        'Arista-7260CX3-D108C10',
         'Force10-S6100',
         'Arista-7260CX3-Q64',
         'Arista-7050CX3-32S-C32',

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -29,7 +29,7 @@ from .tunnel_qos_remap_base import build_testing_packet, check_queue_counter,\
     dut_config, qos_config, tunnel_qos_maps, run_ptf_test, toggle_mux_to_host,\
     setup_module, update_docker_services, swap_syncd, counter_poll_config                               # noqa F401
 from .tunnel_qos_remap_base import leaf_fanout_peer_info, start_pfc_storm, \
-    stop_pfc_storm, get_queue_counter, get_queue_watermark                                              # noqa F401
+    stop_pfc_storm, get_queue_counter, get_queue_watermark, disable_packet_aging                        # noqa F401
 from ptf import testutils
 from ptf.testutils import simple_tcp_packet
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa F401

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2925,7 +2925,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         self.src_port_macs = [self.dataplane.get_mac(
             0, ptid) for ptid in self.src_port_ids]
 
-        if self.testbed_type in ['dualtor', 'dualtor-56', 't0', 't0-28', 't0-64', 't0-116', 't0-120']:
+        if self.testbed_type in ['dualtor', 'dualtor-56', 't0', 't0-28', 't0-64', 't0-116', 't0-118', 't0-120']:
             # populate ARP
             # sender's MAC address is corresponding PTF port's MAC address
             # sender's IP address is caculated in tests/qos/qos_sai_base.py::QosSaiBase::__assignTestPortIps()
@@ -3163,6 +3163,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
             upper_bound = 2 * margin + 1
             if (hwsku == 'Arista-7260CX3-D108C8' and self.testbed_type in ('t0-116', 'dualtor-120')) \
+                    or (hwsku == 'Arista-7260CX3-D108C10' and self.testbed_type in ('t0-118')) \
                     or (hwsku == 'Arista-7260CX3-C64' and self.testbed_type in ('dualtor-aa-56', 't1-64-lag')):
                 upper_bound = 2 * margin + self.pgs_num
             if self.wm_multiplier:


### PR DESCRIPTION
Code sync sonic-net/sonic-mgmt:202411 => 202412
```
* | c6a94a078 (pub_upstream/202411) Revert "[dualtor_io] Allow duplications for link down downstream I/O (#17909)" (#18192)
* | de454d5bf [testARPCompleted] Cleanup ptf ip after test failure (#18170)
* | 4a3d1d96b [dualtor] Refine `fdb_mac_learning_test.py` (#18092)
* | 5964a7818 [dualtor_io] Fix the start marker not found issue (#18096)
* | ce40816ea Extend LACP time multiplier for advanced-reboot tests with cEOS peers (#17964)
* | 0e70ba32f adjust port selection in case testQosSaiXonHysteresis for Cisco-8101 (#18130)
* | 8bb720348 [202411] Restore disable packet aging fixture 202411 (#18103)
* | 8f6d1a323 Filter out Not Applicable values in command line (#18006)
* | 9d5de5c46 Backport t0-118 test configs to 202411 (#17983)
```