### PR TITLE
[add-topo] Set kernel.pty.max to 8192 (#19054)

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -151,6 +151,16 @@
   become: yes
   when: host_distribution_version.stdout == "20.04" or host_distribution_version.stdout == "22.04"
 
+- name: Set kernel.pty.max to 8192
+  become: true
+  sysctl:
+    name: kernel.pty.max
+    value: 8192
+    state: present
+    sysctl_set: true
+    reload: true
+    sysctl_file: /etc/sysctl.d/99-pty.conf
+
 - name: Install br_netfilter kernel module
   become: yes
   modprobe: name=br_netfilter state=present


### PR DESCRIPTION
What is the motivation for this PR?
Support deploy thousands of ceos/net containers on a single server.

How did you do it?
Set kernel.pty.max to 8192 in add-topo ansible-playbook.

How did you verify/test it?
Verified by deploy physical testbed.