### PR TITLE
[202503] Fixed swss feature name for test_lldp_neighbor_post_orchagent_reboot (#15715)

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -26,7 +26,8 @@ def lldp_setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, patch_lldpct
 def restart_orchagent(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asic = duthost.asic_instance(enum_frontend_asic_index)
-    container_name = asic.get_docker_name("swss")
+    feature_name = "swss"
+    container_name = asic.get_docker_name(feature_name)
     program_name = "orchagent"
 
     pre_lldpctl_facts = get_num_lldpctl_facts(duthost, enum_frontend_asic_index)


### PR DESCRIPTION
Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/15715

Otherwise we're failing at 

![image](https://github.com/user-attachments/assets/5d4b6e6f-ae18-4306-8378-cd9d9c7a85fb)



…(#15715)

What is the motivation for this PR?
The test test_lldp_neighbor_post_orchagent_reboot fails on multi-asic system. The test tries to disable autorestart feature for swss by using the namespace container name, e.g., swss0, swss1, etc

For config feature autorestart disable, it needs to use 'swss' as global feature name

How did you do it?
Changed code to use 'swss' as feature name without using namespace id

How did you verify/test it?
run sonic-mgmt test_lldp.py

---------

Signed-off-by: Anand Mehra anamehra@cisco.com