### PR TITLE
Disable route check in snmp queue counter (#18485)

### DIFF
--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -11,6 +11,7 @@ MULTICAST_CTRS = 4
 
 pytestmark = [
     pytest.mark.topology('any'),
+    pytest.mark.disable_route_check,
     pytest.mark.device_type('vs')
 ]
 


### PR DESCRIPTION
Description of PR
Summary:
Fixes # (issue)
32624894

Type of change
 Bug fix
 Testbed and Framework(new/improvement)
 New Test case
 Skipped for non-supported platforms
 Test case improvement

Approach
What is the motivation for this PR?
Disable route check in snmp queue counter, fix the test failure on Cisco chassis

How did you do it?
Disable route check in snmp queue counter

How did you verify/test it?
Run test on physical devices, and it passed.