### PR TITLE
Multiple test streams for Cisco8000

### DIFF
--- a/tests/snappi_tests/pfc/files/lossless_response_to_external_pause_storms_helper.py
+++ b/tests/snappi_tests/pfc/files/lossless_response_to_external_pause_storms_helper.py
@@ -15,6 +15,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, verify_pause_flow, \
      setup_base_traffic_config                                 # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
 
@@ -101,9 +102,7 @@ def run_lossless_response_to_external_pause_storms_test(api,
 
     test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT)
     bg_flow_rate_percent = int(BG_FLOW_AGGR_RATE_PERCENT)
-    no_of_bg_streams = 1
-    if duthost.facts['asic_type'] == "cisco-8000":
-        no_of_bg_streams = 10
+    no_of_bg_streams = get_number_of_streams(duthost, tx_port, rx_port)
     port_id = 0
 
     # Generate base traffic config

--- a/tests/snappi_tests/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
+++ b/tests/snappi_tests/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
@@ -16,6 +16,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, verify_pause_flow, \
      setup_base_traffic_config                                      # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 logger = logging.getLogger(__name__)
@@ -108,9 +109,7 @@ def run_lossless_response_to_throttling_pause_storms_test(api,
 
     test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT)
     bg_flow_rate_percent = int(BG_FLOW_AGGR_RATE_PERCENT)
-    no_of_bg_streams = 1
-    if duthost.facts['asic_type'] == "cisco-8000":
-        no_of_bg_streams = 10
+    no_of_bg_streams = get_number_of_streams(egress_duthost, tx_port, rx_port)
     port_id = 0
 
     # Generate base traffic config

--- a/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -9,6 +9,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, \
      setup_base_traffic_config          # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
 
@@ -92,9 +93,7 @@ def run_m2o_fluctuating_lossless_test(api,
         stop_pfcwd(duthost, asic)
         disable_packet_aging(duthost)
 
-    no_of_bg_streams = 1
-    if duthost.facts['asic_type'] == "cisco-8000":
-        no_of_bg_streams = 10
+    no_of_bg_streams = get_number_of_streams(egress_duthost, tx_port, rx_port)
     port_id = 0
     # Generate base traffic config
     snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -15,6 +15,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, \
      run_traffic                                         # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
 
@@ -96,9 +97,7 @@ def run_m2o_oversubscribe_lossless_test(api,
 
     test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT)
     bg_flow_rate_percent = int(BG_FLOW_AGGR_RATE_PERCENT)
-    no_of_bg_streams = 1
-    if duthost.facts['asic_type'] == "cisco-8000":
-        no_of_bg_streams = 10
+    no_of_bg_streams = get_number_of_streams(egress_duthost, tx_port, rx_port)
     port_id = 0
     # Generate base traffic config
     snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -16,6 +16,7 @@ from tests.common.snappi_tests.traffic_generation import run_traffic, \
      setup_base_traffic_config                      # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
 from tests.common.portstat_utilities import parse_portstat                              # noqa: F401
+from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 logger = logging.getLogger(__name__)
@@ -101,9 +102,7 @@ def run_pfc_m2o_oversubscribe_lossless_lossy_test(api,
         stop_pfcwd(duthost, asic)
         disable_packet_aging(duthost)
 
-    no_of_lossy_streams = 1
-    if duthost.facts['asic_type'] == "cisco-8000":
-        no_of_lossy_streams = 10
+    no_of_lossy_streams = get_number_of_streams(egress_duthost, tx_port, rx_port)
     port_id = 0
     # Generate base traffic config
     snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossy_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossy_helper.py
@@ -15,6 +15,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, \
      run_traffic                                               # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
 
@@ -101,9 +102,7 @@ def run_pfc_m2o_oversubscribe_lossy_test(api,
 
     test_flow_rate_percent = int(TEST_FLOW_AGGR_RATE_PERCENT)
     bg_flow_rate_percent = int(BG_FLOW_AGGR_RATE_PERCENT)
-    no_of_test_streams = 1
-    if duthost.facts['asic_type'] == "cisco-8000":
-        no_of_test_streams = 10
+    no_of_test_streams = get_number_of_streams(egress_duthost, tx_port, rx_port)
     port_id = 0
     # Generate base traffic config
     snappi_extra_params.base_flow_config = setup_base_traffic_config(testbed_config=testbed_config,

--- a/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
@@ -12,6 +12,7 @@ from tests.common.snappi_tests.port import select_ports, select_tx_port         
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp                                 # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.snappi_tests.files.helper import get_number_of_streams
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 logger = logging.getLogger(__name__)
@@ -128,6 +129,7 @@ def run_pfcwd_basic_test(api,
 
     exp_dur_sec = flow2_delay_sec + flow2_dur_sec + 1
     cisco_platform = "Cisco" in egress_duthost.facts['hwsku']
+    number_of_streams = get_number_of_streams(egress_duthost, tx_port, rx_port)
 
     """ Generate traffic config """
     __gen_traffic(testbed_config=testbed_config,
@@ -145,7 +147,7 @@ def run_pfcwd_basic_test(api,
                   prio_list=prio_list,
                   prio_dscp_map=prio_dscp_map,
                   traffic_rate=49.99 if cisco_platform else 100.0,
-                  number_of_streams=1)
+                  number_of_streams=number_of_streams)
 
     flows = testbed_config.flows
 


### PR DESCRIPTION
For Cisco 8000 derive the no of test streams to be created based on src and dest port on different ASIC or DUT and if the src port speed is > 200G

Description of PR

For IXIA snappi tests (originally tested for 400G ports speeds), we had multiple traffic streams:

backplane port is 200G, so we cannot push single stream of 400G
multiple streams gets load balanced across backplane ports
When going to 100G ports as source MSFT is asking to not use multiple streams.
Use multiple streams only for cisco-8000 and only if source port is 400G.

Any platform specific information?
Cisco8000 only