### PR TITLE
Reduce the number of ifconfig calls made in add_topo

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -280,13 +280,14 @@ class VMTopology(object):
                         self.VMs[k] = v
 
         if check_bridge:
+            intf_names = os.listdir('/sys/class/net')
             for hostname, attrs in self.VMs.items():
-                vmname = self.vm_names[self.vm_base_index +
-                                       attrs['vm_offset']]
-                vm_bridges = self.get_vm_bridges(vmname)
-                if len(attrs['vlans']) > len(vm_bridges):
+                vmname = self.vm_names[self.vm_base_index + attrs['vm_offset']]
+                vm_bridge_regx = OVS_FP_BRIDGE_REGEX % vmname
+                num_intfs = len([intf for intf in intf_names if re.search(vm_bridge_regx, intf)])
+                if len(attrs['vlans']) > num_intfs:
                     raise Exception("Wrong vlans parameter for hostname %s, vm %s. Too many vlans. Maximum is %d"
-                                    % (hostname, vmname, len(vm_bridges)))
+                                    % (hostname, vmname, num_intfs))
 
         self.VM_LINKs = {}
         if 'VM_LINKs' in self.topo:
@@ -491,18 +492,6 @@ class VMTopology(object):
     def destroy_ovs_bridge(self, bridge_name):
         logging.info('=== Destroy bridge %s ===' % bridge_name)
         VMTopology.cmd('ovs-vsctl --if-exists del-br %s' % bridge_name)
-
-    def get_vm_bridges(self, vmname):
-        brs = []
-        vm_bridge_regx = OVS_FP_BRIDGE_REGEX % vmname
-        out = VMTopology.cmd(
-            'ifconfig -a', grep_cmd='grep -E %s' % vm_bridge_regx, retry=3)
-        for row in out.split('\n'):
-            fields = row.split(':')
-            if len(fields) > 0:
-                brs.append(fields[0])
-
-        return brs
 
     def add_injected_fp_ports_to_docker(self):
         """


### PR DESCRIPTION
### Description of PR
This is a manual cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/19119 to 202412.

Within `VMTopology.init`, `ifconfig -a` is called for every VM. For topologies with several hundred VMs, each call to `ifconfig -a` can take an appreciable amount of time (from seconds to minutes, depending on exact number of VMs and processing power of the testbed server). Multiplying this across hundreds of VMs results in `add_topo` taking a significant amount of time to complete.

This change decreases the `add_topo` setup time by reducing the number of `ifconfig -a` calls within `VMTopology.init` from <number of VMs in the topology>  to 1. 

This change reduces setup time for non-multi-DUT configurations only; it does not impact the setup time for multi-DUT configurations.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412

### Approach
#### What is the motivation for this PR?
To reduce the setup time for `add_topo`, particularly for topologies with a larger number of VMs.

#### How did you do it?
Reduced the number of `ifconfig -a` calls within `VMTopology.init(...)` from <number of VMs in the topology>  to 1. 

#### How did you verify/test it?
Ran `add_topo` on a t1-isolated topology and confirmed that the setup time was reduced.

#### Any platform specific information?
This change reduces setup time for non-multi-DUT configurations only; it does not impact the setup time for multi-DUT configurations.