### PR TITLE
Revert "[action] [PR:18699] fix: correct DUT variable name in startup tsa pretest (#344)"

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -394,7 +394,7 @@ def test_disable_startup_tsa_tsb_service(duthosts, localhost):
                 duthost.shell("sudo mv {} {}".format(startup_tsa_tsb_file_path, backup_tsa_tsb_file_path))
                 output = duthost.shell("TSB", module_ignore_errors=True)
                 pytest_assert(not output['rc'], "Failed TSB")
-                dut.shell("sudo config save -y")
+                duthost.shell("sudo config save -y")
         else:
             logger.info("{} file does not exist in the specified path on dut {}".
                         format(startup_tsa_tsb_file_path, duthost.hostname))


### PR DESCRIPTION
This reverts commit 7551587556a45487974c1af5d665de9892adadeb.

I thought we cherry picked the multithreading run of pretest PR (https://github.com/sonic-net/sonic-mgmt/pull/17493) into msft.202405 but we never did, so the PR https://github.com/sonic-net/sonic-mgmt/pull/18699 should never be cherry picked into msft.202405 as it's only a fix when test_pretest.py runs with multithreading.

In msft.202405 branch, we are running test_pretest.py (e.g. test_disable_startup_tsa_tsb_service()) in a normal for loop: https://github.com/Azure/sonic-mgmt.msft/blob/202405/tests/test_pretest.py#L385, so we should use duthost instead of dut