### PR TITLE
[202503] add batch_mode support for bind_fp_ports and unbind_fp_ports (#18790)

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -1,14 +1,17 @@
 #!/usr/bin/python
 
+from contextlib import contextmanager
 import functools
 import hashlib
 import json
 import multiprocessing
 import os.path
 import re
+import shutil
 import subprocess
 import shlex
 import sys
+import tempfile
 import threading
 import time
 import traceback
@@ -175,6 +178,8 @@ RT_TABLE_FILEPATH = "/etc/iproute2/rt_tables"
 
 MIN_THREAD_WORKER_COUNT = 8
 LOG_SEPARATOR = "=" * 120
+
+DEFAULT_BATCH_PROCESSES_TIMEOUT = 600
 
 
 def construct_log_filename(cmd, vm_set_name):
@@ -898,7 +903,7 @@ class VMTopology(object):
         VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" %
                        (br_name, vlan2_iface_id, vlan1_iface_id))
 
-    def bind_fp_ports(self, disconnect_vm=False):
+    def bind_fp_ports(self, disconnect_vm=False, batch_mode=False):
         """
         bind dut front panel ports to VMs
 
@@ -930,7 +935,12 @@ class VMTopology(object):
                     (br_name, self.duts_fp_ports[self.duts_name[dut_index]][str(vlan_index)],
                      injected_iface, vm_iface, disconnect_vm)
                 )
-        self.worker.map(lambda args: self.bind_ovs_ports(*args), bind_ovs_ports_args)
+        if batch_mode:
+            with VMTopologyWorker.safe_subprocess_manager() as [processes, tmpdir]:
+                self.worker.map(lambda args: self.bind_ovs_ports(*args, processes=processes,
+                                                                 tmpdir=tmpdir), bind_ovs_ports_args)
+        else:
+            self.worker.map(lambda args: self.bind_ovs_ports(*args), bind_ovs_ports_args)
 
         if self.topo and 'DUT' in self.topo and 'vs_chassis' in self.topo['DUT']:
             # We have a KVM based virtaul chassis, bind the midplane and inband ports
@@ -971,7 +981,7 @@ class VMTopology(object):
                 injected_iface = adaptive_name(INJECTED_INTERFACES_TEMPLATE, self.vm_set_name, ptf_index)
                 self.bind_ovs_ports(br_name, port1, injected_iface, port2, disconnect_vm)
 
-    def unbind_fp_ports(self):
+    def unbind_fp_ports(self, batch_mode=False):
         logging.info("=== unbind front panel ports ===")
         unbind_ovs_ports_args = []
         for attr in self.VMs.values():
@@ -982,7 +992,11 @@ class VMTopology(object):
                     self.vm_names[self.vm_base_index + attr['vm_offset']], vlan_num)
                 unbind_ovs_ports_args.append((br_name, vm_iface))
 
-        self.worker.map(lambda args: self.unbind_ovs_ports(*args), unbind_ovs_ports_args)
+        if batch_mode:
+            with VMTopologyWorker.safe_subprocess_manager() as [processes, _]:
+                self.worker.map(lambda args: self.unbind_ovs_ports(*args, processes=processes), unbind_ovs_ports_args)
+        else:
+            self.worker.map(lambda args: self.unbind_ovs_ports(*args), unbind_ovs_ports_args)
 
         if self.topo and 'DUT' in self.topo and 'vs_chassis' in self.topo['DUT']:
             # We have a KVM based virtaul chassis, unbind the midplane and inband ports
@@ -1116,7 +1130,7 @@ class VMTopology(object):
                     VMTopology.cmd('ovs-vsctl del-port %s %s' %
                                    (br_name, port_name))
 
-    def bind_ovs_ports(self, br_name, dut_iface, injected_iface, vm_iface, disconnect_vm=False):
+    def bind_ovs_ports(self, br_name, dut_iface, injected_iface, vm_iface, disconnect_vm=False, **kwargs):
         """
         bind dut/injected/vm ports under an ovs bridge as follows
 
@@ -1171,83 +1185,113 @@ class VMTopology(object):
             VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" %
                            (br_name, dut_iface_id, injected_iface_id))
         else:
+            bind_helper = VMTopology.cmd
+            is_batch_mode = "processes" in kwargs
+            all_cmds = []
+
+            if is_batch_mode:
+                bind_helper = lambda cmd: \
+                    all_cmds.append(cmd.split()[-1])  # noqa: E731
+
             # Add flow from external iface to a VM and a ptf container
             # Allow BGP, IPinIP, fragmented packets, ICMP, SNMP packets and layer2 packets from DUT to neighbors
             # Block other traffic from DUT to EOS for EOS's stability,
             # Allow all traffic from DUT to PTF.
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,tcp,in_port=%s,tp_src=179,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,tcp,in_port=%s,tp_dst=179,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,tcp,in_port=%s,tp_dst=22,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,tcp,in_port=%s,tp_src=22,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,tcp6,in_port=%s,tp_src=179,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,tcp6,in_port=%s,tp_dst=179,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,tcp6,in_port=%s,tp_dst=22,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,tcp6,in_port=%s,tp_src=22,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,ip,in_port=%s,nw_proto=4,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,ip,in_port=%s,nw_frag=yes,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,ipv6,in_port=%s,nw_frag=yes,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,icmp,in_port=%s,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,icmp6,in_port=%s,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,udp,in_port=%s,udp_src=161,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,udp,in_port=%s,udp_src=53,action=output:%s" %
-                           (br_name, dut_iface_id, vm_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=8,udp6,in_port=%s,udp_src=161,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=6,udp6,in_port=%s,udp_dst=4784,action=output:%s" %
-                           (br_name, dut_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=5,ip,in_port=%s,action=output:%s" %
-                           (br_name, dut_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=5,ipv6,in_port=%s,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=3,in_port=%s,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,ip,in_port=%s,nw_proto=89,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s table=0,priority=10,ipv6,in_port=%s,nw_proto=89,action=output:%s,%s" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=10,tcp,in_port=%s,tp_src=179,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=10,tcp,in_port=%s,tp_dst=179,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=10,tcp,in_port=%s,tp_dst=22,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=10,tcp,in_port=%s,tp_src=22,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=10,tcp6,in_port=%s,tp_src=179,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=10,tcp6,in_port=%s,tp_dst=179,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=10,tcp6,in_port=%s,tp_dst=22,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=10,tcp6,in_port=%s,tp_src=22,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=10,ip,in_port=%s,nw_proto=4,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=8,ip,in_port=%s,nw_frag=yes,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=8,ipv6,in_port=%s,nw_frag=yes,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=8,icmp,in_port=%s,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=8,icmp6,in_port=%s,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=8,udp,in_port=%s,udp_src=161,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=8,udp,in_port=%s,udp_src=53,action=output:%s" %
+                        (br_name, dut_iface_id, vm_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=8,udp6,in_port=%s,udp_src=161,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=6,udp6,in_port=%s,udp_dst=4784,action=output:%s" %
+                        (br_name, dut_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=5,ip,in_port=%s,action=output:%s" %
+                        (br_name, dut_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=5,ipv6,in_port=%s,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=3,in_port=%s,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=10,ip,in_port=%s,nw_proto=89,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s table=0,priority=10,ipv6,in_port=%s,nw_proto=89,action=output:%s,%s" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
 
         # Add flow for BFD Control packets (UDP port 3784)
-            VMTopology.cmd("ovs-ofctl add-flow %s 'table=0,priority=10,udp,in_port=%s,\
-                           udp_dst=3784,action=output:%s,%s'" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s 'table=0,priority=10,udp6,in_port=%s,\
-                           udp_dst=3784,action=output:%s,%s'" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s 'table=0,priority=10,udp,in_port=%s,\
+                        udp_dst=3784,action=output:%s,%s'" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s 'table=0,priority=10,udp6,in_port=%s,\
+                        udp_dst=3784,action=output:%s,%s'" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             # Add flow for BFD Control packets (UDP port 3784)
-            VMTopology.cmd("ovs-ofctl add-flow %s 'table=0,priority=10,udp,in_port=%s,\
-                           udp_src=49152,udp_dst=3784,action=output:%s,%s'" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
-            VMTopology.cmd("ovs-ofctl add-flow %s 'table=0,priority=10,udp6,in_port=%s,\
-                           udp_src=49152,udp_dst=3784,action=output:%s,%s'" %
-                           (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s 'table=0,priority=10,udp,in_port=%s,\
+                        udp_src=49152,udp_dst=3784,action=output:%s,%s'" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
+            bind_helper("ovs-ofctl add-flow %s 'table=0,priority=10,udp6,in_port=%s,\
+                        udp_src=49152,udp_dst=3784,action=output:%s,%s'" %
+                        (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
 
         # Add flow from a ptf container to an external iface
-            VMTopology.cmd("ovs-ofctl add-flow %s 'table=0,in_port=%s,action=output:%s'" %
-                           (br_name, injected_iface_id, dut_iface_id))
+            bind_helper("ovs-ofctl add-flow %s 'table=0,in_port=%s,action=output:%s'" %
+                        (br_name, injected_iface_id, dut_iface_id))
 
-    def unbind_ovs_ports(self, br_name, vm_port):
+            if is_batch_mode and all_cmds:
+                processes = kwargs.get("processes")
+                tmpdir = kwargs.get("tmpdir")
+                with tempfile.NamedTemporaryFile("w", dir=tmpdir, delete=False) as f:
+                    for rule in all_cmds:
+                        f.write(rule.strip("'") + "\n")
+
+                processes.append(VMTopology.fire_and_forget("ovs-ofctl add-flows {} {}".format(br_name, f.name)))
+
+    def unbind_ovs_ports(self, br_name, vm_port, **kwargs):
         """unbind all ports except the vm port from an ovs bridge"""
         if VMTopology.intf_exists(br_name):
             ports = VMTopology.get_ovs_br_ports(br_name)
 
+            bind_helper = VMTopology.cmd
+            is_batch_mode = "processes" in kwargs
+
+            all_cmds = []
+
+            if is_batch_mode:
+                bind_helper = lambda cmd: \
+                    all_cmds.append(cmd[len("ovs-vsctl "):])  # noqa: E731
+
             for port in ports:
                 if port != vm_port:
-                    VMTopology.cmd('ovs-vsctl del-port %s %s' %
-                                   (br_name, port))
+                    bind_helper('ovs-vsctl del-port %s %s' % (br_name, port))
+
+            if is_batch_mode and all_cmds:
+                processes = kwargs.get("processes")
+                batch_cmd = 'ovs-vsctl -- %s' % (' -- '.join(all_cmds))
+                processes.append(VMTopology.fire_and_forget(batch_cmd))
 
     def unbind_ovs_port(self, br_name, port):
         """unbind a port from an ovs bridge"""
@@ -1646,6 +1690,18 @@ class VMTopology(object):
             return VMTopology.cmd('ethtool -K %s tx off' % (iface_name))
         else:
             return VMTopology.cmd('nsenter -t %s -n ethtool -K %s tx off' % (pid, iface_name))
+
+    @staticmethod
+    def fire_and_forget(cmdline):
+        cmdline_ori = cmdline
+        cmdline = shlex.split(cmdline_ori)
+
+        return VMTopologyWorker.Popen(
+                cmdline,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=False)
 
     @staticmethod
     def cmd(cmdline, grep_cmd=None, retry=1, negative=False, shell=False, split_cmd=True, ignore_errors=False):
@@ -2084,6 +2140,50 @@ class VMTopologyWorker(object):
     def __del__(self):
         self.shutdown()
 
+    @staticmethod
+    @contextmanager
+    def safe_subprocess_manager(timeout=DEFAULT_BATCH_PROCESSES_TIMEOUT):
+        tmpdir = tempfile.mkdtemp(prefix="/tmp/")
+        processes = []
+        err_msgs = []
+
+        yield processes, tmpdir
+
+        for process in processes:
+            if sys.version_info.major < 3:
+                # Python 2: implement manual timeout
+                start_time = time.time()
+                while process.poll() is None:
+                    if time.time() - start_time > timeout:
+                        process.kill()
+                        out, err = process.communicate()
+                        raise Exception("Process timeout after {} seconds".format(timeout))
+                    time.sleep(1)
+                out, err = process.communicate()
+            else:
+                out, err = process.communicate(timeout=timeout)
+
+            out, err = out.decode('utf-8'), err.decode('utf-8')
+            return_code = process.returncode
+
+            if return_code != 0:
+                err_msg = "return_code={}, error message='{}', cmd='{}'".format(return_code, err, process.args)
+                err_msgs.append(err_msg)
+
+        shutil.rmtree(tmpdir)
+
+        if len(err_msgs) > 0:
+            raise Exception(json.dumps({'message': 'One of the batch commands failed', 'error': err_msg}, indent=2))
+
+    @staticmethod
+    def Popen(*args, **kwds):
+        res = subprocess.Popen(*args, **kwds)
+
+        if not hasattr(res, "args"):
+            res.args = args[0]
+
+        return res
+
 
 def main():
     module = AnsibleModule(
@@ -2116,7 +2216,8 @@ def main():
             use_thread_worker=dict(required=False, type='bool', default=True),
             thread_worker_count=dict(required=False, type='int',
                                      default=max(MIN_THREAD_WORKER_COUNT,
-                                                 multiprocessing.cpu_count() // 8))
+                                                 multiprocessing.cpu_count() // 8)),
+            batch_mode=dict(required=False, type='bool', default=False)
         ),
         supports_check_mode=False)
 
@@ -2130,6 +2231,7 @@ def main():
     dut_interfaces = module.params['dut_interfaces']
     use_thread_worker = module.params['use_thread_worker']
     thread_worker_count = module.params['thread_worker_count']
+    batch_mode = module.params['batch_mode']
 
     config_module_logging(construct_log_filename(cmd, vm_set_name))
 
@@ -2204,7 +2306,7 @@ def main():
             if vms_exists:
                 net.add_injected_fp_ports_to_docker()
                 net.add_injected_VM_ports_to_docker()
-                net.bind_fp_ports()
+                net.bind_fp_ports(batch_mode=batch_mode)
                 net.bind_vm_backplane()
                 net.add_bp_port_to_docker(ptf_bp_ip_addr, ptf_bp_ipv6_addr)
 
@@ -2280,7 +2382,7 @@ def main():
 
             if vms_exists:
                 net.unbind_vm_backplane()
-                net.unbind_fp_ports()
+                net.unbind_fp_ports(batch_mode=batch_mode)
                 net.remove_injected_fp_ports_from_docker()
 
             if hostif_exists:
@@ -2350,10 +2452,10 @@ def main():
                 net.delete_network_namespace()
 
             if vms_exists:
-                net.unbind_fp_ports()
+                net.unbind_fp_ports(batch_mode=batch_mode)
                 net.add_injected_fp_ports_to_docker()
                 net.add_injected_VM_ports_to_docker()
-                net.bind_fp_ports()
+                net.bind_fp_ports(batch_mode=batch_mode)
                 net.bind_vm_backplane()
                 net.add_bp_port_to_docker(ptf_bp_ip_addr, ptf_bp_ipv6_addr)
 

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -32,6 +32,11 @@
   become: yes
   when: docker_registry_username is defined and docker_registry_password is defined
 
+- name: set batch_mode for lt2 topo
+  set_fact:
+    batch_mode: True
+  when: "'lt2' in topo"
+
 - name: Deploy Keysight API Server container
   block:
     - name: Get Keysight API Server container status
@@ -151,6 +156,7 @@
         duts_name: "{{ duts_name.split(',') }}"
         fp_mtu: "{{ fp_mtu_size }}"
         max_fp_num: "{{ max_fp_num }}"
+        batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
       become: yes
 
   when: container_type == "IxANVL-CONF-TESTER"
@@ -234,6 +240,7 @@
       max_fp_num: "{{ max_fp_num }}"
       netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
       dut_interfaces: "{{ dut_interfaces | default('') }}"
+      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
     become: yes
 
   - name: Bind topology {{ topo }} to DPUs.
@@ -259,6 +266,7 @@
       fp_mtu: "{{ fp_mtu_size }}"
       max_fp_num: "{{ max_fp_num }}"
       netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
+      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
       is_dpu: true
     become: yes
     when: dpu_targets is defined and dpu_targets | length > 0

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -12,6 +12,11 @@
     container_type: "IxANVL-CONF-TESTER"
   when: ptf_imagename is defined and ptf_imagename == "docker-ptf-anvl"
 
+- name: set batch_mode for lt2 topo
+  set_fact:
+    batch_mode: True
+  when: "'lt2' in topo"
+
 - block:
 
   - name: Stop mux simulator
@@ -58,6 +63,7 @@
       duts_name: "{{ duts_name.split(',') }}"
       max_fp_num: "{{ max_fp_num }}"
       dut_interfaces: "{{ dut_interfaces | default('') }}"
+      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
     become: yes
 
   - name: Unbind topology {{ topo }} to DPU VMs. base vm = {{ VM_base }}
@@ -72,6 +78,7 @@
       duts_mgmt_port: "{{ duts_mgmt_port }}"
       duts_name: "{{ duts_name.split(',') }}"
       max_fp_num: "{{ max_fp_num }}"
+      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
       is_dpu: true
     become: yes
     when: dpu_targets is defined and dpu_targets | length > 0
@@ -141,6 +148,7 @@
       duts_mgmt_port: "{{ duts_mgmt_port }}"
       duts_name: "{{ duts_name.split(',') }}"
       max_fp_num: "{{ max_fp_num }}"
+      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
     become: yes
 
   - name: Remove duts ports

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -64,6 +64,11 @@
     loop_control:
       loop_var: dut_name
 
+  - name: set batch_mode for lt2 topo
+    set_fact:
+      batch_mode: True
+    when: "'lt2' in topo"
+
   - name: Unbind topology {{ topo }} to VMs. base vm = {{ VM_base }}
     vm_topology:
       cmd: "unbind"
@@ -75,6 +80,7 @@
       duts_fp_ports: "{{ duts_fp_ports }}"
       duts_name: "{{ duts_name.split(',') }}"
       max_fp_num: "{{ max_fp_num }}"
+      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
     become: yes
 
   - name: Stop ptf container ptf_{{ vm_set_name }}
@@ -173,6 +179,7 @@
       fp_mtu: "{{ fp_mtu_size }}"
       max_fp_num: "{{ max_fp_num }}"
       netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
+      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
     become: yes
 
   - name: Change MAC address for PTF interfaces


### PR DESCRIPTION
Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/18790

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  This PR add option to use batch_mode support for bind_fp_ports. Which improves the speed by 50% tested on 128 VM neighbor.

Fixes # (issue) 32654908


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

When doing ovs flow creation, we're launching subprocess and waiting for each subprocess result before continue with the next call. This process is very inefficient even with the aid of multi-threading support.

#### How did you do it?

This PR change the behavior of multi-threading in the following way:
1. Batching all the ovs flow creation commands that needed to execute into a single file
2. Launch 1 process to call `ovs-ofctl` on the file using add-flows, put the process into queue for wait later and free the thread so that the same thread can be use to launch a different batch
3. In the end, main thread will wait for all the batches launched from process finished

This PR also provide an options to opt in this feature

#### How did you verify/test it?

Verified on physical testbed with 128 VMs. Time deduction for the same settings of 8 Threads is reduced from 1 hour 30 minutes  to 45 minutes average.


The following is a sample of the same settings, same number of threads, with batch_mode enabled on renumber topology and unbind topology. 

We can see the majority of benefit in Renumber topology by batch the bind_fp_ports.

Before

```
Wednesday 04 June 2025  03:12:40 +0000 (0:00:00.055)       1:43:10.602 ********
===============================================================================
vm_set : Renumber topology lt2-o128 to VMs. base vm = VM73166 -------- 4998.28s
vm_set : Unbind topology lt2-o128 to VMs. base vm = VM73166 ----------- 557.45s
vm_set : Kill exabgp and ptf_nn_agent processes in PTF container ------ 206.43s
vm_set : Setup vlan port for vlan tunnel ------------------------------- 92.35s
vm_set : Verify that exabgp processes for IPv4 are started ------------- 45.90s
vm_set : Verify that exabgp processes for IPv6 are started ------------- 45.79s
vm_set : Configure exabgp processes for IPv4 on PTF -------------------- 27.62s
vm_set : configure exabgp processes for IPv6 on PTF -------------------- 26.66s
vm_set : Stop ptf container ptf_vms73-2 -------------------------------- 16.49s
vm_set : Run the "apt-get update" as a separate and retryable step ----- 14.26s
vm_set : Create ptf container ptf_vms73-2 ------------------------------ 14.25s
vm_set : Try to login into docker registry ----------------------------- 12.00s
vm_set : Remove ptf container ptf_vms73-2 ------------------------------ 11.54s
vm_set : Set ipv6 route max size of ptf_vms73-2 ------------------------ 11.13s
vm_set : Enable ipv6 for docker container ptf_vms73-2 ------------------ 11.03s
vm_set : Install necessary packages ------------------------------------ 10.58s
vm_set : Announce routes ------------------------------------------------ 9.99s
vm_set : Install necessary packages ------------------------------------- 9.09s
vm_set : Stop PTF portchannel ------------------------------------------- 4.60s
vm_set : Change PTF interface MAC addresses ----------------------------- 4.35s
```


**After**

```
Wednesday 04 June 2025  07:30:07 +0000 (0:00:00.069)       0:52:51.148 ********
===============================================================================
vm_set : Renumber topology lt2-o128 to VMs. base vm = VM73166 -------- 1980.45s
vm_set : Unbind topology lt2-o128 to VMs. base vm = VM73166 ----------- 552.96s
vm_set : Kill exabgp and ptf_nn_agent processes in PTF container ------ 206.56s
vm_set : Setup vlan port for vlan tunnel ------------------------------ 108.52s
vm_set : Verify that exabgp processes for IPv4 are started ------------- 45.76s
vm_set : Verify that exabgp processes for IPv6 are started ------------- 45.45s
vm_set : Configure exabgp processes for IPv4 on PTF -------------------- 27.49s
vm_set : configure exabgp processes for IPv6 on PTF -------------------- 25.96s
vm_set : Stop ptf container ptf_vms73-2 -------------------------------- 16.17s
vm_set : Create ptf container ptf_vms73-2 ------------------------------ 15.02s
vm_set : Remove ptf container ptf_vms73-2 ------------------------------ 12.38s
vm_set : Set ipv6 route max size of ptf_vms73-2 ------------------------ 11.56s
vm_set : Try to login into docker registry ----------------------------- 11.13s
vm_set : Install necessary packages ------------------------------------ 10.50s
vm_set : Install necessary packages ------------------------------------- 8.84s
vm_set : Announce routes ------------------------------------------------ 7.81s
vm_set : Run the "apt-get update" as a separate and retryable step ------ 6.45s
vm_set : Add exabgpv6 supervisor config and start related processes ----- 4.74s
vm_set : Change PTF interface MAC addresses ----------------------------- 4.67s
vm_set : Stop PTF portchannel ------------------------------------------- 4.51s
```

# Other topology
The only affected functionality are `renumber topology` and `unbind topology`


| topology | no batch | batch|
|-----------|--------|---------|
|t0|![image](https://github.com/user-attachments/assets/0eabf1a0-f463-4c9a-bf0e-65b8d04fc1eb)| ![image](https://github.com/user-attachments/assets/d565bb82-cebf-417f-aad2-f3539ae5f4b1)|
|t1-64-lag|![image](https://github.com/user-attachments/assets/b978c5c2-b39d-4299-9f96-02dbbd31fce7)|![image](https://github.com/user-attachments/assets/176b8d71-f5be-4630-89a3-ed5859c448e0)|
|dualtor-120|![image](https://github.com/user-attachments/assets/38622ea6-cce2-4f95-b5e6-e1ff8d16a491)|![image](https://github.com/user-attachments/assets/b97b2349-b22e-41e0-b77b-1936f4e16caf)|





#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
