### PR TITLE
[202412][PR: 19646] Enhance deployment robustness with safe ovs-vsctl operations 

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -884,9 +884,9 @@ class VMTopology(object):
     def bind_devices_interconnect_ports(self, br_name, vlan1_iface, vlan2_iface):
         ports = VMTopology.get_ovs_br_ports(br_name)
         if vlan1_iface not in ports:
-            VMTopology.cmd('ovs-vsctl add-port %s %s' % (br_name, vlan1_iface))
+            VMTopology.cmd('ovs-vsctl --may-exist add-port %s %s' % (br_name, vlan1_iface))
         if vlan2_iface not in ports:
-            VMTopology.cmd('ovs-vsctl add-port %s %s' % (br_name, vlan2_iface))
+            VMTopology.cmd('ovs-vsctl --may-exist add-port %s %s' % (br_name, vlan2_iface))
         bindings = VMTopology.get_ovs_port_bindings(br_name)
         vlan1_iface_id = bindings[vlan1_iface]
         vlan2_iface_id = bindings[vlan2_iface]
@@ -1049,11 +1049,11 @@ class VMTopology(object):
         # Remove port from ovs bridge
         br = VMTopology.get_ovs_bridge_by_port(port1)
         if br is not None:
-            VMTopology.cmd('ovs-vsctl del-port %s %s' % (br, port1))
+            VMTopology.cmd('ovs-vsctl --if-exists del-port %s %s' % (br, port1))
 
         br = VMTopology.get_ovs_bridge_by_port(port2)
         if br is not None:
-            VMTopology.cmd('ovs-vsctl del-port %s %s' % (br, port2))
+            VMTopology.cmd('ovs-vsctl --if-exists del-port %s %s' % (br, port2))
 
         m_to_ifs, _ = VMTopology.brctl_show()
         if port1 not in m_to_ifs[br_name]:
@@ -1098,10 +1098,10 @@ class VMTopology(object):
             port_name = "{}-{}".format(dut_name, (a_port + 1))
             br = VMTopology.get_ovs_bridge_by_port(port_name)
             if br is not None and br != br_name:
-                VMTopology.cmd('ovs-vsctl del-port %s %s' % (br, port_name))
+                VMTopology.cmd('ovs-vsctl --if-exists del-port %s %s' % (br, port_name))
 
             if port_name not in br_ports:
-                VMTopology.cmd('ovs-vsctl add-port %s %s' %
+                VMTopology.cmd('ovs-vsctl --may-exist add-port %s %s' %
                                (br_name, port_name))
 
     def unbind_vs_dut_ports(self, br_name, dut_ports):
@@ -1112,7 +1112,7 @@ class VMTopology(object):
                 dut_name = self.duts_name[dut_index]
                 port_name = "{}-{}".format(dut_name, (a_port + 1))
                 if port_name in ports:
-                    VMTopology.cmd('ovs-vsctl del-port %s %s' %
+                    VMTopology.cmd('ovs-vsctl --if-exists del-port %s %s' %
                                    (br_name, port_name))
 
     def bind_ovs_ports(self, br_name, dut_iface, injected_iface, vm_iface, disconnect_vm=False):
@@ -1127,26 +1127,26 @@ class VMTopology(object):
         """
         br = VMTopology.get_ovs_bridge_by_port(injected_iface)
         if br is not None and br != br_name:
-            VMTopology.cmd('ovs-vsctl del-port %s %s' % (br, injected_iface))
+            VMTopology.cmd('ovs-vsctl --if-exists del-port %s %s' % (br, injected_iface))
 
         br = VMTopology.get_ovs_bridge_by_port(dut_iface)
         if br is not None and br != br_name:
-            VMTopology.cmd('ovs-vsctl del-port %s %s' % (br, dut_iface))
+            VMTopology.cmd('ovs-vsctl --if-exists del-port %s %s' % (br, dut_iface))
 
         br = VMTopology.get_ovs_bridge_by_port(vm_iface)
         if br is not None and br != br_name:
-            VMTopology.cmd('ovs-vsctl del-port %s %s' % (br, vm_iface))
+            VMTopology.cmd('ovs-vsctl --if-exists del-port %s %s' % (br, vm_iface))
 
         ports = VMTopology.get_ovs_br_ports(br_name)
         if injected_iface not in ports:
-            VMTopology.cmd('ovs-vsctl add-port %s %s' %
+            VMTopology.cmd('ovs-vsctl --may-exist add-port %s %s' %
                            (br_name, injected_iface))
 
         if dut_iface not in ports:
-            VMTopology.cmd('ovs-vsctl add-port %s %s' % (br_name, dut_iface))
+            VMTopology.cmd('ovs-vsctl --may-exist add-port %s %s' % (br_name, dut_iface))
 
         if vm_iface not in ports:
-            VMTopology.cmd('ovs-vsctl add-port %s %s' % (br_name, vm_iface))
+            VMTopology.cmd('ovs-vsctl --may-exist add-port %s %s' % (br_name, vm_iface))
 
         bindings = VMTopology.get_ovs_port_bindings(br_name, [dut_iface])
         dut_iface_id = bindings[dut_iface]
@@ -1245,7 +1245,7 @@ class VMTopology(object):
 
             for port in ports:
                 if port != vm_port:
-                    VMTopology.cmd('ovs-vsctl del-port %s %s' %
+                    VMTopology.cmd('ovs-vsctl --if-exists del-port %s %s' %
                                    (br_name, port))
 
     def unbind_ovs_port(self, br_name, port):
@@ -1254,7 +1254,7 @@ class VMTopology(object):
             ports = VMTopology.get_ovs_br_ports(br_name)
 
             if port in ports:
-                VMTopology.cmd('ovs-vsctl del-port %s %s' % (br_name, port))
+                VMTopology.cmd('ovs-vsctl --if-exists del-port %s %s' % (br_name, port))
 
     def create_dualtor_cable(self, host_ifindex, host_if, upper_if, lower_if, active_if_index=0, nic_if=None):
         """
@@ -1284,7 +1284,7 @@ class VMTopology(object):
         for intf in [host_if, upper_if, lower_if]:
             br = VMTopology.get_ovs_bridge_by_port(intf)
             if br is not None and br != br_name:
-                VMTopology.cmd('ovs-vsctl del-port %s %s' % (br, intf))
+                VMTopology.cmd('ovs-vsctl --if-exists del-port %s %s' % (br, intf))
 
         ports = VMTopology.get_ovs_br_ports(br_name)
         ports_to_be_attached = [host_if, upper_if, lower_if]
@@ -1292,7 +1292,7 @@ class VMTopology(object):
             ports_to_be_attached.append(nic_if)
         for intf in ports_to_be_attached:
             if intf not in ports:
-                VMTopology.cmd('ovs-vsctl add-port %s %s' % (br_name, intf))
+                VMTopology.cmd('ovs-vsctl --may-exist add-port %s %s' % (br_name, intf))
 
         bridge_ports = [upper_if, lower_if]
         if nic_if is not None:


### PR DESCRIPTION
Cherry pick [#19646](https://github.com/sonic-net/sonic-mgmt/pull/19646)

What is the motivation for this PR?
To accelerate deployment, we parallelized certain Ansible tasks. Since multiple Ansible threads might operate on the same port simultaneously, we added the --may-exist and --if-exists options to ovs-vsctl commands. This improves the robustness of our code by preventing conflicts during concurrent port operations.

How did you do it?
Add the --may-exist and --if-exists options to ovs-vsctl commands

How did you verify/test it?
Test by pipeline itself.