### PR TITLE
Update neighbor type for upperspinerouter (#18441)

### DIFF
--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -53,9 +53,10 @@ def common_setup_teardown(
 
     if dut_type in ["ToRRouter", "SpineRouter", "BackEndToRRouter"]:
         neigh_type = "LeafRouter"
+    elif dut_type == "UpperSpineRouter":
+        neigh_type = "SpineRouter"
     else:
         neigh_type = "ToRRouter"
-
     logging.info(
         "pseudoswitch0 neigh_addr {} ns {} dut_asn {} local_addr {} neigh_type {}".format(
             conn0["neighbor_addr"].split("/")[0],

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -96,6 +96,8 @@ def common_setup_teardown(
 
     if dut_type in ["ToRRouter", "SpineRouter", "BackEndToRRouter"]:
         neigh_type = "LeafRouter"
+    elif dut_type == "UpperSpineRouter":
+        neigh_type = "SpineRouter"
     else:
         neigh_type = "ToRRouter"
 


### PR DESCRIPTION
What is the motivation for this PR?
Manual cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/18441
test_bgp_peer_shutdown.py fails on UpperSpineRouter

How did you do it?
Added handling for UpperSpineRouter in bgp_peer_shutdown test and other tests where similar check is done

How did you verify/test it?
Run bgp/test_bgp_peer_shutdown.py on device with dut_type UpperSpineRouter