### PR TITLE
[cherry-pick] Update cEOS configuration to use next-hop-self (#18659)

### DIFF
--- a/ansible/roles/eos/tasks/ceos.yml
+++ b/ansible/roles/eos/tasks/ceos.yml
@@ -20,8 +20,8 @@
     set_fact: force_restart=no
     when: snmp_data.ansible_facts.ansible_sysname is defined
 
-- include_tasks: ceos_config.yml
 - include_vars: group_vars/vm_host/ceos.yml
+- include_tasks: ceos_config.yml
 
 - name: Create cEOS container
   become: yes

--- a/ansible/roles/eos/templates/dpu-tor.j2
+++ b/ansible/roles/eos/templates/dpu-tor.j2
@@ -106,6 +106,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/m0-mx.j2
+++ b/ansible/roles/eos/templates/m0-mx.j2
@@ -102,6 +102,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t0-8-lag-leaf.j2
+++ b/ansible/roles/eos/templates/t0-8-lag-leaf.j2
@@ -106,6 +106,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t0-backend-leaf.j2
+++ b/ansible/roles/eos/templates/t0-backend-leaf.j2
@@ -136,6 +136,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t0-leaf-lag-2.j2
+++ b/ansible/roles/eos/templates/t0-leaf-lag-2.j2
@@ -106,6 +106,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -106,6 +106,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t0-mclag-leaf.j2
+++ b/ansible/roles/eos/templates/t0-mclag-leaf.j2
@@ -106,6 +106,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t0-v6-leaf.j2
+++ b/ansible/roles/eos/templates/t0-v6-leaf.j2
@@ -106,6 +106,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t1-28-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-28-lag-spine.j2
@@ -106,6 +106,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t1-28-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-28-lag-tor.j2
@@ -110,6 +110,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t1-56-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-56-lag-tor.j2
@@ -110,6 +110,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -110,6 +110,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t1-8-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-spine.j2
@@ -104,6 +104,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t1-8-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-tor.j2
@@ -108,6 +108,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t1-backend-tor.j2
+++ b/ansible/roles/eos/templates/t1-backend-tor.j2
@@ -136,6 +136,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -106,6 +106,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t1-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-lag-tor.j2
@@ -103,6 +103,7 @@ router bgp {{ host['bgp']['asn'] }}
  router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t2-core.j2
+++ b/ansible/roles/eos/templates/t2-core.j2
@@ -126,6 +126,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} maximum-routes 0
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t2-leaf.j2
+++ b/ansible/roles/eos/templates/t2-leaf.j2
@@ -114,6 +114,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} maximum-routes 0
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} allowas-in
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t2-vs-core.j2
+++ b/ansible/roles/eos/templates/t2-vs-core.j2
@@ -113,6 +113,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} maximum-routes 0
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t2-vs-leaf.j2
+++ b/ansible/roles/eos/templates/t2-vs-leaf.j2
@@ -113,6 +113,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} maximum-routes 0
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate


### PR DESCRIPTION
The upgraded cEOS instance also changes from single-agent to multi-agent mode.  This includes a behaviour change around the next-hop-self feature.

Fixes: BUG872880

What is the motivation for this PR?
Fixing a bug introduced by using a newer version of cEOS for testing. While the current documentation doesn't specify a newer version of cEOS, it would be good to have this fix in place before people start using a newer version of cEOS.

How did you do it?
Adjust the cEOS configuration templates to force cEOS to rewrite the next-hop as itself

How did you verify/test it?
Normal sonic-mgmt test run

Any platform specific information?
Not platform-dependent.

Supported testbed topology if it's a new test case? All