### PR TITLE
Update mvrf test case for chrony support (#17434)

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -60,18 +60,22 @@ def setup_ntp_func(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6):
         yield result
 
 
-@pytest.fixture(scope="module")
-def ntp_daemon_in_use(duthost):
-    ntpsec_conf_stat = duthost.stat(path="/etc/ntpsec/ntp.conf")
+def get_ntp_daemon_in_use(host):
+    ntpsec_conf_stat = host.stat(path="/etc/ntpsec/ntp.conf")
     if ntpsec_conf_stat["stat"]["exists"]:
         return NtpDaemon.NTPSEC
-    chrony_conf_stat = duthost.stat(path="/etc/chrony/chrony.conf")
+    chrony_conf_stat = host.stat(path="/etc/chrony/chrony.conf")
     if chrony_conf_stat["stat"]["exists"]:
         return NtpDaemon.CHRONY
-    ntp_conf_stat = duthost.stat(path="/etc/ntp.conf")
+    ntp_conf_stat = host.stat(path="/etc/ntp.conf")
     if ntp_conf_stat["stat"]["exists"]:
         return NtpDaemon.NTP
     pytest.fail("Unable to determine NTP daemon in use")
+
+
+@pytest.fixture(scope="module")
+def ntp_daemon_in_use(duthost):
+    return get_ntp_daemon_in_use(duthost)
 
 
 def check_ntp_status(host, ntp_daemon_in_use):

--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -1,6 +1,6 @@
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.ntp_helper import check_ntp_status, run_ntp, setup_ntp_context, NtpDaemon, ntp_daemon_in_use   # noqa F401
+from tests.common.helpers.ntp_helper import check_ntp_status, run_ntp, setup_ntp_context, NtpDaemon, ntp_daemon_in_use  # noqa: F401, E501
 import logging
 import time
 import pytest


### PR DESCRIPTION
What is the motivation for this PR?
With the NTP daemon being changed from ntpd to chrony, commands that refer to the ntpd daemon need to be updated to point to chrony instead.

How did you do it?
Update the mvrf test case to point to chrony-related commands instead of ntpd-related commands.

How did you verify/test it?
Tested on physical T0 and T2 testbed.