### PR TITLE
[Cherrypick] Replace collections.Iterable with collections.abc.Iterable (#19329)

### DIFF
--- a/tests/common/dualtor/control_plane_utils.py
+++ b/tests/common/dualtor/control_plane_utils.py
@@ -1,11 +1,11 @@
 """Contains functions used to verify control plane(APP_DB, STATE_DB) values."""
-import collections
 import json
 import logging
 
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
+from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +269,7 @@ def verify_tor_states(
     Verifies that the expected states for active and standby ToRs are
     reflected in APP_DB and STATE_DB on each device
     """
-    if not isinstance(expected_active_host, collections.Iterable):
+    if not isinstance(expected_active_host, Iterable):
         expected_active_host = [] if expected_active_host is None else [expected_active_host]
     for duthost in expected_active_host:
         db_checker = DBChecker(duthost, 'active', 'healthy',
@@ -282,7 +282,7 @@ def verify_tor_states(
         if not skip_tunnel_route:
             db_checker.verify_tunnel_route(standalone_tunnel_route)
 
-    if not isinstance(expected_standby_host, collections.Iterable):
+    if not isinstance(expected_standby_host, Iterable):
         expected_standby_host = [] if expected_standby_host is None else [expected_standby_host]
     for duthost in expected_standby_host:
         db_checker = DBChecker(duthost, 'standby', expected_standby_health,

--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -2,7 +2,6 @@
 import grpc
 import pytest
 import time
-import collections
 import logging
 
 from tests.common import utilities
@@ -15,6 +14,7 @@ from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.nic_simulator import nic_simulator_grpc_service_pb2
 from tests.common.dualtor.nic_simulator import nic_simulator_grpc_mgmt_service_pb2
 from tests.common.dualtor.nic_simulator import nic_simulator_grpc_mgmt_service_pb2_grpc
+from collections.abc import Iterable
 
 
 __all__ = [
@@ -210,7 +210,7 @@ def nic_simulator_url(nic_simulator_info):
 def toggle_ports(duthosts, intf_name, state):
     """Toggle port from cmd line"""
 
-    if not isinstance(duthosts, collections.Iterable):
+    if not isinstance(duthosts, Iterable):
         duthosts = [duthosts]
 
     toggled_intfs = []


### PR DESCRIPTION
Cherry #19329
What is the motivation for this PR?
Starting with Python 3.3, collections.Iterable was deprecated in favor of collections.abc.Iterable, though it remained temporarily supported for backward compatibility. However, as of Python 3.10, the old reference has been officially removed. Doc image

Since we are upgrading Python from 3.8 to 3.12—where collections.Iterable is no longer supported—we will update all such references to use collections.abc.Iterable to ensure compatibility and prevent runtime errors.

How did you do it?
We will update all such references to use collections.abc.Iterable to ensure compatibility and prevent runtime errors.

How did you verify/test it?
We need to make sure that this change won't affect current test firstly -- test by pipeline itself. And then, we need to make sure that this change works in the new version -- test locally.