### PR TITLE
[test_pfcwd_status] skipped generic_config_updater.test_pfcwd_status for non-supported hwsku SN5640 and Arista7060X6PE (#19430)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1087,6 +1087,8 @@ generic_config_updater/test_pfcwd_status.py:
       - "topo_type in ['m0', 'mx']"
       - "release in ['202211']"
       - "'t2' in topo_name"
+      - "hwsku in ['Mellanox-SN5600-C224O8', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5600-C224O8',
+                   'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']"
 
 generic_config_updater/test_pg_headroom_update.py:
   skip:


### PR DESCRIPTION

What is the motivation for this PR?
Resolved 202412 conflicts in https://github.com/sonic-net/sonic-mgmt/pull/19430
Skipped generic_config_updater.test_pfcwd_status for non-supported hwsku SN5640 and Arista7060X6PE

How did you do it?
Add non-supported hwsku to conditional markers

How did you verify/test it?
Veried it in sonic mgmt test generic_config_updater.test_pfcwd_status

Any platform specific information?
str4-sn5640-3

Supported testbed topology if it's a new test case? t1-isolated-d56u1-lag