### PR TITLE
[202412] Fix for NTP test failing due to unsynchronized clock

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -30,6 +30,12 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
 
     ptfhost.lineinfile(path=ntp_conf_path, line="server 127.127.1.0 prefer")
 
+    # Comment out the tos minclock minsane option line
+    # Having this option enabled can cause the NTP server to not synchronize
+    # with the PTF host, which can lead to test failures.
+    ptfhost.lineinfile(
+        path=ntp_conf_path, line="#tos minclock 4 minsane 3", regexp="^tos.*minclock.*minsane.*")
+
     # restart ntp server
     ntp_en_res = ptfhost.service(name=ntp_service_name, state="restarted")
 


### PR DESCRIPTION
Manual merge of PR https://github.com/sonic-net/sonic-mgmt/pull/19444 as auto-merge failed.