### PR TITLE
Fix test_acl for t1-isolated-d32/128 due to PT0 condition

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -366,8 +366,6 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
                     upstream_ports[neighbor['namespace']].append(interface)
                     upstream_port_ids.append(port_id)
                     upstream_port_id_to_router_mac_map[port_id] = rand_selected_dut.facts["router_mac"]
-                    if neigh_type == "PT0":
-                        upstream_service_ports[neighbor['namespace']].append(interface)
                 count += 1
         else:
             for interface, neighbor in list(mg_facts["minigraph_neighbors"].items()):


### PR DESCRIPTION
Remove broken PT0 condition for t1-isolated-d32/128 acl port selection that is not applicable for the topo.
This fixes the tests in test_acl.py for t1-isolated-d32/128

Only affecting 202412 as regression occurred after merging 202411 changes:
https://github.com/Azure/sonic-mgmt.msft/commit/fb533969e599bb32cf3a95803b9a4d64071daddc