### PR TITLE
[Cherry-pick] Add Arista-7280DR(A|AK|AM)-36(|S) SKUs to sonic-mgmt

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -16,7 +16,7 @@ broadcom_th2_hwskus: ['Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Arista
 broadcom_th3_hwskus: ['DellEMC-Z9332f-M-O16C64',  'DellEMC-Z9332f-O32']
 broadcom_th4_hwskus: ['Arista-7060DX5-32', 'Arista-7060DX5-64S']
 broadcom_th5_hwskus: ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16', 'Arista-7060X6-16PE-384C-O128S2']
-broadcom_j2c+_hwskus: ['Nokia-IXR7250E-36x100G', 'Nokia-IXR7250E-36x400G', 'Arista-7800R3A-36DM2-C36', 'Arista-7800R3A-36DM2-D36', 'Arista-7800R3AK-36DM2-C36', 'Arista-7800R3AK-36DM2-D36', Nokia-IXR7250-X3B']
+broadcom_j2c+_hwskus: ['Nokia-IXR7250E-36x100G', 'Nokia-IXR7250E-36x400G', 'Arista-7280DR3A-36', 'Arista-7280DR3AK-36', 'Arista-7280DR3AK-36S', 'Arista-7280DR3AM-36', 'Arista-7800R3A-36DM2-C36', 'Arista-7800R3A-36DM2-D36', 'Arista-7800R3AK-36DM2-C36', 'Arista-7800R3AK-36DM2-D36', 'Nokia-IXR7250-X3B']
 broadcom_jr2_hwskus: ['Arista-7800R3-48CQ2-C48', 'Arista-7800R3-48CQM2-C48']
 
 mellanox_spc1_hwskus: [ 'ACS-MSN2700', 'ACS-MSN2740', 'ACS-MSN2100', 'ACS-MSN2410', 'ACS-MSN2010', 'Mellanox-SN2700', 'Mellanox-SN2700-A1', 'Mellanox-SN2700-D48C8','Mellanox-SN2700-D40C8S8', 'Mellanox-SN2700-A1-D48C8']

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -277,7 +277,11 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku in ["Arista-7800R3-48CQ2-C48", "Arista-7800R3-48CQM2-C48"]:
             for i in range(1, 49):
                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
-        elif hwsku in ["Arista-7800R3A-36DM2-C36",
+        elif hwsku in ["Arista-7280DR3A-36",
+                       "Arista-7280DR3AK-36",
+                       "Arista-7280DR3AK-36S",
+                       "Arista-7280DR3AM-36",
+                       "Arista-7800R3A-36DM2-C36",
                        "Arista-7800R3AK-36DM2-C36",
                        "Arista-7800R3A-36DM2-D36"]:
             for i in range(1, 37):


### PR DESCRIPTION
**Description of PR**
Summary: Add new Arista SKUs to sonic-mgmt framework. This is a cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/18158

**Approach**
What is the motivation for this PR?
To add Arista-7280DR(A|AK|AM)-36S? to sonic-mgmt framework.

**How did you do it?**
Added the HwSKUs in the ansible directory

**How did you verify/test it?**
We are running sonic-mgmt tests internally

**Any platform specific information?**
Depends on https://github.com/sonic-net/sonic-buildimage/pull/22463