### PR TITLE
Skip multiple servers testbed parsing on branch 202405

### DIFF
--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -169,10 +169,10 @@ class ParseTestbedTopoinfo():
             with open(self.testbed_filename) as f:
                 tb_info = yaml.safe_load(f)
                 for tb in tb_info:
-                    if tb["ptf_ip"]:
+                    if "ptf_ip" in tb and tb["ptf_ip"]:
                         tb["ptf_ip"], tb["ptf_netmask"] = \
                             _cidr_to_ip_mask(tb["ptf_ip"])
-                    if tb["ptf_ipv6"]:
+                    if "ptf_ipv6" in tb and tb["ptf_ipv6"]:
                         tb["ptf_ipv6"], tb["ptf_netmask_v6"] = \
                             _cidr_to_ip_mask(tb["ptf_ipv6"])
                     tb["duts"] = tb.pop("dut")

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -107,10 +107,10 @@ class TestbedInfo(object):
         with open(self.testbed_filename) as f:
             tb_info = yaml.safe_load(f)
             for tb in tb_info:
-                if tb["ptf_ip"]:
+                if "ptf_ip" in tb and tb["ptf_ip"]:
                     tb["ptf_ip"], tb["ptf_netmask"] = \
                         self._cidr_to_ip_mask(tb["ptf_ip"])
-                if tb["ptf_ipv6"]:
+                if "ptf_ipv6" in tb and tb["ptf_ipv6"]:
                     tb["ptf_ipv6"], tb["ptf_netmask_v6"] = \
                         self._cidr_to_ip_mask(tb["ptf_ipv6"])
                 tb["duts"] = tb.pop("dut")


### PR DESCRIPTION
In PRs: https://github.com/sonic-net/sonic-mgmt/pull/15643 and https://github.com/sonic-net/sonic-mgmt/pull/15881
We implemented multi-servers testbed design, however, to enable parsing multi-servers testbed definition, raise this PR to fix out of key error.
The code is already in master branch, and we only need the four lines code to be backport to 202411 and 202405