### PR TITLE
[202503] chore: adjust ASN value for LT2 and FT2 (#18915)

### DIFF
--- a/ansible/generate_topo.py
+++ b/ansible/generate_topo.py
@@ -51,7 +51,7 @@ roles_cfg = {
         "asn_v6": 4200100000,
         "downlink": {"role": "t1", "asn": 4200000000, "asn_v6": 4200000000, "asn_increment": 0, "num_lags": 1},
         "uplink": {"role": "ut2", "asn": 4200200000, "asn_v6": 4200200000, "asn_increment": 0},
-        "fabric": {"role": "ft2", "asn": 4200300000, "asn_v6": 4200300000, "asn_increment": 0},
+        "fabric": {"role": "ft2", "asn": 4200100000, "asn_v6": 4200100000, "asn_increment": 0},
         "peer": None
     },
 }
@@ -118,7 +118,7 @@ hw_port_cfg = {
                          "panel_port_step": 1},
     'p32o64lt2':        {"ds_breakout": 2, "us_breakout": 2, "ds_link_step": 1, "us_link_step": 1,
                          'uplink_ports': PortList(45, 49, 46, 50),
-                         'skip_ports': PortList(11, 12, 13, 14, 27, 28, 29, 30),
+                         'skip_ports': PortList(11, 12, 13, 14, 27, 28, 29, 30, 61, 62, 63),
                          "fabric_breakout": 1,
                          'fabric_ports': PortList(
                                  *[p for p in range(0, 32)]

--- a/ansible/vars/topo_ft2-64.yml
+++ b/ansible/vars/topo_ft2-64.yml
@@ -277,7 +277,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.0
@@ -296,7 +296,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.2
@@ -315,7 +315,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.4
@@ -334,7 +334,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.6
@@ -353,7 +353,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.8
@@ -372,7 +372,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.10
@@ -391,7 +391,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.12
@@ -410,7 +410,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.14
@@ -429,7 +429,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.16
@@ -448,7 +448,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.18
@@ -467,7 +467,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.20
@@ -486,7 +486,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.22
@@ -505,7 +505,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.24
@@ -524,7 +524,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.26
@@ -543,7 +543,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.28
@@ -562,7 +562,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.30
@@ -581,7 +581,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.32
@@ -600,7 +600,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.34
@@ -619,7 +619,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.36
@@ -638,7 +638,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.38
@@ -657,7 +657,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.40
@@ -676,7 +676,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.42
@@ -695,7 +695,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.44
@@ -714,7 +714,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.46
@@ -733,7 +733,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.48
@@ -752,7 +752,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.50
@@ -771,7 +771,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.52
@@ -790,7 +790,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.54
@@ -809,7 +809,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.56
@@ -828,7 +828,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.58
@@ -847,7 +847,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.60
@@ -866,7 +866,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.62
@@ -885,7 +885,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.64
@@ -904,7 +904,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.66
@@ -923,7 +923,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.68
@@ -942,7 +942,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.70
@@ -961,7 +961,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.72
@@ -980,7 +980,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.74
@@ -999,7 +999,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.76
@@ -1018,7 +1018,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.78
@@ -1037,7 +1037,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.80
@@ -1056,7 +1056,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.82
@@ -1075,7 +1075,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.84
@@ -1094,7 +1094,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.86
@@ -1113,7 +1113,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.88
@@ -1132,7 +1132,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.90
@@ -1151,7 +1151,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.92
@@ -1170,7 +1170,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.94
@@ -1189,7 +1189,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.96
@@ -1208,7 +1208,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.98
@@ -1227,7 +1227,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.100
@@ -1246,7 +1246,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.102
@@ -1265,7 +1265,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.104
@@ -1284,7 +1284,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.106
@@ -1303,7 +1303,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.108
@@ -1322,7 +1322,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.110
@@ -1341,7 +1341,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.112
@@ -1360,7 +1360,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.114
@@ -1379,7 +1379,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.116
@@ -1398,7 +1398,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.118
@@ -1417,7 +1417,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.120
@@ -1436,7 +1436,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.122
@@ -1455,7 +1455,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.124
@@ -1474,7 +1474,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 4200200000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.126

--- a/ansible/vars/topo_lt2-p32o64.yml
+++ b/ansible/vars/topo_lt2-p32o64.yml
@@ -328,30 +328,6 @@ topology:
       vlans:
         - 89
       vm_offset: 81
-    ARISTA51T1:
-      vlans:
-        - 90
-      vm_offset: 82
-    ARISTA52T1:
-      vlans:
-        - 91
-      vm_offset: 83
-    ARISTA53T1:
-      vlans:
-        - 92
-      vm_offset: 84
-    ARISTA54T1:
-      vlans:
-        - 93
-      vm_offset: 85
-    ARISTA55T1:
-      vlans:
-        - 94
-      vm_offset: 86
-    ARISTA56T1:
-      vlans:
-        - 95
-      vm_offset: 87
 
 configuration_properties:
   common:
@@ -375,7 +351,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.0
@@ -395,7 +371,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.2
@@ -415,7 +391,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.4
@@ -435,7 +411,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.6
@@ -455,7 +431,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.8
@@ -475,7 +451,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.10
@@ -495,7 +471,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.12
@@ -515,7 +491,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.14
@@ -535,7 +511,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.16
@@ -555,7 +531,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.18
@@ -575,7 +551,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.20
@@ -595,7 +571,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.30
@@ -615,7 +591,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.32
@@ -635,7 +611,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.34
@@ -655,7 +631,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.36
@@ -675,7 +651,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.38
@@ -695,7 +671,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.40
@@ -715,7 +691,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.42
@@ -735,7 +711,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.44
@@ -755,7 +731,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.46
@@ -775,7 +751,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.48
@@ -795,7 +771,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.50
@@ -815,7 +791,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.52
@@ -835,7 +811,7 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 4200300000
+      asn: 4200100000
       peers:
         4200100000:
           - 10.0.0.62
@@ -2160,141 +2136,3 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.91/24
       ipv6: fc0a::5b/64
-  ARISTA51T1:
-    properties:
-    - common
-    - leaf
-    tornum: 51
-    bgp:
-      asn: 4200000000
-      peers:
-        4200100000:
-          - 10.0.0.180
-          - fc00::169
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.91/32
-        ipv6: 2064:100:0:5b::/128
-      Ethernet1:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.0.181/31
-        ipv6: fc00::16a/126
-    bp_interface:
-      ipv4: 10.10.246.92/24
-      ipv6: fc0a::5c/64
-  ARISTA52T1:
-    properties:
-    - common
-    - leaf
-    tornum: 52
-    bgp:
-      asn: 4200000000
-      peers:
-        4200100000:
-          - 10.0.0.182
-          - fc00::16d
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.92/32
-        ipv6: 2064:100:0:5c::/128
-      Ethernet1:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.0.183/31
-        ipv6: fc00::16e/126
-    bp_interface:
-      ipv4: 10.10.246.93/24
-      ipv6: fc0a::5d/64
-  ARISTA53T1:
-    properties:
-    - common
-    - leaf
-    tornum: 53
-    bgp:
-      asn: 4200000000
-      peers:
-        4200100000:
-          - 10.0.0.184
-          - fc00::171
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.93/32
-        ipv6: 2064:100:0:5d::/128
-      Ethernet1:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.0.185/31
-        ipv6: fc00::172/126
-    bp_interface:
-      ipv4: 10.10.246.94/24
-      ipv6: fc0a::5e/64
-  ARISTA54T1:
-    properties:
-    - common
-    - leaf
-    tornum: 54
-    bgp:
-      asn: 4200000000
-      peers:
-        4200100000:
-          - 10.0.0.186
-          - fc00::175
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.94/32
-        ipv6: 2064:100:0:5e::/128
-      Ethernet1:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.0.187/31
-        ipv6: fc00::176/126
-    bp_interface:
-      ipv4: 10.10.246.95/24
-      ipv6: fc0a::5f/64
-  ARISTA55T1:
-    properties:
-    - common
-    - leaf
-    tornum: 55
-    bgp:
-      asn: 4200000000
-      peers:
-        4200100000:
-          - 10.0.0.188
-          - fc00::179
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.95/32
-        ipv6: 2064:100:0:5f::/128
-      Ethernet1:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.0.189/31
-        ipv6: fc00::17a/126
-    bp_interface:
-      ipv4: 10.10.246.96/24
-      ipv6: fc0a::60/64
-  ARISTA56T1:
-    properties:
-    - common
-    - leaf
-    tornum: 56
-    bgp:
-      asn: 4200000000
-      peers:
-        4200100000:
-          - 10.0.0.190
-          - fc00::17d
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.96/32
-        ipv6: 2064:100:0:60::/128
-      Ethernet1:
-        lacp: 1
-      Port-Channel1:
-        ipv4: 10.0.0.191/31
-        ipv6: fc00::17e/126
-    bp_interface:
-      ipv4: 10.10.246.97/24
-      ipv6: fc0a::61/64


### PR DESCRIPTION
Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/18915


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Correct the ASN number of LT2 and FT2
Fixes # (issue) 33226573

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
- Correct the ASN number of FT2 to LT2. For these 2 groups we should have the same ASN.
- Added some missing code for generate_topo

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
