### PR TITLE
Increase delay for route convergence if # of routes are above threshold when port toggle and reboot in ACL test (#18959)

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1414,10 +1414,37 @@ class TestAclWithReboot(TestBasicAcl):
 
         """
         dut.command("config save -y")
+
+        # Get the original number of eBGP v4 and v6 routes on the DUT.
+        sumv4, sumv6 = dut.get_ip_route_summary()
+        v4_routes_count = sumv4.get('ebgp', {'routes': 0})['routes']
+        v6_routes_count = sumv6.get('ebgp', {'routes': 0})['routes']
+        logging.info("eBGP v4 routes: {}, eBGP v6 routes: {}".format(v4_routes_count, v6_routes_count))
+        # Dictionary mapping route thresholds to convergence delays
+        # e.g. if route_delay_map = {10000: 60, 50000: 120}
+        # routes = 0-9999 -> delay = 60s, 10000-49999 -> 120s, 50000+ -> 180s
+        route_delay_map = {10000: 60, 25000: 90, 50000: 120, 75000: 150}
+        max_routes = max(v4_routes_count, v6_routes_count)
+
+        route_convergence_delay = 180  # Default for 75000+ routes
+        for threshold, delay in sorted(route_delay_map.items()):
+            if max_routes < threshold:
+                route_convergence_delay = delay
+                break
+
+        logger.info("Route count: {}, setting convergence delay to: {}".format(max_routes, route_convergence_delay))
+
         reboot(dut, localhost, safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
         # We need some additional delay on e1031
         if dut.facts["platform"] == "x86_64-cel_e1031-r0":
-            time.sleep(240)
+            route_convergence_delay = 240
+        elif dut.get_facts().get("modular_chassis") and dut.facts["asic_type"] == "cisco-8000":
+            # todo: remove the extra sleep on chassis device after bgp suppress fib pending feature is enabled
+            # We observe flakiness failure on chassis devices
+            # Suspect it's because the route is not programmed into hardware
+            # Add external sleep to make sure route is in hardware
+            route_convergence_delay = 180
+
         # We need additional delay and make sure ports are up for Nokia-IXR7250E-36x400G
         if dut.facts["hwsku"] == "Nokia-IXR7250E-36x400G":
             interfaces = conn_graph_facts["device_conn"][dut.hostname]
@@ -1430,8 +1457,8 @@ class TestAclWithReboot(TestBasicAcl):
             assert result, "Not all transceivers are detected or interfaces are up in {} seconds".format(
                 MAX_WAIT_TIME_FOR_INTERFACES)
 
-        # Delay 10 seconds for route convergence
-        time.sleep(10)
+        # Delay for route convergence
+        time.sleep(route_convergence_delay)
 
         populate_vlan_arp_entries()
 
@@ -1452,12 +1479,32 @@ class TestAclWithPortToggle(TestBasicAcl):
             populate_vlan_arp_entries: A fixture to populate ARP/FDB tables for VLAN interfaces.
 
         """
+
+        # Get the original number of eBGP v4 and v6 routes on the DUT.
+        sumv4, sumv6 = dut.get_ip_route_summary()
+        v4_routes_count = sumv4.get('ebgp', {'routes': 0})['routes']
+        v6_routes_count = sumv6.get('ebgp', {'routes': 0})['routes']
+        logging.info("eBGP v4 routes: {}, eBGP v6 routes: {}".format(v4_routes_count, v6_routes_count))
+        # Dictionary mapping route thresholds to convergence delays
+        # e.g. if route_delay_map = {10000: 60, 50000: 120}
+        # routes = 0-9999 -> delay = 60s, 10000-49999 -> 120s, 50000+ -> 180s
+        route_delay_map = {10000: 60, 25000: 90, 50000: 120, 75000: 150}
+        max_routes = max(v4_routes_count, v6_routes_count)
+
+        route_convergence_delay = 180  # Default for 75000+ routes
+        for threshold, delay in sorted(route_delay_map.items()):
+            if max_routes < threshold:
+                route_convergence_delay = delay
+                break
+
+        logger.info("Route count: {}, setting convergence delay to: {}".format(max_routes, route_convergence_delay))
+
         # todo: remove the extra sleep on chassis device after bgp suppress fib pending feature is enabled
         # We observe flakiness failure on chassis devices
         # Suspect it's because the route is not programmed into hardware
         # Add external sleep to make sure route is in hardware
         if dut.get_facts().get("modular_chassis"):
-            port_toggle(dut, tbinfo, wait_after_ports_up=180)
-        else:
-            port_toggle(dut, tbinfo)
+            route_convergence_delay = 180
+
+        port_toggle(dut, tbinfo, wait_after_ports_up=route_convergence_delay)
         populate_vlan_arp_entries()


### PR DESCRIPTION
Fix conflicts for https://github.com/sonic-net/sonic-mgmt/pull/18959

Description of PR
Summary:
Fixes #18953

Type of change
 Bug fix
 Testbed and Framework(new/improvement)
 New Test case
 Skipped for non-supported platforms
 Test case improvement

Approach
What is the motivation for this PR?
Fix packets in ACL tests being dropped or using wrong route after reboot / port toggle when there are too many routes, causing route convergence to be slower

How did you do it?
Make test use common param for route convergence, which is able to be manipulated by new # of route check and existing checks

How did you verify/test it?
Run the full test suite twice on a TB with 100,000+ routes https://elastictest.org/scheduler/testplan/68654ccb3d76d955497fbeb0?leftSideViewMode=detail&testcase=acl%2Ftest_acl.py%7C%7C%7C1&type=console

Signed-off-by: Javier Tan javiertan@microsoft.com