### PR TITLE
Porting:17934-to-msft.202405: T2:Snappi Tests:Cisco-8000:Remove la_error ignore fixture, and fix the occurance of LA errors

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -8,7 +8,6 @@ import snappi
 import sys
 import random
 from copy import copy
-import snappi_convergence
 from tests.common.helpers.assertions import pytest_require
 from tests.common.errors import RunAnsibleModuleFail
 from ipaddress import ip_address, IPv4Address, IPv6Address

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -7,6 +7,7 @@ import logging
 import snappi
 import sys
 import random
+from copy import copy
 import snappi_convergence
 from tests.common.helpers.assertions import pytest_require
 from tests.common.errors import RunAnsibleModuleFail
@@ -939,6 +940,19 @@ def create_ip_list(value, count, mask=32, incr=0):
 
 
 def cleanup_config(duthost_list, snappi_ports):
+    if (duthost_list[0].facts['asic_type'] == "cisco-8000" and
+            duthost_list[0].get_facts().get("modular_chassis", None)):
+        global DEST_TO_GATEWAY_MAP
+        copy_DEST_TO_GATEWAY_MAP = copy(DEST_TO_GATEWAY_MAP)
+        for addr in copy_DEST_TO_GATEWAY_MAP:
+            static_routes_cisco_8000(
+                addr,
+                dut=DEST_TO_GATEWAY_MAP[addr]['dut'],
+                intf=None,
+                namespace=DEST_TO_GATEWAY_MAP[addr]['asic'],
+                setup=False)
+
+        time.sleep(4)
     for index, duthost in enumerate(duthost_list):
         port_count = len(snappi_ports)
         dutIps = create_ip_list(dut_ip_start, port_count, mask=prefix_length)
@@ -1319,7 +1333,6 @@ def static_routes_cisco_8000(addr, dut=None, intf=None, namespace=None, setup=Tr
     global DEST_TO_GATEWAY_MAP
     if dut is None:
         if addr not in DEST_TO_GATEWAY_MAP:
-            logger.warn(f"Request for dest addr: {addr} without setting it in advance.")
             return addr
         return DEST_TO_GATEWAY_MAP[addr]['dest']
 
@@ -1342,6 +1355,8 @@ def static_routes_cisco_8000(addr, dut=None, intf=None, namespace=None, setup=Tr
     DEST_TO_GATEWAY_MAP[addr] = {}
     DEST_TO_GATEWAY_MAP[addr]['dest'] = str(ip_addr + 3*256*256*256)
     DEST_TO_GATEWAY_MAP[addr]['intf'] = intf
+    DEST_TO_GATEWAY_MAP[addr]['dut'] = dut
+    DEST_TO_GATEWAY_MAP[addr]['asic'] = namespace
     cmd = "del"
     if setup:
         cmd = "add"
@@ -1349,6 +1364,8 @@ def static_routes_cisco_8000(addr, dut=None, intf=None, namespace=None, setup=Tr
     if namespace is not None:
         asic_arg = f"ip netns exec {namespace}"
     try:
+        dut.shell("{} arp -i {} -s {} aa:bb:cc:dd:ee:ff".format(
+            asic_arg, intf, addr))
         dut.shell(
             "{} config route {} prefix {}/32 nexthop {} {}".format(
                 asic_arg, cmd, DEST_TO_GATEWAY_MAP[addr]['dest'], addr,

--- a/tests/snappi_tests/conftest.py
+++ b/tests/snappi_tests/conftest.py
@@ -76,19 +76,3 @@ def enable_packet_aging_after_test(duthosts, rand_one_dut_hostname):
 
     duthost = duthosts[rand_one_dut_hostname]
     enable_packet_aging(duthost)
-
-
-@pytest.fixture(scope="function", autouse=True)
-def ignore_route_check_for_cisco_8000(duthosts, loganalyzer):
-    if not loganalyzer:
-        yield
-        return
-    ignore_list = [r".*'routeCheck' status failed .*", r".*missing interface entry for static route.*"]
-    for dut in duthosts:
-        if (dut.facts['asic_type'] == "cisco-8000" and
-                dut.get_facts().get("modular_chassis", None)):
-            for line in ignore_list:
-                loganalyzer[dut.hostname].ignore_regex.append(line)
-
-    yield
-    return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Recently https://github.com/sonic-net/sonic-mgmt/pull/17012 introduced static routes-based destinations for snappi tests.  That PR included a LA-error ignore fixture, since the static route introduced two LA errors during the runs. This PR removes this fixture, and updates the static route functions to completely remove the LA Error in the first place. The LA errors were: 
```
routeCheck' status failed .*", r".*missing interface entry for static route.
```

1. RouteCheck error disappeared after making sure the static route's outgoing interface always has an IP address. So, we should always add route after IP address, and remove the route before the IP address.
2. The second "missing interface" error is from arp_update. This disappeared after making sure there is an arp entry for the GW address used by the static route. When this arp entry is missing, we see that error.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X]  202411
- [X] 202405

### Approach
#### What is the motivation for this PR?
Pls see the description.

#### How did you do it?
As mentioned in description.

#### How did you verify/test it?
Ran it on T2 TB:
```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================================================== PASSES ===========================================================================================================================
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info0-test_ecn_config0] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info0-test_ecn_config1] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info0-test_ecn_config2] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info0-test_ecn_config3] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info1-test_ecn_config0] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info1-test_ecn_config1] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info1-test_ecn_config2] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info1-test_ecn_config3] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info2-test_ecn_config1] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info2-test_ecn_config2] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info2-test_ecn_config3] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info3-test_ecn_config0] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info3-test_ecn_config1] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info3-test_ecn_config2] _______________________________________________________________________________________
______________________________________________________________________________________ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info3-test_ecn_config3] _______________________________________________________________________________________
-------------------------------------------------------------------------------------- generated xml file: /run_logs/100G/ecn-la-error-test/2025-04-08-20-11-47/tr.xml ---------------------------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
================================================================================================================== short test summary info ===================================================================================================================
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info0-test_ecn_config0]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info0-test_ecn_config1]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info0-test_ecn_config2]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info0-test_ecn_config3]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info1-test_ecn_config0]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info1-test_ecn_config1]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info1-test_ecn_config2]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info1-test_ecn_config3]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info2-test_ecn_config1]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info2-test_ecn_config2]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info2-test_ecn_config3]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info3-test_ecn_config0]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info3-test_ecn_config1]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info3-test_ecn_config2]
PASSED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info3-test_ecn_config3]
ERROR snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info3-test_ecn_config3] - Failed: Not all bgp sessions are established after config reload
FAILED snappi_tests/ecn/test_ecn_marking_with_pfc_quanta_variance_with_snappi.py::test_ecn_marking_with_pfc_quanta_variance[multidut_port_info2-test_ecn_config0] - snappi_ixnetwork.exceptions.SnappiIxnException:   File "/usr/local/lib/python3.8/dist-packages/snappi_ixnetwork/snappi_api.py", line 502, in get_metrics
============================================================================================== 1 failed, 15 passed, 20 warnings, 1 error in 18529.96s (5:08:49) ==============================================================================================
sonic@snappi-sonic-mgmt-msft-t2:/data/tests$
sonic@snappi-sonic-mgmt-msft-t2:/data/tests$
sonic@snappi-sonic-mgmt-msft-t2:/data/tests$ 
```
#### Any platform specific information?
Cisco-8000 only.