### PR TITLE
Add 128 my sid support into SRv6 data plane script

### DIFF
--- a/tests/common/helpers/srv6_helper.py
+++ b/tests/common/helpers/srv6_helper.py
@@ -1,0 +1,503 @@
+import logging
+import sys
+from io import StringIO
+import ptf.testutils as testutils
+import ptf.packet as scapy
+from ptf.mask import Mask
+
+logger = logging.getLogger(__name__)
+
+
+class SRv6():
+    uN = 'uN'
+    prefix_len = '48'
+    pipe_mode = 'pipe'
+    uniform_mode = 'uniform'
+
+
+class SRv6Packets():
+    '''
+    Define the ipv6 packets used in srv6 test
+    Each item was defined with actions and packet type as well as segment left and segment list, destination ip
+    '''
+    srv6_next_header = {
+        scapy.IP: 4,
+        scapy.IPv6: 41
+    }
+
+    @classmethod
+    def generate_srv6_packets(cls, my_locator_list, srv6_packet_type):
+        """
+        Generate SRv6 test packets based on the provided locator list.
+        Each packet will have different configurations for comprehensive testing.
+
+        Args:
+            my_locator_list (list): List of locator entries
+            srv6_packet_type (str): Type of SRv6 packet to generate
+
+        Returns:
+            list: List of SRv6 packet configurations
+        """
+        srv6_packets = []
+
+        # Define base packet types with different configurations
+        base_packets = [
+            {  # 1
+                'action': 'uN',
+                'srv6_packet_type': 'no_srh',
+                'validate_dip_shift': True,
+                'validate_usd_flavor': False,
+                'srh_seg_list': None,
+                'srh_seg_left': 0,
+                'inner_pkt_ver': '6',
+                'outer_dscp': 0,
+                'inner_dscp': 0,
+                'exp_dst_ipv6': None,
+                'exp_srh_seg_left': 0,
+                'exp_inner_dscp_pipe': 0,
+                'exp_outer_dscp_uniform': 0,
+                'exp_process_result': 'forward'
+            },
+            {  # 2
+                'action': 'uN',
+                'srv6_packet_type': 'srh',
+                'validate_dip_shift': True,
+                'validate_usd_flavor': False,
+                'srh_seg_list': 1,
+                'srh_seg_left': 0,
+                'inner_pkt_ver': '6',
+                'outer_dscp': 0,
+                'inner_dscp': 0,
+                'exp_dst_ipv6': None,
+                'exp_srh_seg_left': 0,
+                'exp_inner_dscp_pipe': 0,
+                'exp_outer_dscp_uniform': 0,
+                'exp_process_result': 'forward'
+            },
+            {  # 3
+                'action': 'uN',
+                'srv6_packet_type': 'srh',
+                'validate_dip_shift': True,
+                'validate_usd_flavor': False,
+                'srh_seg_list': 2,
+                'srh_seg_left': 0,
+                'inner_pkt_ver': '6',
+                'outer_dscp': 0,
+                'inner_dscp': 0,
+                'exp_dst_ipv6': None,
+                'exp_srh_seg_left': 0,
+                'exp_inner_dscp_pipe': 0,
+                'exp_outer_dscp_uniform': 0,
+                'exp_process_result': 'forward'
+            },
+            {  # 4
+                'action': 'uN',
+                'srv6_packet_type': 'srh',
+                'validate_dip_shift': False,
+                'validate_usd_flavor': False,
+                'srh_seg_list': 1,
+                'srh_seg_left': 1,
+                'inner_pkt_ver': '6',
+                'outer_dscp': 32,
+                'inner_dscp': 48,
+                'exp_dst_ipv6': None,
+                'exp_srh_seg_left': 0,
+                'exp_inner_dscp_pipe': 48,
+                'exp_outer_dscp_uniform': 32,
+                'exp_process_result': 'forward'
+            },
+            {  # 5
+                'action': 'uN',
+                'srv6_packet_type': 'srh',
+                'validate_dip_shift': False,
+                'validate_usd_flavor': False,
+                'srh_seg_list': 2,
+                'srh_seg_left': 2,
+                'inner_pkt_ver': '6',
+                'outer_dscp': 16,
+                'inner_dscp': 24,
+                'exp_dst_ipv6': None,
+                'exp_srh_seg_left': 1,
+                'exp_inner_dscp_pipe': 24,
+                'exp_outer_dscp_uniform': 16,
+                'exp_process_result': 'forward'
+            },
+            {  # 6
+                'action': 'uN',
+                'srv6_packet_type': 'no_srh',
+                'validate_dip_shift': False,
+                'validate_usd_flavor': True,
+                'srh_seg_list': None,
+                'srh_seg_left': 0,
+                'inner_pkt_ver': '6',
+                'outer_dscp': 48,
+                'inner_dscp': 56,
+                'exp_dst_ipv6': None,
+                'exp_srh_seg_left': 0,
+                'exp_inner_dscp_pipe': 56,
+                'exp_outer_dscp_uniform': 48,
+                'exp_process_result': 'forward'
+            },
+            {  # 7
+                'action': 'uN',
+                'srv6_packet_type': 'srh',
+                'validate_dip_shift': False,
+                'validate_usd_flavor': True,
+                'srh_seg_list': 1,
+                'srh_seg_left': 0,
+                'inner_pkt_ver': '6',
+                'outer_dscp': 48,
+                'inner_dscp': 56,
+                'exp_dst_ipv6': None,
+                'exp_srh_seg_left': 0,
+                'exp_inner_dscp_pipe': 56,
+                'exp_outer_dscp_uniform': 48,
+                'exp_process_result': 'forward'
+            },
+            {  # 8
+                'action': 'uN',
+                'srv6_packet_type': 'srh',
+                'validate_dip_shift': False,
+                'validate_usd_flavor': True,
+                'srh_seg_list': 2,
+                'srh_seg_left': 0,
+                'inner_pkt_ver': '6',
+                'outer_dscp': 48,
+                'inner_dscp': 56,
+                'exp_dst_ipv6': None,
+                'exp_srh_seg_left': 0,
+                'exp_inner_dscp_pipe': 56,
+                'exp_outer_dscp_uniform': 48,
+                'exp_process_result': 'forward'
+            }
+        ]
+
+        # Use dictionary mapping for packet type filtering
+        packet_type_map = {
+            'srh': 'srh',
+            'no_srh': 'no_srh'
+        }
+        filtered_base_packets = [
+            packet for packet in base_packets
+            if packet['srv6_packet_type'] == packet_type_map.get(srv6_packet_type, 'no_srh')
+        ]
+        # Generate packets for each SID
+        for i, sid_entry in enumerate(my_locator_list):
+            # Select base packet type based on index
+            base_type = filtered_base_packets[i % len(filtered_base_packets)]
+            current_sid_container = sid_entry[1]
+            usid = sid_entry[2]
+
+            # Create packet configuration
+            packet = base_type.copy()
+            packet['inner_src_ip'] = '1.1.1.1'
+            packet['inner_dst_ip'] = '2.2.2.2'
+            packet['inner_src_ipv6'] = '2000::1'
+            packet['inner_dst_ipv6'] = '3000::2'
+            packet['outer_src_ipv6'] = '1000:1000::1'
+            packet['dst_ipv6'] = current_sid_container
+            next_sid_index = (i + 1) % len(my_locator_list)
+            next_usid = 1000 + int(my_locator_list[next_sid_index][2])
+
+            if base_type['validate_dip_shift']:
+                # Prepare the expected destination IPv6 address for DIP shift validation
+                packet['dst_ipv6'] = current_sid_container.replace(f'{usid}::', f'{usid}:{next_usid}::')
+                packet['exp_dst_ipv6'] = current_sid_container.replace(f'{usid}::', f'{next_usid}::')
+
+            temp_sid_container = current_sid_container.replace(f'{usid}::', f'{next_usid}::')
+            # Set segment list based on base type
+            if base_type['srh_seg_list'] == 1:
+                packet['srh_seg_list'] = [temp_sid_container]
+            elif base_type['srh_seg_list'] == 2:
+                packet['srh_seg_list'] = [current_sid_container, temp_sid_container]
+
+            # Set expected destination IPv6 if not validating USD flavor
+            if not base_type['validate_usd_flavor']:
+                packet['exp_dst_ipv6'] = temp_sid_container
+
+            packet['exp_inner_dscp_pipe'] = packet['inner_dscp'] = packet['exp_outer_dscp_uniform'] = \
+                packet['outer_dscp'] = i % 64
+
+            if packet['validate_usd_flavor']:
+                packet['exp_outer_dscp_uniform'] = packet['outer_dscp'] = i % 64
+                packet['exp_inner_dscp_pipe'] = packet['inner_dscp'] = (packet['outer_dscp'] + 8) % 64
+
+            # Alternate between IPv4 and IPv6 for inner packet
+            if i % 2 == 1:
+                packet['inner_pkt_ver'] = '4'
+
+            srv6_packets.append(packet)
+
+        return srv6_packets
+
+
+def dump_packet_detail(pkt):
+    _stdout, sys.stdout = sys.stdout, StringIO()
+    try:
+        pkt.show()
+        return sys.stdout.getvalue()
+    finally:
+        sys.stdout = _stdout
+
+
+def create_srv6_packet(
+        outer_src_mac,
+        outer_dst_mac,
+        outer_src_pkt_ip,
+        outer_dst_pkt_ip,
+        srv6_action,
+        inner_dscp,
+        outer_dscp,
+        exp_outer_dst_pkt_ip,
+        exp_seg_left,
+        exp_dscp_pipe,
+        exp_dscp_uniform,
+        seg_left,
+        sef_list,
+        inner_pkt_ver,
+        dscp_mode,
+        router_mac,
+        inner_src_ip,
+        inner_dst_ip,
+        inner_src_ipv6,
+        inner_dst_ipv6):
+    """
+    Create SRv6 packets for testing
+
+    Args:
+        outer_src_mac (str): Outer source MAC address
+        outer_dst_mac (str): Outer destination MAC address
+        outer_src_pkt_ip (str): Outer source IP address
+        outer_dst_pkt_ip (str): Outer destination IP address
+        srv6_action (str): SRv6 action type
+        inner_dscp (int): Inner DSCP value
+        outer_dscp (int): Outer DSCP value
+        exp_outer_dst_pkt_ip (str): Expected outer destination IP address
+        exp_seg_left (int): Expected segment left value
+        exp_dscp_pipe (int): Expected DSCP value in pipe mode
+        exp_dscp_uniform (int): Expected DSCP value in uniform mode
+        seg_left (int): Segment left value
+        sef_list (list): Segment list
+        inner_pkt_ver (str): Inner packet version ('4' for IPv4, '6' for IPv6)
+        dscp_mode (str): DSCP mode ('pipe' or 'uniform')
+        router_mac (str): Router MAC address
+        inner_src_ip (str): Inner source IPv4 address
+        inner_dst_ip (str): Inner destination IPv4 address
+        inner_src_ipv6 (str): Inner source IPv6 address
+        inner_dst_ipv6 (str): Inner destination IPv6 address
+
+    Returns:
+        tuple: (srv6_pkt, exp_pkt) - Created SRv6 packet and expected packet
+    """
+    srv6_next_header = SRv6Packets.srv6_next_header
+
+    if dscp_mode == SRv6.uniform_mode:
+        exp_dscp = exp_dscp_uniform
+    else:
+        exp_dscp = exp_dscp_pipe
+
+    if inner_pkt_ver == '4':
+        inner_pkt = testutils.simple_tcp_packet(
+            eth_src=router_mac,
+            ip_src=inner_src_ip,
+            ip_dst=inner_dst_ip,
+            ip_dscp=inner_dscp if inner_dscp else 0
+        )
+
+        exp_inner_pkt = testutils.simple_tcp_packet(
+            eth_src=router_mac,
+            ip_src=inner_src_ip,
+            ip_dst=inner_dst_ip,
+            ip_dscp=exp_dscp if exp_dscp else 0
+        )
+        scapy_ver = scapy.IP
+    else:
+        inner_pkt = testutils.simple_tcpv6_packet(
+            eth_src=router_mac,
+            ipv6_src=inner_src_ipv6,
+            ipv6_dst=inner_dst_ipv6,
+            ipv6_dscp=inner_dscp if inner_dscp else 0
+        )
+
+        exp_inner_pkt = testutils.simple_tcpv6_packet(
+            eth_src=router_mac,
+            ipv6_src=inner_src_ipv6,
+            ipv6_dst=inner_dst_ipv6,
+            ipv6_dscp=exp_dscp if exp_dscp else 0
+        )
+        scapy_ver = scapy.IPv6
+
+    if srv6_action == SRv6.uN:
+        if exp_outer_dst_pkt_ip:
+            if seg_left or sef_list:
+                logger.info('Create SRv6 packets with SRH')
+                srv6_pkt = testutils.simple_ipv6_sr_packet(
+                    eth_dst=outer_dst_mac,
+                    eth_src=outer_src_mac,
+                    ipv6_src=outer_src_pkt_ip,
+                    ipv6_dst=outer_dst_pkt_ip,
+                    srh_seg_left=seg_left,
+                    srh_seg_list=sef_list,
+                    ipv6_tc=outer_dscp * 4 if outer_dscp else 0,
+                    srh_nh=srv6_next_header[scapy_ver],
+                    inner_frame=inner_pkt[scapy_ver],
+                )
+                exp_pkt = testutils.simple_ipv6_sr_packet(
+                    eth_dst=outer_dst_mac,
+                    eth_src=outer_src_mac,
+                    ipv6_src=outer_src_pkt_ip,
+                    ipv6_dst=exp_outer_dst_pkt_ip,
+                    srh_seg_left=exp_seg_left,
+                    srh_seg_list=sef_list,
+                    ipv6_tc=exp_dscp * 4 if exp_dscp else 0,
+                    srh_nh=srv6_next_header[scapy_ver],
+                    inner_frame=exp_inner_pkt[scapy_ver],
+                )
+            else:
+                logger.info('Create SRv6 packet with reduced SRH(no SRH header)')
+                srv6_pkt = testutils.simple_ipv6ip_packet(
+                    eth_dst=outer_dst_mac,
+                    eth_src=outer_src_mac,
+                    ipv6_src=outer_src_pkt_ip,
+                    ipv6_dst=outer_dst_pkt_ip,
+                    ipv6_tc=outer_dscp * 4 if outer_dscp else 0,
+                    inner_frame=inner_pkt[scapy_ver],
+                )
+                exp_pkt = testutils.simple_ipv6ip_packet(
+                    eth_dst=outer_dst_mac,
+                    eth_src=outer_src_mac,
+                    ipv6_src=outer_src_pkt_ip,
+                    ipv6_dst=exp_outer_dst_pkt_ip,
+                    ipv6_tc=exp_dscp * 4 if exp_dscp else 0,
+                    inner_frame=exp_inner_pkt[scapy_ver],
+                )
+
+            exp_pkt['IPv6'].hlim -= 1
+            exp_pkt = Mask(exp_pkt)
+
+            logger.info('Do not care packet ethernet destination address')
+            exp_pkt.set_do_not_care_packet(scapy.Ether, 'dst')
+            logger.info('Do not care packet ethernet source address')
+            exp_pkt.set_do_not_care_packet(scapy.Ether, 'src')
+
+        else:
+            if seg_left or sef_list:
+                logger.info('Create SRv6 packets with SRH for USD flavor validation')
+                srv6_pkt = testutils.simple_ipv6_sr_packet(
+                    eth_dst=outer_dst_mac,
+                    eth_src=outer_src_mac,
+                    ipv6_src=outer_src_pkt_ip,
+                    ipv6_dst=outer_dst_pkt_ip,
+                    srh_seg_left=seg_left,
+                    srh_seg_list=sef_list,
+                    ipv6_tc=outer_dscp * 4 if outer_dscp else 0,
+                    srh_nh=srv6_next_header[scapy_ver],
+                    inner_frame=inner_pkt[scapy_ver],
+                )
+            else:
+                logger.info('Create SRv6 packets without SRH for USD flavor validation')
+                srv6_pkt = testutils.simple_ipv6ip_packet(
+                    eth_dst=outer_dst_mac,
+                    eth_src=outer_src_mac,
+                    ipv6_src=outer_src_pkt_ip,
+                    ipv6_dst=outer_dst_pkt_ip,
+                    ipv6_tc=outer_dscp * 4 if outer_dscp else 0,
+                    inner_frame=inner_pkt[scapy_ver],
+                )
+
+            if inner_pkt_ver == '4':
+                exp_inner_pkt['IP'].ttl -= 1
+                exp_pkt = Mask(exp_inner_pkt)
+                logger.info('Do not care packet checksum')
+                exp_pkt.set_do_not_care_packet(scapy.IP, "chksum")
+            else:
+                exp_inner_pkt['IPv6'].hlim -= 1
+                exp_pkt = Mask(exp_inner_pkt)
+            logger.info('Do not care packet ethernet destination address')
+            exp_pkt.set_do_not_care_packet(scapy.Ether, 'dst')
+
+    return srv6_pkt, exp_pkt
+
+
+def send_verify_srv6_packet(
+        ptfadapter,
+        pkt,
+        exp_pkt,
+        exp_pro,
+        ptf_src_port_id,
+        ptf_dst_port_ids,
+        packet_num=10):
+    """
+    Send and verify SRv6 packets
+
+    Args:
+        ptfadapter: PTF adapter object
+        pkt: Packet to send
+        exp_pkt: Expected packet
+        exp_pro (str): Expected process result ('forward' or 'drop')
+        ptf_src_port_id (int): Source PTF port ID
+        ptf_dst_port_ids (list): List of destination PTF port IDs
+        packet_num (int): Number of packets to send (default: 10)
+    """
+    ptfadapter.dataplane.flush()
+    ptfadapter.dataplane.set_qlen(1000000)
+    logger.info(f'Send SRv6 packet(s) from PTF port {ptf_src_port_id} to upstream')
+    testutils.send(ptfadapter, ptf_src_port_id, pkt, count=packet_num)
+    logger.info('SRv6 packet format:\n ---------------------------')
+    logger.info(f'{dump_packet_detail(pkt)}\n---------------------------')
+    logger.info('Expect receive SRv6 packet format:\n ---------------------------')
+    logger.info(f'{dump_packet_detail(exp_pkt.exp_pkt)}\n---------------------------')
+
+    try:
+        if exp_pro == 'forward':
+            # set timeout to 60 to override the affection of huge BGP update exchange after config reload or bgp restart
+            port_index, _ = testutils.verify_packet_any_port(ptfadapter, exp_pkt, timeout=60, ports=ptf_dst_port_ids)
+            logger.info(f'Received packet(s) on port {ptf_dst_port_ids[port_index]}\n')
+        elif exp_pro == 'drop':
+            testutils.verify_no_packet_any(ptfadapter, exp_pkt, ports=ptf_dst_port_ids)
+            logger.info(f'No packet received on {ptf_dst_port_ids}')
+        else:
+            logger.error(f'Wrong expected process result: {exp_pro}')
+    except AssertionError as detail:
+        raise detail
+
+
+def create_srv6_locator(duthost,
+                        locator_name,
+                        prefix,
+                        block_len=32,
+                        node_len=16,
+                        func_len=0,
+                        arg_len=0):
+    logger.info(f'Configure locator: SRV6_MY_LOCATORS|{locator_name}')
+    duthost.shell(
+        f'sonic-db-cli CONFIG_DB HSET "SRV6_MY_LOCATORS|{locator_name}" '
+        f'"prefix" "{prefix}" '
+        f'"block_len" "{block_len}" '
+        f'"node_len" "{node_len}" '
+        f'"func_len" "{func_len}" '
+        f'"arg_len" "{arg_len}"')
+
+
+def del_srv6_locator(duthost, locator_name):
+    logger.info(f'Delete locator: SRV6_MY_LOCATORS|{locator_name}')
+    duthost.shell(f'sonic-db-cli CONFIG_DB DEL "SRV6_MY_LOCATORS|{locator_name}"')
+
+
+def create_srv6_sid(duthost,
+                    locator_name,
+                    ip_addr,
+                    action=SRv6.uN,
+                    decap_vrf='default',
+                    decap_dscp_mode=SRv6.uniform_mode):
+    logger.info(f'Configure sid: SRV6_MY_SIDS|{locator_name}|{ip_addr}/{SRv6.prefix_len}')
+    duthost.shell(
+        f'sonic-db-cli CONFIG_DB HSET "SRV6_MY_SIDS|{locator_name}|{ip_addr}/{SRv6.prefix_len}" '
+        f'"action" "{action}" '
+        f'"decap_vrf" "{decap_vrf}" '
+        f'"decap_dscp_mode" "{decap_dscp_mode}"')
+
+
+def del_srv6_sid(duthost, locator_name, ip_addr):
+    logger.info(f'Delete sid: SRV6_MY_SIDS|{locator_name}|{ip_addr}/{SRv6.prefix_len}')
+    duthost.shell(f'sonic-db-cli CONFIG_DB DEL "SRV6_MY_SIDS|{locator_name}|{ip_addr}/{SRv6.prefix_len}"')

--- a/tests/srv6/conftest.py
+++ b/tests/srv6/conftest.py
@@ -1,0 +1,165 @@
+import pytest
+import time
+import re
+import logging
+import random
+from tests.common.utilities import wait_until
+from tests.common.helpers.ptf_tests_helper import get_stream_ptf_ports
+from tests.common.helpers.ptf_tests_helper import select_random_link
+from tests.common.helpers.ptf_tests_helper import downstream_links, upstream_links  # noqa F401
+from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
+from tests.common.helpers.srv6_helper import SRv6Packets, create_srv6_locator, del_srv6_locator, create_srv6_sid, \
+    del_srv6_sid
+from tests.srv6.srv6_utils import MyLocators, MySIDs, get_srv6_mysid_entry_usage, \
+    enable_srv6_counterpoll, disable_srv6_counterpoll, set_srv6_counterpoll_interval, verify_srv6_counterpoll_status, \
+    verify_srv6_crm_status, ROUTE_BASE
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='class')
+def prepare_param(rand_selected_dut, srv6_packet_type, downstream_links, upstream_links):  # noqa F811
+    prepare_param = {}
+    prepare_param['packet_num'] = 100
+    prepare_param['router_mac'] = rand_selected_dut.facts["router_mac"]
+    prepare_param['srv6_packets'] = SRv6Packets.generate_srv6_packets(MyLocators.my_locator_list, srv6_packet_type)
+    prepare_param['srv6_next_header'] = SRv6Packets.srv6_next_header
+
+    downlink = select_random_link(downstream_links)
+    uplink_ptf_ports = get_stream_ptf_ports(upstream_links)
+
+    assert downlink, "No downlink found"
+    assert uplink_ptf_ports, "No uplink found"
+    assert prepare_param['router_mac'], "No router MAC found"
+
+    prepare_param['ptf_downlink_port'] = downlink.get("ptf_port_id")
+    prepare_param['ptf_uplink_ports'] = uplink_ptf_ports
+
+    return prepare_param
+
+
+@pytest.fixture(scope='module')
+def srv6_crm_total_sids(rand_selected_dut):
+    '''
+    Get the default available SRV6 SID entries.
+    '''
+    output = rand_selected_dut.command('crm show summary')['stdout']
+    parsed = re.findall(r'Polling Interval: +(\d+) +second', output)
+    original_crm_polling_interval = int(parsed[0])
+
+    rand_selected_dut.command("crm config polling interval 1")
+    logger.info("Waiting 2 sec for CRM counters to become updated")
+    time.sleep(2)
+    mysid_crm_status = get_srv6_mysid_entry_usage(rand_selected_dut)
+
+    yield mysid_crm_status['total_count']
+
+    rand_selected_dut.command(f"crm config polling interval {original_crm_polling_interval}")
+
+
+def get_random_uplink_port(upstream_links, intf_infos):  # noqa F811
+    '''
+    Get a random uplink port that is used by the ipv6 interface info
+    '''
+    upstream_ports = set(upstream_links.keys())
+    intf_neighbor_map = {intf_info['interface']: intf_info['neighbor ip'] for intf_info in intf_infos}
+    common_ports = upstream_ports.intersection(intf_neighbor_map.keys())
+    if common_ports:
+        random_port = random.choice(list(common_ports))
+        return random_port, intf_neighbor_map[random_port]
+
+
+@pytest.fixture(scope="class", params=MySIDs.TUNNEL_MODE)
+def config_setup(request, rand_selected_dut, srv6_crm_total_sids, upstream_links):  # noqa F811
+    '''
+    Configure 128 instances of SRV6_MY_SIDS
+    '''
+    with allure.step('Create static route for SRv6'):
+        ipv6_intf_info = rand_selected_dut.show_and_parse('show ipv6 interface')
+        ifname, nexthop = get_random_uplink_port(upstream_links, ipv6_intf_info)
+        rand_selected_dut.command(f"sonic-db-cli CONFIG_DB HSET STATIC_ROUTE\\|default\\|{ROUTE_BASE}::/16 "
+                                  f"nexthop {nexthop} ifname {ifname}")
+
+    with allure.step('Enable SRv6 counterpoll'):
+        enable_srv6_counterpoll(rand_selected_dut)
+        set_srv6_counterpoll_interval(rand_selected_dut, 1000)
+        verify_srv6_counterpoll_status(rand_selected_dut, 'enable', 1000)
+
+    with allure.step('Create SRv6 Locators and SIDs'):
+        for locator_param in MyLocators.my_locator_list:
+            locator_name = locator_param[0]
+            locator_prefix = locator_param[1]
+            create_srv6_locator(rand_selected_dut, locator_name, locator_prefix)
+
+        for sid_param in MySIDs.MY_SID_LIST:
+            locator_name = sid_param[0]
+            ip_addr = sid_param[1]
+            action = sid_param[2]
+            vrf = sid_param[3]
+            dscp_mode = request.param
+            create_srv6_sid(rand_selected_dut, locator_name, ip_addr, action, vrf, dscp_mode)
+
+    with allure.step('Verify the CRM usage of SRv6 SID'):
+        used_mysid_num = len(MySIDs.MY_SID_LIST)
+        available_mysid_num = srv6_crm_total_sids - used_mysid_num
+        wait_until(10, 1, 0, verify_srv6_crm_status, rand_selected_dut, used_mysid_num, available_mysid_num)
+
+    rand_selected_dut.shell('sudo config save -y')
+
+    yield dscp_mode
+
+    with allure.step('Disable SRv6 counterpoll'):
+        disable_srv6_counterpoll(rand_selected_dut)
+        verify_srv6_counterpoll_status(rand_selected_dut, 'disable')
+
+    with allure.step('Delete SRv6 Locators and SIDs'):
+        for locator_param in MyLocators.my_locator_list:
+            locator_name = locator_param[0]
+            del_srv6_locator(rand_selected_dut, locator_name)
+
+        for sid_param in MySIDs.MY_SID_LIST:
+            locator_name = sid_param[0]
+            ip_addr = sid_param[1]
+            del_srv6_sid(rand_selected_dut, locator_name, ip_addr)
+
+    with allure.step('Verify the CRM usage of SRv6 SID after the test'):
+        used_mysid_num = 0
+        available_mysid_num = srv6_crm_total_sids
+        wait_until(10, 1, 0, verify_srv6_crm_status, rand_selected_dut, used_mysid_num, available_mysid_num)
+
+    with allure.step('Delete static route for SRv6'):
+        rand_selected_dut.command(f"sonic-db-cli CONFIG_DB DEL STATIC_ROUTE\\|default\\|{ROUTE_BASE}::/16")
+
+    rand_selected_dut.shell('sudo config save -y')
+
+
+def pytest_addoption(parser):
+    """
+    Adds options to pytest that are used by the srv6 reboot tests.
+    """
+    parser.addoption(
+        "--srv6_reboot_type",
+        action="store",
+        choices=['random', 'reload', 'cold', 'bgp'],
+        default='random',
+        required=False,
+        help="reboot type such as random, reload, cold, bgp"
+    )
+
+    parser.addoption(
+        "--srv6_packet_type",
+        action="store",
+        default="srh,no_srh",
+        help="SRv6 test parameters, comma separated values, default: srh,no_srh"
+    )
+
+
+def pytest_generate_tests(metafunc):
+    if "srv6_packet_type" in metafunc.fixturenames:
+        params = metafunc.config.getoption('--srv6_packet_type').split(',')
+        metafunc.parametrize("srv6_packet_type", [param.strip() for param in params], scope="class")
+
+
+@pytest.fixture(scope="class")
+def srv6_packet_type(request):
+    return request.param

--- a/tests/srv6/srv6_utils.py
+++ b/tests/srv6/srv6_utils.py
@@ -3,10 +3,167 @@ import time
 import requests
 import ptf.packet as scapy
 import ptf.testutils as testutils
-
+from tests.common.helpers.dut_utils import get_available_tech_support_files, get_new_techsupport_files_list, \
+    extract_techsupport_tarball_file
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.srv6_helper import SRv6
 
 logger = logging.getLogger(__name__)
+LOCATOR_NUM = 128
+ROUTE_BASE = '2001'
+
+
+class MyLocators():
+    # Generate 128 locators with incrementing IPv6 addresses
+    my_locator_list = [
+        [f'locator_{i + 1}', f'{ROUTE_BASE}:1001:{1 + i}::', f'{1 + i}'] for i in range(LOCATOR_NUM)
+    ]
+
+
+class MySIDs(MyLocators):
+    TUNNEL_MODE = [SRv6.pipe_mode]
+    # Generate 128 SIDs based on the locator list
+    MY_SID_LIST = [
+        [locator_name, sid, SRv6.uN, 'default']
+        for locator_name, sid, _ in MyLocators.my_locator_list
+    ]
+
+
+def validate_srv6_in_appl_db(duthost,
+                             block_len=32,
+                             node_len=16,
+                             func_len=0,
+                             arg_len=0):
+    """
+    Validate all SRv6 MySIDs in Application DB using a single query.
+
+    Args:
+        duthost (SonicHost): DUT host object
+        block_len (int): Block length for SRv6 SID
+        node_len (int): Node length for SRv6 SID
+        func_len (int): Function length for SRv6 SID
+        arg_len (int): Argument length for SRv6 SID
+
+    Returns:
+        bool: True if all MySIDs are valid, False otherwise
+    """
+    try:
+        # Get all SRv6 MySID entries from APPL_DB
+        appl_db_keys = duthost.shell('sonic-db-cli APPL_DB KEYS "SRV6_MY_SID_TABLE*"')["stdout"]
+        if not appl_db_keys:
+            logger.error("No SRv6 MySID entries found in APPL_DB")
+            return False
+
+        # Convert keys to a set for faster lookup
+        appl_db_keys_set = set(appl_db_keys.split())
+
+        # Validate each MySID
+        for entry in MySIDs.MY_SID_LIST:
+            prefix = entry[1]
+            expected_key = f"SRV6_MY_SID_TABLE:{block_len}:{node_len}:{func_len}:{arg_len}:{prefix}"
+
+            # Check if the key exists
+            if expected_key not in appl_db_keys_set:
+                logger.error(f"MySID entry not found in APPL_DB: {expected_key}")
+                return False
+
+        return True
+
+    except Exception as err:
+        raise Exception(f"Failed to validate SRv6 MySIDs in Application DB: {str(err)}")
+
+
+def validate_srv6_in_asic_db(duthost):
+    """
+    Validate all SRv6 MySIDs in ASIC DB using a single query.
+
+    Args:
+        duthost (SonicHost): DUT host object
+
+    Returns:
+        bool: True if all MySIDs are valid, False otherwise
+    """
+    try:
+        asic_db_keys = duthost.shell('sonic-db-cli ASIC_DB keys "*ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY*"')["stdout"]
+        if not asic_db_keys:
+            logger.error("No SRv6 MySID entries found in ASIC_DB")
+            return False
+
+        # Validate each MySID
+        for entry in MySIDs.MY_SID_LIST:
+            prefix = entry[1]
+
+            # Check if the key exists
+            if prefix not in asic_db_keys:
+                logger.error(f"MySID entry not found in ASIC_DB: {prefix}")
+                return False
+
+        return True
+
+    except Exception as err:
+        raise Exception(f"Failed to validate SRv6 MySIDs in ASIC DB: {str(err)}")
+
+
+def validate_srv6_route(duthost):
+    """
+    Validate the SRv6 route in ASIC DB
+    """
+    try:
+        asic_route = duthost.shell(
+            f'sonic-db-cli ASIC_DB keys "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:*{ROUTE_BASE}::/16*"')["stdout"]
+
+        if not asic_route:
+            logger.error(f"No SRv6 route {ROUTE_BASE}::/16 found")
+            return False
+
+        logger.info(f"SRv6 route {ROUTE_BASE}::/16 installed")
+        return True
+
+    except Exception as err:
+        raise Exception(f"Failed to validate SRv6 route {ROUTE_BASE}::/16: {str(err)}")
+
+
+def validate_sai_sdk_dump_files(duthost, techsupport_folder, feature_list=[]):
+    """
+    Validated that expected SAI dump file available inside in techsupport dump file
+    """
+    logger.info('Validate SAI dump file is included in the tech-support dump')
+    saidump_files_inside_techsupport = \
+        duthost.shell(f'ls {techsupport_folder}/sai_sdk_dump')['stdout_lines']
+    assert saidump_files_inside_techsupport, 'Expected SAI SDK dump file(folder) not available in techsupport dump'
+    for feature in feature_list:
+        for sai_sdk_dump in saidump_files_inside_techsupport:
+            res = duthost.shell(f'zgrep {feature} {techsupport_folder}/sai_sdk_dump/{sai_sdk_dump}',
+                                module_ignore_errors=True)['stdout_lines']
+            if res and feature in ''.join(res):
+                logger.info(f'Feature {feature} parameter exist in {techsupport_folder}/sai_sdk_dump/{sai_sdk_dump}'
+                            f'\n{res}')
+                break
+        else:
+            raise Exception(f'Feature "{feature}" parameter does not exist in sai sdk dump files')
+
+
+def validate_techsupport_generation(duthost, feature_list=[]):
+    """
+    Validate sai sdk dump file exist
+    """
+    available_tech_support_files = get_available_tech_support_files(duthost)
+    logger.info('Execute show techsupport command')
+    duthost.shell('show techsupport')
+    new_techsupport_files_list = get_new_techsupport_files_list(duthost, available_tech_support_files)
+    tech_support_file_path = new_techsupport_files_list[0]
+    logger.info(f'New tech support file: {new_techsupport_files_list}')
+    tech_support_name = tech_support_file_path.split('.')[0].lstrip('/var/dump/')
+
+    try:
+        logger.info(f'Doing validation for techsupport : {tech_support_name}')
+        techsupport_folder_path = extract_techsupport_tarball_file(duthost, tech_support_file_path)
+        logger.info('Checking that expected SAI SDK dump file available in techsupport file')
+        validate_sai_sdk_dump_files(duthost, techsupport_folder_path, feature_list)
+    finally:
+        logger.info(f'Delete {tech_support_file_path}')
+        duthost.shell(f'sudo rm -rf {tech_support_file_path}')
+
 
 #
 # log directory inside each vsonic. vsonic starts with admin as user.
@@ -295,3 +452,286 @@ def collect_frr_debugfile(duthosts, rand_one_dut_hostname, nbrhosts, filename, v
 def verify_appl_db_sid_entry_exist(duthost, sonic_db_cli, key, exist):
     appl_db_my_sids = duthost.command(sonic_db_cli + " APPL_DB keys SRV6_MY_SID_TABLE*")["stdout"]
     return key in appl_db_my_sids if exist else key not in appl_db_my_sids
+
+
+def enable_srv6_counterpoll(duthost):
+    """
+    Enable SRv6 counterpoll on the DUT.
+
+    Args:
+        duthost (SonicHost): DUT host object
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    try:
+        cmd = 'sudo counterpoll srv6 enable'
+        duthost.shell(cmd)
+        logger.info("Successfully enabled SRv6 counterpoll")
+        return True
+    except Exception as e:
+        raise Exception(f"Failed to enable SRv6 counterpoll: {str(e)}")
+
+
+def disable_srv6_counterpoll(duthost):
+    """
+    Disable SRv6 counterpoll on the DUT.
+
+    Args:
+        duthost (SonicHost): DUT host object
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    try:
+        cmd = 'sudo counterpoll srv6 disable'
+        duthost.shell(cmd)
+        logger.info("Successfully disabled SRv6 counterpoll")
+        return True
+    except Exception as e:
+        raise Exception(f"Failed to disable SRv6 counterpoll: {str(e)}")
+
+
+def set_srv6_counterpoll_interval(duthost, interval_ms, wait_for_new_interval=True):
+    """
+    Set the polling interval for SRv6 counterpoll.
+
+    Args:
+        duthost (SonicHost): DUT host object
+        interval_ms (int): Polling interval in milliseconds
+        wait_for_new_interval (bool): Whether to wait for the new interval to take effect
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    try:
+        # Get current interval
+        current_status = duthost.get_counter_poll_status()
+        if 'SRV6_STAT' not in current_status:
+            logger.error("SRv6 counterpoll is not available")
+            return False
+
+        current_interval = current_status['SRV6_STAT']['interval']
+
+        # Set new interval
+        cmd = f'sudo counterpoll srv6 interval {interval_ms}'
+        duthost.shell(cmd)
+
+        # Wait for the new interval to take effect if requested
+        if wait_for_new_interval:
+            wait_time = current_interval / 1000 + 1  # Convert to seconds and add 1 second buffer
+            logger.info(f"Waiting {wait_time} seconds for new interval to take effect")
+            time.sleep(wait_time)
+
+        logger.info(f"Successfully set SRv6 counterpoll interval to {interval_ms} ms")
+        return True
+    except Exception as e:
+        raise Exception(f"Failed to set SRv6 counterpoll interval: {str(e)}")
+
+
+def get_srv6_counterpoll_status(duthost):
+    """
+    Get the current status of SRv6 counterpoll.
+
+    Args:
+        duthost (SonicHost): DUT host object
+
+    Returns:
+        dict: Dictionary containing status information or None if failed
+    """
+    try:
+        status = duthost.get_counter_poll_status()
+        if 'SRV6_STAT' in status:
+            return status['SRV6_STAT']
+        return None
+    except Exception as e:
+        raise Exception(f"Failed to get SRv6 counterpoll status: {str(e)}")
+
+
+def verify_srv6_counterpoll_status(duthost, expected_status, expected_interval=None):
+    """
+    Verify the status of SRv6 counterpoll.
+
+    Args:
+        duthost (SonicHost): DUT host object
+        expected_status (str): Expected status ('enable' or 'disable')
+        expected_interval (str): Expected interval in milliseconds
+    Returns:
+        bool: True if status matches expected, False otherwise
+    """
+    try:
+        status = get_srv6_counterpoll_status(duthost)
+        if status is None:
+            return False
+
+        actual_status = status['status'].lower()
+        expected_status = expected_status.lower()
+        actual_interval = status['interval']
+
+        if expected_interval:
+            if actual_interval != expected_interval:
+                logger.error(f"SRv6 counterpoll interval mismatch. Expected: {expected_interval}, "
+                             f"Actual: {actual_interval}")
+                return False
+
+        if actual_status == expected_status:
+            logger.info(f"SRv6 counterpoll status verified as {expected_status}")
+            return True
+        else:
+            logger.error(f"SRv6 counterpoll status mismatch. Expected: {expected_status}, Actual: {actual_status}")
+            return False
+    except Exception as e:
+        raise Exception(f"Failed to verify SRv6 counterpoll status: {str(e)}")
+
+
+def validate_srv6_counters(duthost, srv6_pkt_list, mysid_list, pkt_num):
+    """
+    Validate SRv6 counters based on the list of SRv6 packets.
+
+    Args:
+        duthost (SonicHost): DUT host object
+        srv6_pkt_list (list): List of SRv6 packets
+        mysid_list (list): List of MySID to validate
+        pkt_num (int): Number of packets to validate
+
+    Returns:
+        bool: True if counters match expected values, False otherwise
+    """
+    try:
+        stats_list = duthost.show_and_parse('show srv6 stats')
+        stats_dict = {item['mysid']: item for item in stats_list}
+
+        for srv6_pkt, mysid in zip(srv6_pkt_list, mysid_list):
+            # Wireshark and PTF do not include FCS field when calculating frame length, but the switch does,
+            # so add 4 bytes when validating SRv6 counters at switch
+            single_pkt_len = len(srv6_pkt) + 4
+            mysid_with_prefix = mysid[1] + '/' + str(SRv6.prefix_len)
+
+            if mysid_with_prefix not in stats_dict:
+                logger.error(f"MySID {mysid_with_prefix} not found in SRv6 statistics")
+                return False
+
+            current_stats = stats_dict[mysid_with_prefix]
+            current_packets = int(current_stats['packets'])
+            current_bytes = int(current_stats['bytes'])
+
+            if current_packets != pkt_num or current_bytes != pkt_num * single_pkt_len:
+                logger.error(f"SRv6 statistics mismatch for MySID {mysid_with_prefix}: "
+                             f"Expected Packets={pkt_num}, Bytes={pkt_num * single_pkt_len}, "
+                             f"Actual Packets={current_packets}, Bytes={current_bytes}")
+                return False
+
+            logger.info(f"SRv6 statistics match expected values for MySID {mysid_with_prefix}: "
+                        f"Packets={current_packets}, Bytes={current_bytes}")
+
+        return True
+    except Exception as e:
+        raise Exception(f"Failed to validate SRv6 counters: {str(e)}")
+
+
+def get_srv6_mysid_entry_usage(duthost):
+    """
+    Get the usage information of SRv6 MySID Entry resources.
+
+    Args:
+        duthost (SonicHost): DUT host object
+
+    Returns:
+        dict: Dictionary containing usage information with keys:
+            - 'used_count': Number of used entries
+            - 'available_count': Number of available entries
+            - 'total_count': Total number of entries
+        Returns None if failed to get the information
+    """
+    try:
+        # Get SRv6 MySID Entry usage information using show_and_parse
+        usage_list = duthost.show_and_parse('crm show resources srv6-my-sid-entry')
+
+        # Find the entry for srv6_my_sid_entry
+        for entry in usage_list:
+            if entry['resource name'] == 'srv6_my_sid_entry':
+                used_count = int(entry['used count'])
+                available_count = int(entry['available count'])
+                total_count = used_count + available_count
+
+                result = {
+                    'used_count': used_count,
+                    'available_count': available_count,
+                    'total_count': total_count
+                }
+
+                logger.info(f"SRv6 MySID Entry usage: Used={used_count}, Available={available_count}, "
+                            f"Total={total_count}")
+                return result
+
+        logger.error("SRv6 MySID Entry resource not found in CRM output")
+        return None
+
+    except Exception as e:
+        raise Exception(f"Failed to get SRv6 MySID Entry usage: {str(e)}")
+
+
+def clear_srv6_counters(duthost):
+    """
+    Clear all SRv6 counters using sonic-clear command.
+
+    Args:
+        duthost (SonicHost): DUT host object
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    try:
+        cmd = 'sudo sonic-clear srv6counters'
+        duthost.shell(cmd)
+        logger.info("Successfully cleared SRv6 counters")
+        return True
+    except Exception as e:
+        raise Exception(f"Failed to clear SRv6 counters: {str(e)}")
+
+
+def verify_srv6_crm_status(duthost, expected_used_count, expected_available_count):
+    '''
+    Verify the CRM status of SRv6 SID.
+
+    Args:
+        duthost (SonicHost): DUT host object
+        expected_used_count (int): Expected number of used entries
+        expected_available_count (int): Expected number of available entries
+    '''
+    mysid_crm_status = get_srv6_mysid_entry_usage(duthost)
+    if not mysid_crm_status:
+        logger.info("Failed to get SRv6 MySID Entry usage")
+        return False
+    if mysid_crm_status['used_count'] != expected_used_count:
+        logger.info(f"Expected {expected_used_count} used SRv6 MySID Entries, but got {mysid_crm_status['used_count']}")
+        return False
+    if mysid_crm_status['available_count'] != expected_available_count:
+        logger.info(f"Expected {expected_available_count} available SRv6 MySID Entries, "
+                    f"but got {mysid_crm_status['available_count']}")
+        return False
+
+    logger.info("SRv6 MySID Entry usage verified successfully")
+    return True
+
+
+#
+# Get the mac address of a neighbor
+#
+def get_neighbor_mac(dut, neighbor_ip):
+    """Get the MAC address of the neighbor via the ip neighbor table"""
+    return dut.command("ip neigh show {}".format(neighbor_ip))['stdout'].split()[4]
+
+
+def verify_asic_db_sid_entry_exist(duthost, sonic_db_cli):
+    """
+    Verify that ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY entries exist in the ASIC DB.
+    Args:
+        duthost: The DUT host object
+        sonic_db_cli: The sonic-db-cli command with namespace options
+    Returns:
+        bool: True if entries exist, False otherwise
+    """
+    asic_db_my_sids = duthost.command(sonic_db_cli +
+                                      " ASIC_DB keys *ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY*")["stdout"]
+    return len(asic_db_my_sids.strip()) > 0

--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -3,14 +3,24 @@ import time
 import random
 import logging
 import string
+import json
 from scapy.all import Raw
-from scapy.layers.inet6 import IPv6, ICMPv6EchoRequest, UDP
+from scapy.layers.inet6 import IPv6, UDP
 from scapy.layers.l2 import Ether
-
-from srv6_utils import runSendReceive, verify_appl_db_sid_entry_exist
-from common.reboot import reboot
-from common.utilities import wait_until
-from ptf.testutils import simple_ipv6_sr_packet
+from ptf.testutils import simple_ipv6_sr_packet, send_packet, verify_no_packet_any
+from ptf.mask import Mask
+from tests.srv6.srv6_utils import MySIDs, runSendReceive, verify_appl_db_sid_entry_exist, SRv6, \
+    validate_srv6_in_appl_db, validate_techsupport_generation, validate_srv6_counters, clear_srv6_counters, \
+    get_neighbor_mac, validate_srv6_in_asic_db, validate_srv6_route, verify_asic_db_sid_entry_exist
+from tests.common.reboot import reboot
+from tests.common.config_reload import config_reload
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.portstat_utilities import parse_portstat
+from tests.common.utilities import wait_until
+from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
+from tests.common.mellanox_data import is_mellanox_device
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
+from tests.common.helpers.srv6_helper import create_srv6_packet, send_verify_srv6_packet
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +30,31 @@ pytestmark = [
 ]
 
 
-def get_neighbor_mac(dut, neighbor_ip):
-    """Get the MAC address of the neighbor via the ip neighbor table"""
-    return dut.command("ip neigh show {}".format(neighbor_ip))['stdout'].split()[4]
+def is_bgp_route_synced(duthost):
+    cmd = 'vtysh -c "show ip bgp neighbors json"'
+    output = duthost.command(cmd)['stdout']
+    bgp_info = json.loads(output)
+    for neighbor, info in bgp_info.items():
+        if 'gracefulRestartInfo' in info:
+            if "ipv4Unicast" in info['gracefulRestartInfo']:
+                if not info['gracefulRestartInfo']["ipv4Unicast"]['endOfRibStatus']['endOfRibSend']:
+                    logger.info(f"BGP neighbor {neighbor} is sending updates")
+                    return False
+                if not info['gracefulRestartInfo']["ipv4Unicast"]['endOfRibStatus']['endOfRibRecv']:
+                    logger.info(
+                        f"BGP neighbor {neighbor} is receiving updates")
+                    return False
+
+            if "ipv6Unicast" in info['gracefulRestartInfo']:
+                if not info['gracefulRestartInfo']["ipv6Unicast"]['endOfRibStatus']['endOfRibSend']:
+                    logger.info(f"BGP neighbor {neighbor} is sending updates")
+                    return False
+                if not info['gracefulRestartInfo']["ipv6Unicast"]['endOfRibStatus']['endOfRibRecv']:
+                    logger.info(
+                        f"BGP neighbor {neighbor} is receiving updates")
+                    return False
+    logger.info("BGP routes are synced")
+    return True
 
 
 def get_ptf_src_port_and_dut_port_and_neighbor(dut, tbinfo):
@@ -39,8 +71,7 @@ def get_ptf_src_port_and_dut_port_and_neighbor(dut, tbinfo):
         if intf in ports_map:
             return intf, ports_map[intf], entry[1]  # local intf, ptf_src_port, neighbor hostname
 
-    dut_port, ptf_src_port = random.choice(ports_map)
-    return dut_port, ptf_src_port, None
+    pytest.skip("No active LLDP neighbor found for {}".format(dut))
 
 
 def run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh):
@@ -51,7 +82,7 @@ def run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapte
             injected_pkt = simple_ipv6_sr_packet(
                 eth_dst=dut_mac,
                 eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode(),
-                ipv6_src=ptfhost.mgmt_ipv6,
+                ipv6_src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1",
                 ipv6_dst="fcbb:bbbb:1:2::",
                 srh_seg_left=1,
                 srh_nh=41,
@@ -59,8 +90,8 @@ def run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapte
             )
         else:
             injected_pkt = Ether(dst=dut_mac, src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode()) \
-                / IPv6(src=ptfhost.mgmt_ipv6, dst="fcbb:bbbb:1:2::") \
-                / IPv6() / UDP(dport=4791) / Raw(load=payload)
+                           / IPv6(src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1", dst="fcbb:bbbb:1:2::") \
+                           / IPv6() / UDP(dport=4791) / Raw(load=payload)
 
         expected_pkt = injected_pkt.copy()
         expected_pkt['Ether'].dst = get_neighbor_mac(duthost, neighbor_ip)
@@ -71,10 +102,16 @@ def run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapte
         runSendReceive(injected_pkt, ptf_src_port, expected_pkt, [ptf_src_port], True, ptfadapter)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def setup_uN(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, tbinfo):
     duthost = duthosts[enum_frontend_dut_hostname]
     asic_index = enum_frontend_asic_index
+
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    ptf_port_ids = []
+    for interface in list(mg_facts["minigraph_ptf_indices"].keys()):
+        port_id = mg_facts["minigraph_ptf_indices"][interface]
+        ptf_port_ids.append(port_id)
 
     if duthost.is_multi_asic:
         cli_options = " -n " + duthost.get_namespace_from_asic_id(asic_index)
@@ -111,19 +148,30 @@ def setup_uN(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, tbi
     # add a uN sid configuration entry
     duthost.command(sonic_db_cli +
                     " CONFIG_DB HSET SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48 action uN decap_dscp_mode pipe")
-    # add the static route for IPv6 forwarding towards PTF's uSID
-    duthost.command(sonic_db_cli + " CONFIG_DB HSET STATIC_ROUTE\\|default\\|fcbb:bbbb:2::/48 nexthop {} ifname {}"
-                    .format(neighbor_ip, dut_port))
+    random.seed(time.time())
+    # add the static route for IPv6 forwarding towards PTF's uSID and the blackhole route in a random order
+    if random.randint(0, 1) == 0:
+        duthost.command(sonic_db_cli + " CONFIG_DB HSET STATIC_ROUTE\\|default\\|fcbb:bbbb:2::/48 nexthop {} ifname {}"
+                        .format(neighbor_ip, dut_port))
+        duthost.command(sonic_db_cli + " CONFIG_DB HSET STATIC_ROUTE\\|default\\|fcbb:bbbb::/32 blackhole true")
+    else:
+        duthost.command(sonic_db_cli + " CONFIG_DB HSET STATIC_ROUTE\\|default\\|fcbb:bbbb::/32 blackhole true")
+        duthost.command(sonic_db_cli + " CONFIG_DB HSET STATIC_ROUTE\\|default\\|fcbb:bbbb:2::/48 nexthop {} ifname {}"
+                        .format(neighbor_ip, dut_port))
     duthost.command("config save -y")
-    time.sleep(5)
+    # Verify that the ASIC DB has the SRv6 SID entries
+    assert wait_until(20, 5, 0, verify_asic_db_sid_entry_exist, duthost, sonic_db_cli), \
+        "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY entries are missing in ASIC_DB"
 
     setup_info = {
         "asic_index": asic_index,
         "duthost": duthost,
         "dut_mac": dut_mac,
+        "dut_port": dut_port,
         "ptf_src_port": ptf_src_port,
         "neighbor_ip": neighbor_ip,
-        "cli_options": cli_options
+        "cli_options": cli_options,
+        "ptf_port_ids": ptf_port_ids
     }
 
     yield setup_info
@@ -132,46 +180,167 @@ def setup_uN(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, tbi
     duthost.command(sonic_db_cli + " CONFIG_DB DEL SRV6_MY_LOCATORS\\|loc1")
     duthost.command(sonic_db_cli + " CONFIG_DB DEL SRV6_MY_SIDS\\|loc1\\|fcbb:bbbb:1::/48")
     duthost.command(sonic_db_cli + " CONFIG_DB DEL STATIC_ROUTE\\|default\\|fcbb:bbbb:2::/48")
+    duthost.command(sonic_db_cli + " CONFIG_DB DEL STATIC_ROUTE\\|default\\|fcbb:bbbb::/32")
     duthost.command("config save -y")
 
 
-@pytest.mark.parametrize("with_srh", [True, False])
-def test_srv6_uN_forwarding(setup_uN, ptfadapter, ptfhost, with_srh):
-    duthost = setup_uN['duthost']
-    dut_mac = setup_uN['dut_mac']
-    ptf_src_port = setup_uN['ptf_src_port']
-    neighbor_ip = setup_uN['neighbor_ip']
+class SRv6Base():
 
-    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh)
+    @pytest.fixture(autouse=True)
+    def use_param(self, prepare_param):
+        self.params = prepare_param
 
+    def _validate_srv6_function(self, duthost, ptfadapter, dscp_mode):
+        srv6_pkt_list = []
+        logger.info('Clear the SRv6 counters')
+        clear_srv6_counters(duthost)
 
-@pytest.mark.parametrize("with_srh", [True, False])
-def test_srv6_uN_decap_pipe_mode(setup_uN, ptfadapter, ptfhost, with_srh):
-    duthost = setup_uN['duthost']
-    dut_mac = setup_uN['dut_mac']
-    ptf_src_port = setup_uN['ptf_src_port']
-    neighbor_ip = setup_uN['neighbor_ip']
+        logger.info('Validate SRv6 table in APPL DB')
+        pytest_assert(wait_until(60, 5, 0, validate_srv6_in_appl_db, duthost),
+                      "SRv6 table in APPL DB is not as expected")
 
-    for i in range(0, 10):
-        if with_srh:
-            injected_pkt = simple_ipv6_sr_packet(
-                eth_dst=dut_mac,
-                eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode(),
-                ipv6_src=ptfhost.mgmt_ipv6,
-                ipv6_dst="fcbb:bbbb:1::",
-                srh_seg_left=1,
-                srh_nh=41,
-                inner_frame=IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6, tc=0x1, hlim=64)/ICMPv6EchoRequest(seq=i)
+        logger.info('Validate SRv6 table in ASIC DB')
+        pytest_assert(wait_until(60, 5, 0, validate_srv6_in_asic_db, duthost),
+                      "SRv6 table in ASIC DB is not as expected")
+
+        logger.info('Validate SRv6 route in ASIC DB')
+        pytest_assert(wait_until(120, 5, 0, validate_srv6_route, duthost),
+                      "SRv6 route in ASIC DB is not as expected")
+
+        ptf_src_mac = ptfadapter.dataplane.get_mac(0, self.params['ptf_downlink_port']).decode('utf-8')
+        for srv6_packet in self.params['srv6_packets']:
+            if duthost.facts["asic_type"] == "broadcom" and \
+               (srv6_packet['srh_seg_left'] or srv6_packet['srh_seg_list']):
+                logger.info("Skip the test for Broadcom ASIC with SRH")
+                continue
+
+            logger.info('-------------------------------------------------------------------------')
+            if srv6_packet['validate_dip_shift']:
+                logger.info('Validate DIP shift')
+            if srv6_packet['validate_usd_flavor']:
+                logger.info('Validate USD flavor')
+            logger.info(f'SRv6 tunnel decapsulation mode: {dscp_mode}')
+            logger.info(f'Send {self.params["packet_num"]} SRv6 packets with action: {srv6_packet["action"]}')
+            logger.info(f'Pkt Src MAC: {ptf_src_mac}')
+            logger.info(f'Pkt Dst MAC: {self.params["router_mac"]}')
+            if srv6_packet['action'] == SRv6.uN:
+                logger.info(f'Outer Pkt Src IP: {srv6_packet["outer_src_ipv6"]}')
+                logger.info(f'Outer Pkt Dst IP: {srv6_packet["dst_ipv6"]}')
+                if srv6_packet["exp_dst_ipv6"]:
+                    logger.info(f'Expect Outer Pkt Dst IP: {srv6_packet["exp_dst_ipv6"]}')
+            if dscp_mode == SRv6.uniform_mode:
+                if srv6_packet['outer_dscp']:
+                    logger.info(f'Outer DSCP value: {srv6_packet["outer_dscp"]}')
+                if srv6_packet['exp_outer_dscp_uniform']:
+                    logger.info(f'Expect inner DSCP value: {srv6_packet["exp_outer_dscp_uniform"]}')
+            else:
+                if srv6_packet['inner_dscp']:
+                    logger.info(f'Inner DSCP value: {srv6_packet["inner_dscp"]}')
+                if srv6_packet['exp_inner_dscp_pipe']:
+                    logger.info(f'Expect inner DSCP value: {srv6_packet["exp_inner_dscp_pipe"]}')
+            logger.info(f'SRH Segment List: {srv6_packet["srh_seg_list"]}')
+            logger.info(f'SRH Segment Left: {srv6_packet["srh_seg_left"]}')
+
+            logger.info(f'Expect Segment Left: {srv6_packet["exp_srh_seg_left"]}')
+            logger.info(f'Expect process result: {srv6_packet["exp_process_result"]}')
+            logger.info('-------------------------------------------------------------------------')
+
+            srv6_pkt, exp_pkt = create_srv6_packet(
+                outer_src_mac=ptf_src_mac,
+                outer_dst_mac=self.params['router_mac'],
+                outer_src_pkt_ip=srv6_packet['outer_src_ipv6'],
+                outer_dst_pkt_ip=srv6_packet['dst_ipv6'],
+                srv6_action=srv6_packet['action'],
+                inner_dscp=srv6_packet['inner_dscp'],
+                outer_dscp=srv6_packet['outer_dscp'],
+                exp_outer_dst_pkt_ip=srv6_packet['exp_dst_ipv6'],
+                exp_seg_left=srv6_packet['exp_srh_seg_left'],
+                exp_dscp_pipe=srv6_packet['exp_inner_dscp_pipe'],
+                exp_dscp_uniform=srv6_packet['exp_outer_dscp_uniform'],
+                seg_left=srv6_packet['srh_seg_left'],
+                sef_list=srv6_packet['srh_seg_list'],
+                inner_pkt_ver=srv6_packet['inner_pkt_ver'],
+                dscp_mode=dscp_mode,
+                router_mac=self.params['router_mac'],
+                inner_src_ip=srv6_packet['inner_src_ip'],
+                inner_dst_ip=srv6_packet['inner_dst_ip'],
+                inner_src_ipv6=srv6_packet['inner_src_ipv6'],
+                inner_dst_ipv6=srv6_packet['inner_dst_ipv6']
             )
-        else:
-            injected_pkt = Ether(dst=dut_mac, src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode()) \
-                / IPv6(src=ptfhost.mgmt_ipv6, dst="fcbb:bbbb:1::") \
-                / IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6) / ICMPv6EchoRequest(seq=i)
 
-        expected_pkt = Ether(dst=get_neighbor_mac(duthost, neighbor_ip), src=dut_mac) / \
-            IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6, tc=0x1, hlim=63)/ICMPv6EchoRequest(seq=i)
-        logger.debug("Expected packet #{}: {}".format(i, expected_pkt.summary()))
-        runSendReceive(injected_pkt, ptf_src_port, expected_pkt, [ptf_src_port], True, ptfadapter)
+            send_verify_srv6_packet(
+                ptfadapter=ptfadapter,
+                pkt=srv6_pkt,
+                exp_pkt=exp_pkt,
+                exp_pro=srv6_packet["exp_process_result"],
+                ptf_src_port_id=self.params['ptf_downlink_port'],
+                ptf_dst_port_ids=self.params['ptf_uplink_ports'],
+                packet_num=self.params['packet_num']
+            )
+
+            srv6_pkt_list.append(srv6_pkt)
+
+        return srv6_pkt_list
+
+
+class TestSRv6DataPlaneBase(SRv6Base):
+
+    def test_srv6_full_func(self, config_setup, srv6_crm_total_sids,
+                            setup_standby_ports_on_rand_unselected_tor,       # noqa: F811
+                            toggle_all_simulator_ports_to_rand_selected_tor,  # noqa: F811
+                            ptfadapter, rand_selected_dut, localhost, request, enum_frontend_asic_index):
+
+        with allure.step('Validate SRv6 packet process'):
+            srv6_pkt_list = self._validate_srv6_function(rand_selected_dut, ptfadapter, config_setup)
+
+        with allure.step('Validate SRv6 counters'):
+            pytest_assert(wait_until(60, 5, 0, validate_srv6_counters, rand_selected_dut, srv6_pkt_list,
+                                     MySIDs.MY_SID_LIST, self.params['packet_num']),
+                          "SRv6 counters are not as expected")
+
+        if random.random() < 0.5:
+
+            with allure.step('Execute reboot test'):
+                reboot_type = request.config.getoption("--srv6_reboot_type")
+
+                if reboot_type == "random":
+                    reboot_type = random.choice(["cold", "reload", "bgp"])
+
+                if reboot_type == "cold":
+                    with allure.step('Execute cold reboot'):
+                        reboot(rand_selected_dut, localhost, reboot_type=reboot_type, wait_warmboot_finalizer=True,
+                               safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
+                elif reboot_type == "reload":
+                    with allure.step('Execute config reload'):
+                        config_reload(rand_selected_dut, safe_reload=True, check_intf_up_ports=True)
+                else:
+                    with allure.step('Execute BGP restart'):
+                        if rand_selected_dut.is_multi_asic:
+                            rand_selected_dut.command(
+                                f"systemctl restart bgp@{enum_frontend_asic_index}")
+                        else:
+                            rand_selected_dut.command("systemctl restart bgp")
+
+                with allure.step('Validate BGP docker UP'):
+                    pytest_assert(wait_until(100, 10, 0, rand_selected_dut.is_service_fully_started_per_asic_or_host,
+                                             "bgp"),
+                                  "BGP not started.")
+
+                with allure.step('Validate BGP route sync'):
+                    pytest_assert(wait_until(120, 5, 0, is_bgp_route_synced,
+                                             rand_selected_dut), "BGP route is not synced")
+
+                with allure.step('Validate SRv6 packet process'):
+                    self._validate_srv6_function(rand_selected_dut, ptfadapter, config_setup)
+
+                with allure.step('Validate SRv6 counters'):
+                    pytest_assert(wait_until(60, 5, 0, validate_srv6_counters, rand_selected_dut, srv6_pkt_list,
+                                             MySIDs.MY_SID_LIST, self.params['packet_num']),
+                                  "SRv6 counters are not as expected")
+
+            if is_mellanox_device(rand_selected_dut) and config_setup == SRv6.pipe_mode:
+                with allure.step('Validate SAI SDK dump contains SRv6 information'):
+                    validate_techsupport_generation(rand_selected_dut, feature_list=['SRv6'])
 
 
 @pytest.mark.parametrize("with_srh", [True, False])
@@ -182,7 +351,7 @@ def test_srv6_dataplane_after_config_reload(setup_uN, ptfadapter, ptfhost, with_
     neighbor_ip = setup_uN['neighbor_ip']
 
     # verify the forwarding works
-    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, with_srh)
+    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh)
 
     # reload the config
     duthost.command("config reload -y -f")
@@ -192,6 +361,9 @@ def test_srv6_dataplane_after_config_reload(setup_uN, ptfadapter, ptfhost, with_
     # wait for the config to be reprogrammed
     assert wait_until(180, 2, 0, verify_appl_db_sid_entry_exist, duthost, sonic_db_cli,
                       "SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1::", True), "SID is missing in APPL_DB"
+    # Verify that the ASIC DB has the SRv6 SID entries
+    assert wait_until(20, 5, 0, verify_asic_db_sid_entry_exist, duthost, sonic_db_cli), \
+        "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY entries are missing in ASIC_DB after config reload"
 
     # verify the forwarding works after config reload
     run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh)
@@ -205,7 +377,7 @@ def test_srv6_dataplane_after_bgp_restart(setup_uN, ptfadapter, ptfhost, with_sr
     neighbor_ip = setup_uN['neighbor_ip']
 
     # verify the forwarding works
-    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, with_srh)
+    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh)
 
     # restart BGP service, which will restart the BGP container
     if duthost.is_multi_asic:
@@ -218,6 +390,9 @@ def test_srv6_dataplane_after_bgp_restart(setup_uN, ptfadapter, ptfhost, with_sr
     # wait for the config to be reprogrammed
     assert wait_until(180, 2, 0, verify_appl_db_sid_entry_exist, duthost, sonic_db_cli,
                       "SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1::", True), "SID is missing in APPL_DB"
+    # Verify that the ASIC DB has the SRv6 SID entries
+    assert wait_until(20, 5, 0, verify_asic_db_sid_entry_exist, duthost, sonic_db_cli), \
+        "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY entries are missing in ASIC_DB after BGP restart"
 
     # verify the forwarding works after BGP restart
     run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh)
@@ -231,7 +406,7 @@ def test_srv6_dataplane_after_reboot(setup_uN, ptfadapter, ptfhost, localhost, w
     neighbor_ip = setup_uN['neighbor_ip']
 
     # verify the forwarding works
-    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, with_srh)
+    run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh)
 
     # reboot DUT
     reboot(duthost, localhost, safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
@@ -240,6 +415,70 @@ def test_srv6_dataplane_after_reboot(setup_uN, ptfadapter, ptfhost, localhost, w
     # wait for the config to be reprogrammed
     assert wait_until(180, 2, 0, verify_appl_db_sid_entry_exist, duthost, sonic_db_cli,
                       "SRV6_MY_SID_TABLE:32:16:0:0:fcbb:bbbb:1::", True), "SID is missing in APPL_DB"
+    # Verify that the ASIC DB has the SRv6 SID entries
+    assert wait_until(20, 5, 0, verify_asic_db_sid_entry_exist, duthost, sonic_db_cli), \
+        "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY entries are missing in ASIC_DB after reboot"
 
     # verify the forwarding works after reboot
     run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh)
+
+
+@pytest.mark.parametrize("with_srh", [True, False])
+def test_srv6_no_sid_blackhole(setup_uN, ptfadapter, ptfhost, with_srh):
+    duthost = setup_uN['duthost']
+    dut_mac = setup_uN['dut_mac']
+    dut_port = setup_uN['dut_port']
+    ptf_src_port = setup_uN['ptf_src_port']
+    neighbor_ip = setup_uN['neighbor_ip']
+    ptf_port_ids = setup_uN['ptf_port_ids']
+    # Verify that the ASIC DB has the SRv6 SID entries
+    sonic_db_cli = "sonic-db-cli" + setup_uN['cli_options']
+    assert wait_until(20, 5, 0, verify_asic_db_sid_entry_exist, duthost, sonic_db_cli), \
+        "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY entries are missing in ASIC_DB before blackhole test"
+
+    # get the drop counter before traffic test
+    if duthost.facts["asic_type"] == "broadcom":
+        portstat = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])
+        before_count = int(portstat[dut_port]['rx_drp'])
+    elif duthost.facts["asic_type"] == "mellanox":
+        before_count = int(duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines'][6].split()[0])
+
+    # inject a number of packets with random payload
+    pkt_count = 100
+    payload = ''.join(random.choices(string.ascii_letters + string.digits, k=20))
+    if with_srh:
+        injected_pkt = simple_ipv6_sr_packet(
+            eth_dst=dut_mac,
+            eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode(),
+            ipv6_src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1",
+            ipv6_dst="fcbb:bbbb:3:2::",
+            srh_seg_left=1,
+            srh_nh=41,
+            inner_frame=IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1") / UDP(
+                dport=4791) / Raw(load=payload)
+        )
+    else:
+        injected_pkt = Ether(dst=dut_mac, src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode()) \
+                       / IPv6(src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1", dst="fcbb:bbbb:3:2::") \
+                       / IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else "1000::1") \
+                       / UDP(dport=4791) / Raw(load=payload)
+
+    expected_pkt = injected_pkt.copy()
+    expected_pkt['IPv6'].dst = "fcbb:bbbb:3:2::"
+    expected_pkt['IPv6'].hlim -= 1
+    logger.debug("Expected packet: {}".format(expected_pkt.summary()))
+
+    expected_pkt = Mask(expected_pkt)
+    expected_pkt.set_do_not_care_packet(Ether, "dst")
+    expected_pkt.set_do_not_care_packet(Ether, "src")
+    send_packet(ptfadapter, ptf_src_port, injected_pkt, count=pkt_count)
+    verify_no_packet_any(ptfadapter, expected_pkt, ptf_port_ids, 0, 1)
+
+    # verify that the RX_DROP counter is incremented
+    if duthost.facts["asic_type"] == "broadcom":
+        portstat = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])
+        after_count = int(portstat[dut_port]['rx_drp'])
+        assert after_count >= (before_count + pkt_count), "RX_DRP counter is not incremented as expected"
+    elif duthost.facts["asic_type"] == "mellanox":
+        after_count = int(duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines'][6].split()[0])
+        assert after_count >= (before_count + pkt_count), "RIF RX_ERR counter is not incremented as expected"


### PR DESCRIPTION
1.Auto generate 128 SRv6 locators and sids
2.Auto generate 128 matching packets
2.1.Test DIP shift
2.2.Test uSID container copy action
2.3.Test USD flavor
2.4.Test DSCP mapping
2.5.Test ttl and hop limit change
3.Split SRH and non SRH packets test into two test cases required by MSFT 3.1.Test reboot and BGP restart test randomly to save time 4.Test SRv6 counter 5.Test SRv6 CRM resource
6.Add static route for 128 sids validation
7.Add check for route asic db installation
8.Add timeout when captureing packet to override large scale of BGP update packets affection 9.Use a unified locator block for all the sids 
10.Use command line to set SRv6 packet type