### PR TITLE
[202412] fix PT0 template in t0-isolated topology (#18995)

### DIFF
--- a/ansible/generate_topo.py
+++ b/ansible/generate_topo.py
@@ -3,11 +3,15 @@
 from collections import defaultdict, namedtuple
 import copy
 from typing import Any, Dict, List, Tuple, Union
-from ipaddress import IPv4Network, IPv6Network
+from ipaddress import IPv4Network, IPv6Network, IPv4Address
 import click
 import jinja2
 
 PTF_BACKPLANE_IPV4 = "10.10.246.254"
+# current PTF subnet is  10.10.246.0/22
+PTF_BACKPLANE_IPV4_LOWER_BOUND = "10.10.244.1"
+PTF_BACKPLANE_IPV4_UPPER_BOUND = "10.10.247.254"
+PTF_BACKPLANE_IPV4_DEFAULT_START = "10.10.246.1"
 backplane_additional_offset_ipv4 = 0
 PTF_BACKPLANE_IPV6 = "fc0a::ff"
 backplane_additional_offset_ipv6 = 0
@@ -195,11 +199,21 @@ class VM:
         # Backplane IPs
         global backplane_additional_offset_ipv4
         self.bp_ipv4 = calc_ipv4(
-            "10.10.246.1", self.ip_offset+1+backplane_additional_offset_ipv4)
+            PTF_BACKPLANE_IPV4_DEFAULT_START, self.ip_offset+1+backplane_additional_offset_ipv4)
         if self.bp_ipv4 == PTF_BACKPLANE_IPV4:
             backplane_additional_offset_ipv4 = 1
             self.bp_ipv4 = calc_ipv4(
-                "10.10.246.1", self.ip_offset+1+backplane_additional_offset_ipv4)
+                PTF_BACKPLANE_IPV4_DEFAULT_START, self.ip_offset+1+backplane_additional_offset_ipv4)
+        # Ensure backplane IP is within the allowed range
+        # Default [10.10.246.1 ---- 10.10.247.254], once crossed the upper bound, it will be starting from
+        # lower bound [10.10.244.1 -- 10.10.245.255]. If the backplane IP reaches to 10.10.246.1 again. that
+        # means the range is exhausted.
+        if IPv4Address(self.bp_ipv4) > IPv4Address(PTF_BACKPLANE_IPV4_UPPER_BOUND):
+            diff = int(IPv4Address(self.bp_ipv4)) - int(IPv4Address(PTF_BACKPLANE_IPV4_UPPER_BOUND))
+            self.bp_ipv4 = IPv4Address(PTF_BACKPLANE_IPV4_LOWER_BOUND) + diff - 1
+            if self.bp_ipv4 >= IPv4Address(PTF_BACKPLANE_IPV4_DEFAULT_START):
+                assert False, "Backplane IP address exceeds the allowed range"
+
         global backplane_additional_offset_ipv6
         self.bp_ipv6 = calc_ipv6(
             "fc0a::1", (self.ip_offset+1+backplane_additional_offset_ipv6))

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -211,6 +211,8 @@
 {% else %}
 {% set dev_type = 'AZNGHub' %}
 {% endif %}
+{% elif 'PT0' in dev %}
+{% set dev_type = 'ToRRouter' %}
 {% elif ('T0' in dev) and (enable_compute_ai_deployment|default('false')|bool) %}
 {% set dev_type = 'BackEndToRRouter' %}
 {% elif 'T0' in dev %}

--- a/ansible/vars/topo_t0-isolated-d32u32s2.yml
+++ b/ansible/vars/topo_t0-isolated-d32u32s2.yml
@@ -861,7 +861,7 @@ configuration:
         ipv4: 10.0.4.1/31
         ipv6: fc00::802/126
     bp_interface:
-      ipv4: 10.10.248.2/22
+      ipv4: 10.10.244.4/22
       ipv6: fc0a::202/64
   ARISTA02PT0:
     properties:
@@ -880,5 +880,5 @@ configuration:
         ipv4: 10.0.4.3/31
         ipv6: fc00::806/126
     bp_interface:
-      ipv4: 10.10.248.3/22
+      ipv4: 10.10.244.5/22
       ipv6: fc0a::203/64


### PR DESCRIPTION
Summary:
Two issues:
PT0 should use different template with T1 neighbors. the current bp_interface subnet is: 10.10.246.0/22 (10.10.244.0-10.10.247.255). while in t0-isolated topology, the bp_interface may choose 10.10.248.2 or 10.10.248.3 which is outside the range.

What is the motivation for this PR?
Fix bp_interface and PT0 template for t0-isolated topology

(cherry picked from commit 939485fd3e5d890de5d94f3b7eedd44e82844180)