### PR TITLE
Cisco-8000: Add Power loss RE match for Kernel Panic

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -50,12 +50,6 @@ DUT_ACTIVE.set()
     test_reboot_cause_only : indicate if the purpose of test is for reboot cause only
 '''
 reboot_ctrl_dict = {
-    REBOOT_TYPE_POWEROFF: {
-        "timeout": 300,
-        "wait": 120,
-        "cause": "Power Loss",
-        "test_reboot_cause_only": True
-    },
     REBOOT_TYPE_SOFT: {
         "command": "soft-reboot",
         "timeout": 300,
@@ -136,6 +130,12 @@ reboot_ctrl_dict = {
         # This change relates to changes of PR #6130 in sonic-buildimage repository
         "cause": r"'reboot'|Non-Hardware \(reboot|^reboot",
         "test_reboot_cause_only": False
+    },
+    REBOOT_TYPE_POWEROFF: {
+        "timeout": 300,
+        "wait": 120,
+        "cause": "Power Loss",
+        "test_reboot_cause_only": True
     }
 }
 
@@ -379,8 +379,14 @@ def get_reboot_cause(dut):
     cause = output['stdout']
 
     for type, ctrl in list(reboot_ctrl_dict.items()):
-        if re.search(ctrl['cause'], cause):
-            return type
+        if dut.facts['asic_type'] == "cisco-8000" and dut.get_facts().get("modular_chassis") \
+            and type == REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS:
+            # Skip the check for SUP heartbeat loss on T2 chassis
+            if re.search(r"Heartbeat|headless|Power Loss", cause):
+                return type
+        else:
+            if re.search(ctrl['cause'], cause):
+                return type
 
     return REBOOT_TYPE_UNKNOWN
 


### PR DESCRIPTION
Add power loss to list of causes  for Cisco-8000 distributed chassis. @abdosi and @yejianquan have context of the issue

==================================== PASSES ====================================
________________ TestKernelPanic.test_kernel_panic[sfd-lt2-lc0] ________________
________________ TestKernelPanic.test_kernel_panic[sfd-lt2-lc1] ________________
________________ TestKernelPanic.test_kernel_panic[sfd-lt2-sup] ________________
- generated xml file: /run_logs/24505_nightly/platform_tests/test_kdump_2025-05-17-18-43-09.xml -
=========================== short test summary info ============================
PASSED platform_tests/test_kdump.py::TestKernelPanic::test_kernel_panic[sfd-lt2-lc0]
PASSED platform_tests/test_kdump.py::TestKernelPanic::test_kernel_panic[sfd-lt2-lc1]
PASSED platform_tests/test_kdump.py::TestKernelPanic::test_kernel_panic[sfd-lt2-sup]
================== 3 passed, 1 warning in 3472.83s (0:57:52) ===================