### PR TITLE
Enable pretest with ipv6 testbeds (#19584)

### DIFF
--- a/ansible/library/show_ipv6_interface.py
+++ b/ansible/library/show_ipv6_interface.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python
+
+from ansible.module_utils.basic import AnsibleModule
+import re
+
+DOCUMENTATION = '''
+module: show_ipv6_interface.py
+Short_description: Retrieve show ipv6 interface
+Description:
+    - Retrieve IPv6 address of interface and IPv6 address of its neighbor
+
+options:
+    - namespace::
+          Description: In multi ASIC env, namespace to run the command
+          Required: False
+
+'''
+
+EXAMPLES = '''
+  # Get show ipv6 interface
+  - show_ipv6_interface:
+
+  # Get show ipv6 interface in namespace asic0
+  - show_ipv6_interface: namespace='asic0'
+
+'''
+
+
+class ShowIpv6InterfaceModule(object):
+    def __init__(self):
+        self.module = AnsibleModule(
+            argument_spec=dict(
+                namespace=dict(required=False, type='str', default=None),
+            ),
+            supports_check_mode=False
+        )
+        self.m_args = self.module.params
+        self.out = None
+        self.facts = {}
+        self.ns = ""
+        ns = self.m_args["namespace"]
+        if ns is not None:
+            self.ns = " -n {} -d all  ".format(ns)
+
+    def run(self):
+        """
+            Main method of the class
+        """
+        regex_int = re.compile(
+            r"\s*(\S+)\s+"                                    # interface name
+            r"([0-9a-fA-F:]+)\/(\d{1,3})\s*"                 # IPv6 address/prefix
+            r"(up|down)\/(up|down)\s*"                        # oper/admin state
+            r"(\S+)\s*"                                       # neighbor name
+            r"([0-9a-fA-F:]+|N\/A)\s*"                       # peer IPv6
+        )
+
+        regex_old = re.compile(
+            r"\s*(\S+)\s+"                                    # interface name
+            r"([0-9a-fA-F:]+)\/(\d{1,3})\s*"                 # IPv6 address/prefix
+            r"(up|down)\/(up|down)\s*"                        # oper/admin state
+        )
+
+        self.ipv6_int = {}
+        try:
+            rc, self.out, err = self.module.run_command(
+                "show ipv6 interfaces{}".format(self.ns),
+                executable='/bin/bash',
+                use_unsafe_shell=True
+            )
+            for line in self.out.split("\n"):
+                line = line.strip()
+                m = re.match(regex_int, line)
+                om = re.match(regex_old, line)
+                if m:
+                    self.ipv6_int[m.group(1)] = {}
+                    self.ipv6_int[m.group(1)]["ipv6"] = m.group(2)
+                    self.ipv6_int[m.group(1)]["prefix_len"] = m.group(3)
+                    self.ipv6_int[m.group(1)]["admin"] = m.group(4)
+                    self.ipv6_int[m.group(1)]["oper_state"] = m.group(5)
+                    self.ipv6_int[m.group(1)]["bgp_neighbor"] = m.group(6)
+                    self.ipv6_int[m.group(1)]["peer_ipv6"] = m.group(7)
+                elif om:
+                    self.ipv6_int[om.group(1)] = {}
+                    self.ipv6_int[om.group(1)]["ipv6"] = om.group(2)
+                    self.ipv6_int[om.group(1)]["prefix_len"] = om.group(3)
+                    self.ipv6_int[om.group(1)]["admin"] = om.group(4)
+                    self.ipv6_int[om.group(1)]["oper_state"] = om.group(5)
+            self.facts['ipv6_interfaces'] = self.ipv6_int
+        except Exception as e:
+            self.module.fail_json(msg=str(e))
+        if rc != 0:
+            self.module.fail_json(
+                msg="Command failed rc = %d, out = %s, err = %s" % (rc, self.out, err))
+
+        self.module.exit_json(ansible_facts=self.facts)
+
+
+def main():
+    ShowIpv6Int = ShowIpv6InterfaceModule()
+    ShowIpv6Int.run()
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -159,6 +159,19 @@ class SonicAsic(object):
         complex_args['namespace'] = self.namespace
         return self.sonichost.show_ip_interface(*module_args, **complex_args)
 
+    def show_ipv6_interface(self, *module_args, **complex_args):
+        """Wrapper for the ansible module 'show_ipv6_interface'
+
+        Args:
+            module_args: other ansible module args passed from the caller
+            complex_args: other ansible keyword args
+
+        Returns:
+            [dict]: [the output of show ipv6 interfaces command]
+        """
+        complex_args['namespace'] = self.namespace
+        return self.sonichost.show_ipv6_interface(*module_args, **complex_args)
+
     def run_sonic_db_cli_cmd(self, sonic_db_cmd):
         cmd = "{} {}".format(self.sonic_db_cli, sonic_db_cmd)
         return self.sonichost.command(cmd, verbose=False)

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -7,10 +7,10 @@ import pytest
 import time
 
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
-from tests.common.utilities import wait, wait_until, is_ipv4_address
-from tests.common.dualtor.mux_simulator_control import get_mux_status, reset_simulator_port     # noqa F401
-from tests.common.dualtor.mux_simulator_control import restart_mux_simulator                    # noqa F401
-from tests.common.dualtor.nic_simulator_control import restart_nic_simulator                    # noqa F401
+from tests.common.utilities import wait, wait_until, is_ipv4_address, is_ipv6_address
+from tests.common.dualtor.mux_simulator_control import get_mux_status, reset_simulator_port     # noqa: F401
+from tests.common.dualtor.mux_simulator_control import restart_mux_simulator                    # noqa: F401
+from tests.common.dualtor.nic_simulator_control import restart_nic_simulator                    # noqa: F401
 from tests.common.dualtor.constants import UPPER_TOR, LOWER_TOR, NIC
 from tests.common.dualtor.dual_tor_common import CableType, active_standby_ports                # noqa F401
 from tests.common.cache import FactsCache
@@ -63,9 +63,13 @@ def _find_down_phy_ports(dut, phy_interfaces):
     return down_phy_ports
 
 
-def _find_down_ip_ports(dut, ip_interfaces):
+def _find_down_ip_ports(dut, ip_interfaces, use_ipv6=False):
     down_ip_ports = []
-    ip_intf_facts = dut.show_ip_interface()['ansible_facts']['ip_interfaces']
+    if use_ipv6:
+        ip_intf_facts = dut.show_ipv6_interface()['ansible_facts']['ipv6_interfaces']
+    else:
+        ip_intf_facts = dut.show_ip_interface()['ansible_facts']['ip_interfaces']
+
     for intf in ip_interfaces:
         try:
             if ip_intf_facts[intf]['oper_state'] == 'down':
@@ -75,26 +79,27 @@ def _find_down_ip_ports(dut, ip_interfaces):
     return down_ip_ports
 
 
-def _find_down_ports(dut, phy_interfaces, ip_interfaces):
+def _find_down_ports(dut, phy_interfaces, ip_interfaces, use_ipv6=False):
     """Finds the ports which are operationally down
 
     Args:
         dut (object): The sonichost/sonicasic object
         phy_interfaces (list): List of all phyiscal operation in 'admin_up'
         ip_interfaces (list): List of the L3 interfaces
+        use_ipv6 (bool): Whether to use IPv6 interface check instead of IPv4
 
     Returns:
         [list]: list of the down ports
     """
     down_ports = []
-    down_ports = _find_down_ip_ports(dut, ip_interfaces) + \
+    down_ports = _find_down_ip_ports(dut, ip_interfaces, use_ipv6) + \
         _find_down_phy_ports(dut, phy_interfaces)
 
     return down_ports
 
 
 @pytest.fixture(scope="module")
-def check_interfaces(duthosts):
+def check_interfaces(duthosts, tbinfo):
     init_result = {"failed": False, "check_item": "interfaces"}
 
     def _check(*args, **kwargs):
@@ -118,6 +123,14 @@ def check_interfaces(duthosts):
 
         down_ports = []
         check_result = {"failed": True, "check_item": "interfaces", "host": dut.hostname}
+
+        # Determine if we should use IPv6 interface checking
+        use_ipv6 = (
+            "-v6-" in tbinfo["topo"]["name"]
+            if tbinfo and "topo" in tbinfo and "name" in tbinfo["topo"]
+            else False
+        )
+
         for asic in dut.asics:
             ip_interfaces = []
             cfg_facts = asic.config_facts(host=dut.hostname,
@@ -128,22 +141,29 @@ def check_interfaces(duthosts):
                 ip_interfaces = list(cfg_facts["PORTCHANNEL_INTERFACE"].keys())
             if "VLAN_INTERFACE" in cfg_facts:
                 for vlan in cfg_facts["VLAN_INTERFACE"]:
-                    # check for IPv4 address only for now.
-                    if any(is_ipv4_address(addr) for addr in cfg_facts["VLAN_INTERFACE"][vlan]):
-                        ip_interfaces.append(vlan)
+                    if use_ipv6:
+                        # check for IPv6 address.
+                        if any(is_ipv6_address(addr) for addr in cfg_facts["VLAN_INTERFACE"][vlan]):
+                            ip_interfaces.append(vlan)
+                    else:
+                        # check for IPv4 address.
+                        if any(is_ipv4_address(addr) for addr in cfg_facts["VLAN_INTERFACE"][vlan]):
+                            ip_interfaces.append(vlan)
 
             logger.info(json.dumps(phy_interfaces, indent=4))
             logger.info(json.dumps(ip_interfaces, indent=4))
+            if use_ipv6:
+                logger.info("Using IPv6 interface checking for topology: %s" % tbinfo["topo"]["name"])
 
             if timeout == 0:  # Check interfaces status, do not retry.
-                down_ports += _find_down_ports(asic, phy_interfaces, ip_interfaces)
+                down_ports += _find_down_ports(asic, phy_interfaces, ip_interfaces, use_ipv6)
                 check_result["failed"] = True if len(down_ports) > 0 else False
                 check_result["down_ports"] = down_ports
             else:  # Retry checking interface status
                 start = time.time()
                 elapsed = 0
                 while elapsed < timeout:
-                    down_ports = _find_down_ports(asic, phy_interfaces, ip_interfaces)
+                    down_ports = _find_down_ports(asic, phy_interfaces, ip_interfaces, use_ipv6)
                     check_result["failed"] = True if len(down_ports) > 0 else False
                     check_result["down_ports"] = down_ports
 

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -181,6 +181,7 @@ def check_interfaces(duthosts, tbinfo):
         results[dut.hostname] = check_result
     return _check
 
+
 @pytest.fixture(scope="module")
 def check_bgp(duthosts, tbinfo):
     init_result = {"failed": False, "check_item": "bgp"}

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -495,6 +495,16 @@ def is_ipv4_address(ip_address):
         return False
 
 
+def is_ipv6_address(ip_address):
+    """Check if ip address is ipv6."""
+    ip_address = ip_address.encode().decode()
+    try:
+        ipaddress.IPv6Address(ip_address)
+        return True
+    except ipaddress.AddressValueError:
+        return False
+
+
 def get_mgmt_ipv6(duthost):
     config_facts = duthost.get_running_config_facts()
     mgmt_interfaces = config_facts.get("MGMT_INTERFACE", {})


### PR DESCRIPTION
Enable pretest with ipv6 testbeds [#19584](https://github.com/sonic-net/sonic-mgmt/pull/19584)
Cherry-pick from https://github.com/sonic-net/sonic-mgmt/pull/19584