### PR TITLE
Porting 18564 to msft.202405: T2:snappi_tests:Add a fixture to disable voq watchdog, use it in pfc scripts.

### DIFF
--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -70,3 +70,30 @@ def setup_markings_dut(duthost, localhost, **kwargs):
     if reboot_required:
         duthost.copy(content=json.dumps(json_contents, sort_keys=True, indent=4), dest=config_file)
         reboot(duthost, localhost)
+
+
+def copy_dshell_script_cisco_8000(dut, asic, dshell_script, script_name):
+    if dut.facts['asic_type'] != "cisco-8000":
+        raise RuntimeError("This function should have been called only for cisco-8000.")
+
+    script_path = "/tmp/{}".format(script_name)
+    dut.copy(content=dshell_script, dest=script_path)
+    if dut.sonichost.is_multi_asic:
+        dest = f"syncd{asic}"
+    else:
+        dest = "syncd"
+    dut.docker_copy_to_all_asics(
+        container_name=dest,
+        src=script_path,
+        dst="/")
+
+
+def copy_set_voq_watchdog_script_cisco_8000(dut, asic="", enable=True):
+    dshell_script = '''
+from common import d0
+def set_voq_watchdog(enable):
+    d0.set_bool_property(sdk.la_device_property_e_VOQ_WATCHDOG_ENABLED, enable)
+set_voq_watchdog({})
+'''.format(enable)
+
+    copy_dshell_script_cisco_8000(dut, asic, dshell_script, script_name="set_voq_watchdog.py")

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -16,7 +16,8 @@ from tests.common.fixtures.ptfhost_utils import ptf_portmap_file  # noqa F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.mellanox_data import is_mellanox_device as isMellanoxDevice
-from tests.common.cisco_data import is_cisco_device
+from tests.common.cisco_data import is_cisco_device, copy_set_voq_watchdog_script_cisco_8000, \
+        copy_dshell_script_cisco_8000
 from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, dualtor_ports, is_tunnel_qos_remap_enabled  # noqa F401
 from tests.common.dualtor.mux_simulator_control \
     import toggle_all_simulator_ports, get_mux_status, check_mux_status, validate_check_result  # noqa F401
@@ -2639,21 +2640,6 @@ class QosSaiBase(QosBase):
                         return True
         return False
 
-    def copy_dshell_script_cisco_8000(self, dut, asic, dshell_script, script_name):
-        if dut.facts['asic_type'] != "cisco-8000":
-            raise RuntimeError("This function should have been called only for cisco-8000.")
-
-        script_path = "/tmp/{}".format(script_name)
-        dut.copy(content=dshell_script, dest=script_path)
-        if dut.sonichost.is_multi_asic:
-            dest = f"syncd{asic}"
-        else:
-            dest = "syncd"
-        dut.docker_copy_to_all_asics(
-            container_name=dest,
-            src=script_path,
-            dst="/")
-
     def copy_set_cir_script_cisco_8000(self, dut, ports, asic="", speed="10000000"):
         dshell_script = '''
 from common import *
@@ -2670,7 +2656,7 @@ def set_port_cir(interface, rate):
         for intf in ports:
             dshell_script += f'\nset_port_cir("{intf}", {speed})'
 
-        self.copy_dshell_script_cisco_8000(dut, asic, dshell_script, script_name="set_scheduler.py")
+        copy_dshell_script_cisco_8000(dut, asic, dshell_script, script_name="set_scheduler.py")
 
     @pytest.fixture(scope="function", autouse=False)
     def set_cir_change(self, get_src_dst_asic_and_duts, dutConfig):
@@ -2750,16 +2736,6 @@ def set_port_cir(interface, rate):
                         "Changing lacp timer multiplier to default for %s in %s" % (neighbor_lag_member, peer_device))
                     vm_host.no_lacp_time_multiplier(neighbor_lag_member)
 
-    def copy_set_voq_watchdog_script_cisco_8000(self, dut, asic="", enable=True):
-        dshell_script = '''
-from common import d0
-def set_voq_watchdog(enable):
-    d0.set_bool_property(sdk.la_device_property_e_VOQ_WATCHDOG_ENABLED, enable)
-set_voq_watchdog({})
-'''.format(enable)
-
-        self.copy_dshell_script_cisco_8000(dut, asic, dshell_script, script_name="set_voq_watchdog.py")
-
     @pytest.fixture(scope='class', autouse=True)
     def disable_voq_watchdog(self, duthosts, get_src_dst_asic_and_duts, dutConfig):
         dst_dut = get_src_dst_asic_and_duts['dst_dut']
@@ -2784,7 +2760,7 @@ set_voq_watchdog({})
 
         # Disable voq watchdog.
         for (dut, asic_index) in zip(dut_list, asic_index_list):
-            self.copy_set_voq_watchdog_script_cisco_8000(
+            copy_set_voq_watchdog_script_cisco_8000(
                 dut=dut,
                 asic=asic_index,
                 enable=False)
@@ -2797,7 +2773,7 @@ set_voq_watchdog({})
 
         # Enable voq watchdog.
         for (dut, asic_index) in zip(dut_list, asic_index_list):
-            self.copy_set_voq_watchdog_script_cisco_8000(
+            copy_set_voq_watchdog_script_cisco_8000(
                 dut=dut,
                 asic=asic_index,
                 enable=True)

--- a/tests/snappi_tests/cisco/helper.py
+++ b/tests/snappi_tests/cisco/helper.py
@@ -1,0 +1,32 @@
+# Helper functions to be used only for cisco platforms.
+from tests.common.cisco_data import copy_set_voq_watchdog_script_cisco_8000
+import pytest
+
+
+@pytest.fixture(scope='module', autouse=True)
+def disable_voq_watchdog(duthosts):
+    if duthosts[0].facts['asic_type'] != "cisco-8000":
+        yield
+        return
+
+    for duthost in duthosts:
+        modify_voq_watchdog_cisco_8000(duthost, False)
+
+    yield
+
+    for duthost in duthosts:
+        modify_voq_watchdog_cisco_8000(duthost, True)
+
+
+def modify_voq_watchdog_cisco_8000(duthost, enable):
+    asics = duthost.get_asic_ids()
+
+    '''
+    # Enable when T0/T1 supports voq_watchdog
+    #if not asics:
+    #    copy_set_voq_watchdog_script_cisco_8000(duthost, "", enable=enable)
+    '''
+
+    for asic in asics:
+        copy_set_voq_watchdog_script_cisco_8000(duthost, asic, enable=enable)
+        duthost.shell(f"sudo show platform npu script -n asic{asic} -s set_voq_watchdog.py")

--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -18,7 +18,7 @@ from tests.common.snappi_tests.snappi_fixtures import get_snappi_ports_for_rdma,
 from tests.common.snappi_tests.qos_fixtures import reapply_pfcwd, get_pfcwd_config
 from tests.common.snappi_tests.common_helpers import \
         stop_pfcwd, disable_packet_aging, enable_packet_aging
-
+from tests.snappi_tests.cisco.helper import modify_voq_watchdog_cisco_8000
 
 logger = logging.getLogger(__name__)
 
@@ -423,6 +423,8 @@ def reboot_duts_and_disable_wd(setup_ports_and_dut, localhost, request):
         pfcwd_value[duthost.hostname] = get_pfcwd_config(duthost)
         stop_pfcwd(duthost)
         disable_packet_aging(duthost)
+        if duthost.facts['asic_type'] == "cisco-8000":
+            modify_voq_watchdog_cisco_8000(duthost, False)
 
     yield
 

--- a/tests/snappi_tests/pfc/test_global_pause_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_global_pause_with_snappi.py
@@ -11,6 +11,7 @@ from tests.common.snappi_tests.qos_fixtures import lossless_prio_list, prio_dscp
 from tests.snappi_tests.pfc.files.helper import run_pfc_test                      # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/snappi_tests/pfc/test_lossless_response_to_external_pause_storms.py
+++ b/tests/snappi_tests/pfc/test_lossless_response_to_external_pause_storms.py
@@ -13,6 +13,7 @@ from tests.snappi_tests.pfc.files.lossless_response_to_external_pause_storms_hel
      run_lossless_response_to_external_pause_storms_test,
     )
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 

--- a/tests/snappi_tests/pfc/test_lossless_response_to_throttling_pause_storms.py
+++ b/tests/snappi_tests/pfc/test_lossless_response_to_throttling_pause_storms.py
@@ -13,6 +13,7 @@ from tests.snappi_tests.pfc.files.lossless_response_to_throttling_pause_storms_h
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import setup_ports_and_dut, multidut_port_info   # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict     # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]

--- a/tests/snappi_tests/pfc/test_m2o_fluctuating_lossless.py
+++ b/tests/snappi_tests/pfc/test_m2o_fluctuating_lossless.py
@@ -11,6 +11,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
 from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut   # noqa: F401
 from tests.snappi_tests.pfc.files.m2o_fluctuating_lossless_helper import run_m2o_fluctuating_lossless_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen')]
 

--- a/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless.py
+++ b/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless.py
@@ -13,6 +13,7 @@ from tests.snappi_tests.pfc.files.m2o_oversubscribe_lossless_helper import (
     )
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import setup_ports_and_dut, multidut_port_info   # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 

--- a/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless_lossy.py
+++ b/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless_lossy.py
@@ -14,6 +14,7 @@ from tests.snappi_tests.pfc.files.m2o_oversubscribe_lossless_lossy_helper import
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams            # noqa: F401
 from tests.snappi_tests.files.helper import setup_ports_and_dut, multidut_port_info  # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict        # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 

--- a/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossy.py
+++ b/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossy.py
@@ -11,6 +11,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
 from tests.snappi_tests.pfc.files.m2o_oversubscribe_lossy_helper import run_pfc_m2o_oversubscribe_lossy_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import setup_ports_and_dut, multidut_port_info   # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen')]
 

--- a/tests/snappi_tests/pfc/test_pfc_mixed_speed.py
+++ b/tests/snappi_tests/pfc/test_pfc_mixed_speed.py
@@ -12,6 +12,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_
 from tests.snappi_tests.variables import MIXED_SPEED_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.pfc.files.mixed_speed_multidut_helper import run_pfc_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 import logging
 logger = logging.getLogger(__name__)

--- a/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
+++ b/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
@@ -13,6 +13,7 @@ from tests.snappi_tests.pfc.files.pfc_congestion_helper import run_pfc_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.files.helper import adjust_test_flow_rate
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 import logging
 logger = logging.getLogger(__name__)

--- a/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
@@ -13,6 +13,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
 from tests.snappi_tests.pfc.files.helper import run_pfc_test
 import logging
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 
 logger = logging.getLogger(__name__)

--- a/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
@@ -14,6 +14,7 @@ from tests.snappi_tests.pfc.files.helper import run_pfc_test
 import logging
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import reboot_duts, setup_ports_and_dut, multidut_port_info  # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]

--- a/tests/snappi_tests/pfc/test_pfc_pause_response_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_response_with_snappi.py
@@ -10,6 +10,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list, disable_pfcwd          # noqa F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/snappi_tests/pfc/test_pfc_pause_unset_bit_enable_vector.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_unset_bit_enable_vector.py
@@ -10,6 +10,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list, disable_pfcwd # noqa F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/snappi_tests/pfc/test_pfc_pause_zero_mac.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_zero_mac.py
@@ -10,6 +10,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list, disable_pfcwd  # noqa F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/snappi_tests/pfc/test_pfc_port_congestion.py
+++ b/tests/snappi_tests/pfc/test_pfc_port_congestion.py
@@ -12,6 +12,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.pfc.files.pfc_congestion_helper import run_pfc_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 import logging
 logger = logging.getLogger(__name__)

--- a/tests/snappi_tests/pfc/test_tx_drop_counter_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_tx_drop_counter_with_snappi.py
@@ -13,6 +13,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
 from tests.snappi_tests.pfc.files.helper import run_tx_drop_counter
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut  # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]

--- a/tests/snappi_tests/pfc/test_valid_pfc_frame_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_valid_pfc_frame_with_snappi.py
@@ -11,6 +11,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
     lossy_prio_list, disable_pfcwd # noqa F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.common_helpers import packet_capture
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/snappi_tests/pfc/test_valid_src_mac_pfc_frame.py
+++ b/tests/snappi_tests/pfc/test_valid_src_mac_pfc_frame.py
@@ -13,6 +13,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.common_helpers import packet_capture
 from tests.common.cisco_data import is_cisco_device
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Recently cisco-8000 enabled VoQ Watchdog feature, which is similar to PfcWd feature. It drops the packets which get stuck in voq, and resets all the counters, when the interface is experiencing congestion due to pfc Xoff. This causes a number of failures in the PFC scripts which assume there is no watchdog. To prevent these failures, we add a fixture to disable the voq Watchdog in all DUT asics, and enable it at the end of the script.

This PR uses the voq-wd-disable function implemented in https://github.com/sonic-net/sonic-mgmt/pull/17937

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Pls see description.
#### How did you do it?
Implemented a new fixture to disable voq Watchdog.

#### How did you verify/test it?
Ran the failing test:
```
====================================================================================================================== warnings summary ======================================================================================================================
../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py: 14 warnings
  /usr/lib/python3/dist-packages/urllib3/connectionpool.py:1004: InsecureRequestWarning: Unverified HTTPS request is being made to host '172.27.147.46'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================================================== PASSES ===========================================================================================================================
___________________________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info0-yy39top-lc2|3] ___________________________________________________________________________________________
___________________________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info0-yy39top-lc2|4] ___________________________________________________________________________________________
___________________________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info1-yy39top-lc2|3] ___________________________________________________________________________________________
___________________________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info1-yy39top-lc2|4] ___________________________________________________________________________________________
______________________________________________________________________________________________ test_pfc_pause_counter_check[multidut_port_info0-yy39top-lc2|3] _______________________________________________________________________________________________
______________________________________________________________________________________________ test_pfc_pause_counter_check[multidut_port_info0-yy39top-lc2|4] _______________________________________________________________________________________________
______________________________________________________________________________________________ test_pfc_pause_counter_check[multidut_port_info1-yy39top-lc2|3] _______________________________________________________________________________________________
______________________________________________________________________________________________ test_pfc_pause_counter_check[multidut_port_info1-yy39top-lc2|4] _______________________________________________________________________________________________
__________________________________________________________________________________________________ test_pfc_pause_multi_lossless_prio[multidut_port_info0] ___________________________________________________________________________________________________
__________________________________________________________________________________________________ test_pfc_pause_multi_lossless_prio[multidut_port_info1] ___________________________________________________________________________________________________
_____________________________________________________________________________________ test_pfc_pause_single_lossless_prio_reboot[multidut_port_info0-cold-yy39top-lc2|4] _____________________________________________________________________________________
_____________________________________________________________________________________ test_pfc_pause_single_lossless_prio_reboot[multidut_port_info1-cold-yy39top-lc2|4] _____________________________________________________________________________________
____________________________________________________________________________________________ test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info0-cold] _____________________________________________________________________________________________
____________________________________________________________________________________________ test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info1-cold] _____________________________________________________________________________________________
------------------------------------------------------------------------------ generated xml file: /run_logs/ixia/disable-voq-wd/2025-05-23-17-34-59/tr_2025-05-23-17-34-59.xml ------------------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
================================================================================================================== short test summary info ===================================================================================================================
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info0-yy39top-lc2|3]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info0-yy39top-lc2|4]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info1-yy39top-lc2|3]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info1-yy39top-lc2|4]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_counter_check[multidut_port_info0-yy39top-lc2|3]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_counter_check[multidut_port_info0-yy39top-lc2|4]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_counter_check[multidut_port_info1-yy39top-lc2|3]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_counter_check[multidut_port_info1-yy39top-lc2|4]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio[multidut_port_info0]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio[multidut_port_info1]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[multidut_port_info0-cold-yy39top-lc2|4]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[multidut_port_info1-cold-yy39top-lc2|4]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info0-cold]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info1-cold]
SKIPPED [2] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:202: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:202: Reboot type fast is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:262: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:262: Reboot type fast is not supported on cisco-8000 switches
================================================================================================== 14 passed, 8 skipped, 15 warnings in 10452.26s (2:54:12) ==================================================================================================
sonic@snappi-sonic-mgmt-msft-t2-400g-WB:/data/tests$ ```

#### Any platform specific information?
Specific to cisco-8000.