### PR TITLE
Add SPC5 hwskus for SN5640 platforms (#18921)

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -25,7 +25,7 @@ mellanox_spc3_hwskus: [ 'ACS-MSN4700', 'Mellanox-SN4700-O28', 'Mellanox-SN4700-O
 mellanox_spc4_hwskus: [ 'ACS-SN5600' , 'Mellanox-SN5600-V256', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5600-C224O8',
                         'Mellanox-SN5610N-C256S2', 'Mellanox-SN5610N-C224O8']
 mellanox_spc5_hwskus: [ 'Mellanox-SN5640-C512S2', 'Mellanox-SN5640-C448O16']
-mellanox_hwskus: "{{ mellanox_spc1_hwskus + mellanox_spc2_hwskus + mellanox_spc3_hwskus + mellanox_spc4_hwskus + mellanox_spc5_hwskus + mellanox_spc5_hwskus }}"
+mellanox_hwskus: "{{ mellanox_spc1_hwskus + mellanox_spc2_hwskus + mellanox_spc3_hwskus + mellanox_spc4_hwskus + mellanox_spc5_hwskus }}"
 mellanox_dualtor_hwskus: [ 'Mellanox-SN4600C-C64' ]
 
 cavium_hwskus: [ "AS7512", "XP-SIM" ]

--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -7,7 +7,8 @@ SPC2_HWSKUS = ["ACS-MSN3700", "ACS-MSN3700C", "ACS-MSN3800", "Mellanox-SN3800-D1
 SPC3_HWSKUS = ["ACS-MSN4700", "Mellanox-SN4700-O28", "ACS-MSN4600C", "ACS-MSN4410", "ACS-MSN4600",
                "Mellanox-SN4600C-D112C8", "Mellanox-SN4600C-C64", "ACS-SN4280", "Mellanox-SN4280-O28"]
 SPC4_HWSKUS = ["ACS-SN5600", "Mellanox-SN5600-V256", "Mellanox-SN5600-C256S1", "Mellanox-SN5600-C224O8"]
-SWITCH_HWSKUS = SPC1_HWSKUS + SPC2_HWSKUS + SPC3_HWSKUS + SPC4_HWSKUS
+SPC5_HWSKUS = ["Mellanox-SN5640-C512S2", "Mellanox-SN5640-C448O16"]
+SWITCH_HWSKUS = SPC1_HWSKUS + SPC2_HWSKUS + SPC3_HWSKUS + SPC4_HWSKUS + SPC5_HWSKUS
 
 PSU_CAPABILITIES = [
     ['psu{}_curr', 'psu{}_curr_in', 'psu{}_power', 'psu{}_power_in', 'psu{}_volt', 'psu{}_volt_in', 'psu{}_volt_out'],


### PR DESCRIPTION
What is the motivation for this PR?
Added 2 new spc5 hwskus Mellanox-SN5640-C512S2, Mellanox-SN5640-C448O16 for Nvidia SN5640 platforms

How did you do it?
Added data to sonic-mgmt framework

How did you verify/test it?
Manually verified it in multiple platform tests such as platform_tests/test_reboot.py

================================================================================================================================================== short test summary info ================================================================================================================================================== SKIPPED [1] platform_tests/test_reboot.py: Skip test_soft_reboot for m0/mx and test is supported only on S6100 hwsku SKIPPED [1] platform_tests/test_reboot.py: Skip test_fast_reboot for m0/mx/t1/t2 / Fast reboot is broken on dualtor topology. Skipping for now. SKIPPED [1] platform_tests/test_reboot.py: Skip test_warm_reboot for m0/mx/t1/t2 / Warm reboot is broken on dualtor topology. Skipping for now. =================================================================================================================================== 3 passed, 3 skipped, 1 warning in 6155.83s (1:42:35) ====================================================================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_continuous_reboot[str4-sn5640-3]>