### PR TITLE
BFD check in sanity check was always reporting as false

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -1124,6 +1124,7 @@ def check_bfd_up_count(duthosts):
         return list(result.values())
 
     def _check_bfd_up_count(dut, asic_id, check_result):
+        check_result["failed"] = False
         res = dut.shell(
             "ip netns exec {} show bfd summary | grep -c 'Up'".format(asic_id),
             module_ignore_errors=True,


### PR DESCRIPTION
Hi @cyw233 @yejianquan ,

In case of presanity check for bfd, if _check_bfd_up_count is false once, the state never changes to true even when all the bfd sessions come up, added a small fix to set the state to true at the start of the check, this way it is able to recover

If this looks good, I will create a similar PR for sonic-mgmt master

16/05/2025 00:50:23 checks._check_bfd_up_count               L1137 INFO   | BFD up count on asic0 of sfd-lt2-lc0: 160. Expected BFD up count: 160
16/05/2025 00:50:23 utilities.wait_until                     L0153 DEBUG  | _check_bfd_up_count is False, wait 20 seconds and check again
16/05/2025 00:50:43 utilities.wait_until                     L0135 DEBUG  | Time elapsed: 46.300968 seconds
16/05/2025 00:50:43 base._run                                L0071 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#136: [sfd-lt2-lc0] AnsibleModule::shell, args=["ip netns exec asic2 show bfd summary | grep -c 'Up'"], kwargs={"module_ignore_errors": true}
16/05/2025 00:50:43 utilities.wait_until                     L0135 DEBUG  | Time elapsed: 46.334935 seconds