### PR TITLE
Added asn_increment for asn_v6, and updated topo_t1-isolated-v6-d56u1…

### DIFF
--- a/ansible/generate_topo.py
+++ b/ansible/generate_topo.py
@@ -346,6 +346,7 @@ def generate_topo(role: str,
             end_vlan_range = link_id_start + len(lag_port) * num_breakout
 
             vm_role_cfg["asn"] += vm_role_cfg.get("asn_increment", 1)
+            vm_role_cfg["asn_v6"] += vm_role_cfg.get("asn_increment", 1)
             vm = VM(range(link_id_start, end_vlan_range), len(vm_list), per_role_vm_count[vm_role_cfg["role"]], tornum,
                     dut_role_cfg["asn"], dut_role_cfg["asn_v6"], vm_role_cfg, link_id_start,
                     num_lags=len(lag_port) * num_breakout)
@@ -372,14 +373,19 @@ def generate_topo(role: str,
 
             # Create the VM or host interface based on the configuration
             if vm_role_cfg is not None:
-                per_role_vm_count[vm_role_cfg["role"]] += 1
+                if 'lt2' not in role:    # For non LT2 topo , the VM id is per-link basis.
+                    per_role_vm_count[vm_role_cfg["role"]] += 1
 
                 if (link_id - link_id_start) % link_step == 0 and panel_port_id not in skip_ports:
                     # Skip breakout if defined
                     if (panel_port_id, link_id - link_id_start) in skip_ports:
                         continue
 
+                    if 'lt2' in role:  # for LT2 topo, the VM id is continuous regardless of the link.
+                        per_role_vm_count[vm_role_cfg["role"]] += 1
+
                     vm_role_cfg["asn"] += vm_role_cfg.get("asn_increment", 1)
+                    vm_role_cfg["asn_v6"] += vm_role_cfg.get("asn_increment", 1)
                     vm = VM(link_id, len(vm_list), per_role_vm_count[vm_role_cfg["role"]], tornum,
                             dut_role_cfg["asn"], dut_role_cfg["asn_v6"], vm_role_cfg, link_id,
                             num_lags=vm_role_cfg.get('num_lags', 0))

--- a/ansible/vars/topo_t1-isolated-v6-d56u1-lag.yml
+++ b/ansible/vars/topo_t1-isolated-v6-d56u1-lag.yml
@@ -256,7 +256,7 @@ configuration:
     tornum: 1
     bgp:
       router-id: 100.1.0.1
-      asn: 4200000000
+      asn: 4200000001
       peers:
         4200100000:
           - fc00::1
@@ -274,7 +274,7 @@ configuration:
     tornum: 2
     bgp:
       router-id: 100.1.0.9
-      asn: 4200000000
+      asn: 4200000002
       peers:
         4200100000:
           - fc00::21
@@ -292,7 +292,7 @@ configuration:
     tornum: 3
     bgp:
       router-id: 100.1.0.17
-      asn: 4200000000
+      asn: 4200000003
       peers:
         4200100000:
           - fc00::41
@@ -310,7 +310,7 @@ configuration:
     tornum: 4
     bgp:
       router-id: 100.1.0.25
-      asn: 4200000000
+      asn: 4200000004
       peers:
         4200100000:
           - fc00::61
@@ -328,7 +328,7 @@ configuration:
     tornum: 5
     bgp:
       router-id: 100.1.0.33
-      asn: 4200000000
+      asn: 4200000005
       peers:
         4200100000:
           - fc00::81
@@ -346,7 +346,7 @@ configuration:
     tornum: 6
     bgp:
       router-id: 100.1.0.41
-      asn: 4200000000
+      asn: 4200000006
       peers:
         4200100000:
           - fc00::a1
@@ -364,7 +364,7 @@ configuration:
     tornum: 7
     bgp:
       router-id: 100.1.0.49
-      asn: 4200000000
+      asn: 4200000007
       peers:
         4200100000:
           - fc00::c1
@@ -382,7 +382,7 @@ configuration:
     tornum: 8
     bgp:
       router-id: 100.1.0.57
-      asn: 4200000000
+      asn: 4200000008
       peers:
         4200100000:
           - fc00::e1
@@ -400,7 +400,7 @@ configuration:
     tornum: 9
     bgp:
       router-id: 100.1.0.65
-      asn: 4200000000
+      asn: 4200000009
       peers:
         4200100000:
           - fc00::101
@@ -418,7 +418,7 @@ configuration:
     tornum: 10
     bgp:
       router-id: 100.1.0.73
-      asn: 4200000000
+      asn: 4200000010
       peers:
         4200100000:
           - fc00::121
@@ -436,7 +436,7 @@ configuration:
     tornum: 11
     bgp:
       router-id: 100.1.0.81
-      asn: 4200000000
+      asn: 4200000011
       peers:
         4200100000:
           - fc00::141
@@ -454,7 +454,7 @@ configuration:
     tornum: 12
     bgp:
       router-id: 100.1.0.89
-      asn: 4200000000
+      asn: 4200000012
       peers:
         4200100000:
           - fc00::161
@@ -493,7 +493,7 @@ configuration:
     tornum: 13
     bgp:
       router-id: 100.1.0.101
-      asn: 4200000000
+      asn: 4200000013
       peers:
         4200100000:
           - fc00::191
@@ -511,7 +511,7 @@ configuration:
     tornum: 14
     bgp:
       router-id: 100.1.0.109
-      asn: 4200000000
+      asn: 4200000014
       peers:
         4200100000:
           - fc00::1b1
@@ -529,7 +529,7 @@ configuration:
     tornum: 15
     bgp:
       router-id: 100.1.0.121
-      asn: 4200000000
+      asn: 4200000015
       peers:
         4200100000:
           - fc00::1e1
@@ -547,7 +547,7 @@ configuration:
     tornum: 16
     bgp:
       router-id: 100.1.0.129
-      asn: 4200000000
+      asn: 4200000016
       peers:
         4200100000:
           - fc00::201
@@ -565,7 +565,7 @@ configuration:
     tornum: 17
     bgp:
       router-id: 100.1.0.137
-      asn: 4200000000
+      asn: 4200000017
       peers:
         4200100000:
           - fc00::221
@@ -583,7 +583,7 @@ configuration:
     tornum: 18
     bgp:
       router-id: 100.1.0.145
-      asn: 4200000000
+      asn: 4200000018
       peers:
         4200100000:
           - fc00::241
@@ -601,7 +601,7 @@ configuration:
     tornum: 19
     bgp:
       router-id: 100.1.0.153
-      asn: 4200000000
+      asn: 4200000019
       peers:
         4200100000:
           - fc00::261
@@ -619,7 +619,7 @@ configuration:
     tornum: 20
     bgp:
       router-id: 100.1.0.161
-      asn: 4200000000
+      asn: 4200000020
       peers:
         4200100000:
           - fc00::281
@@ -637,7 +637,7 @@ configuration:
     tornum: 21
     bgp:
       router-id: 100.1.0.169
-      asn: 4200000000
+      asn: 4200000021
       peers:
         4200100000:
           - fc00::2a1
@@ -655,7 +655,7 @@ configuration:
     tornum: 22
     bgp:
       router-id: 100.1.0.177
-      asn: 4200000000
+      asn: 4200000022
       peers:
         4200100000:
           - fc00::2c1
@@ -673,7 +673,7 @@ configuration:
     tornum: 23
     bgp:
       router-id: 100.1.0.185
-      asn: 4200000000
+      asn: 4200000023
       peers:
         4200100000:
           - fc00::2e1
@@ -691,7 +691,7 @@ configuration:
     tornum: 24
     bgp:
       router-id: 100.1.0.193
-      asn: 4200000000
+      asn: 4200000024
       peers:
         4200100000:
           - fc00::301
@@ -709,7 +709,7 @@ configuration:
     tornum: 25
     bgp:
       router-id: 100.1.0.201
-      asn: 4200000000
+      asn: 4200000025
       peers:
         4200100000:
           - fc00::321
@@ -727,7 +727,7 @@ configuration:
     tornum: 26
     bgp:
       router-id: 100.1.0.209
-      asn: 4200000000
+      asn: 4200000026
       peers:
         4200100000:
           - fc00::341
@@ -745,7 +745,7 @@ configuration:
     tornum: 27
     bgp:
       router-id: 100.1.0.217
-      asn: 4200000000
+      asn: 4200000027
       peers:
         4200100000:
           - fc00::361
@@ -763,7 +763,7 @@ configuration:
     tornum: 28
     bgp:
       router-id: 100.1.0.225
-      asn: 4200000000
+      asn: 4200000028
       peers:
         4200100000:
           - fc00::381
@@ -781,7 +781,7 @@ configuration:
     tornum: 29
     bgp:
       router-id: 100.1.0.233
-      asn: 4200000000
+      asn: 4200000029
       peers:
         4200100000:
           - fc00::3a1
@@ -799,7 +799,7 @@ configuration:
     tornum: 30
     bgp:
       router-id: 100.1.0.241
-      asn: 4200000000
+      asn: 4200000030
       peers:
         4200100000:
           - fc00::3c1
@@ -817,7 +817,7 @@ configuration:
     tornum: 31
     bgp:
       router-id: 100.1.0.249
-      asn: 4200000000
+      asn: 4200000031
       peers:
         4200100000:
           - fc00::3e1
@@ -835,7 +835,7 @@ configuration:
     tornum: 32
     bgp:
       router-id: 100.1.1.1
-      asn: 4200000000
+      asn: 4200000032
       peers:
         4200100000:
           - fc00::401
@@ -853,7 +853,7 @@ configuration:
     tornum: 33
     bgp:
       router-id: 100.1.1.9
-      asn: 4200000000
+      asn: 4200000033
       peers:
         4200100000:
           - fc00::421
@@ -871,7 +871,7 @@ configuration:
     tornum: 34
     bgp:
       router-id: 100.1.1.17
-      asn: 4200000000
+      asn: 4200000034
       peers:
         4200100000:
           - fc00::441
@@ -889,7 +889,7 @@ configuration:
     tornum: 35
     bgp:
       router-id: 100.1.1.25
-      asn: 4200000000
+      asn: 4200000035
       peers:
         4200100000:
           - fc00::461
@@ -907,7 +907,7 @@ configuration:
     tornum: 36
     bgp:
       router-id: 100.1.1.33
-      asn: 4200000000
+      asn: 4200000036
       peers:
         4200100000:
           - fc00::481
@@ -925,7 +925,7 @@ configuration:
     tornum: 37
     bgp:
       router-id: 100.1.1.41
-      asn: 4200000000
+      asn: 4200000037
       peers:
         4200100000:
           - fc00::4a1
@@ -943,7 +943,7 @@ configuration:
     tornum: 38
     bgp:
       router-id: 100.1.1.49
-      asn: 4200000000
+      asn: 4200000038
       peers:
         4200100000:
           - fc00::4c1
@@ -961,7 +961,7 @@ configuration:
     tornum: 39
     bgp:
       router-id: 100.1.1.57
-      asn: 4200000000
+      asn: 4200000039
       peers:
         4200100000:
           - fc00::4e1
@@ -979,7 +979,7 @@ configuration:
     tornum: 40
     bgp:
       router-id: 100.1.1.65
-      asn: 4200000000
+      asn: 4200000040
       peers:
         4200100000:
           - fc00::501
@@ -997,7 +997,7 @@ configuration:
     tornum: 41
     bgp:
       router-id: 100.1.1.77
-      asn: 4200000000
+      asn: 4200000041
       peers:
         4200100000:
           - fc00::531
@@ -1015,7 +1015,7 @@ configuration:
     tornum: 42
     bgp:
       router-id: 100.1.1.85
-      asn: 4200000000
+      asn: 4200000042
       peers:
         4200100000:
           - fc00::551
@@ -1033,7 +1033,7 @@ configuration:
     tornum: 43
     bgp:
       router-id: 100.1.1.97
-      asn: 4200000000
+      asn: 4200000043
       peers:
         4200100000:
           - fc00::581
@@ -1051,7 +1051,7 @@ configuration:
     tornum: 44
     bgp:
       router-id: 100.1.1.105
-      asn: 4200000000
+      asn: 4200000044
       peers:
         4200100000:
           - fc00::5a1
@@ -1069,7 +1069,7 @@ configuration:
     tornum: 45
     bgp:
       router-id: 100.1.1.113
-      asn: 4200000000
+      asn: 4200000045
       peers:
         4200100000:
           - fc00::5c1
@@ -1087,7 +1087,7 @@ configuration:
     tornum: 46
     bgp:
       router-id: 100.1.1.121
-      asn: 4200000000
+      asn: 4200000046
       peers:
         4200100000:
           - fc00::5e1
@@ -1105,7 +1105,7 @@ configuration:
     tornum: 47
     bgp:
       router-id: 100.1.1.129
-      asn: 4200000000
+      asn: 4200000047
       peers:
         4200100000:
           - fc00::601
@@ -1123,7 +1123,7 @@ configuration:
     tornum: 48
     bgp:
       router-id: 100.1.1.137
-      asn: 4200000000
+      asn: 4200000048
       peers:
         4200100000:
           - fc00::621
@@ -1141,7 +1141,7 @@ configuration:
     tornum: 49
     bgp:
       router-id: 100.1.1.145
-      asn: 4200000000
+      asn: 4200000049
       peers:
         4200100000:
           - fc00::641
@@ -1159,7 +1159,7 @@ configuration:
     tornum: 50
     bgp:
       router-id: 100.1.1.153
-      asn: 4200000000
+      asn: 4200000050
       peers:
         4200100000:
           - fc00::661
@@ -1177,7 +1177,7 @@ configuration:
     tornum: 51
     bgp:
       router-id: 100.1.1.161
-      asn: 4200000000
+      asn: 4200000051
       peers:
         4200100000:
           - fc00::681
@@ -1195,7 +1195,7 @@ configuration:
     tornum: 52
     bgp:
       router-id: 100.1.1.169
-      asn: 4200000000
+      asn: 4200000052
       peers:
         4200100000:
           - fc00::6a1
@@ -1213,7 +1213,7 @@ configuration:
     tornum: 53
     bgp:
       router-id: 100.1.1.177
-      asn: 4200000000
+      asn: 4200000053
       peers:
         4200100000:
           - fc00::6c1
@@ -1231,7 +1231,7 @@ configuration:
     tornum: 54
     bgp:
       router-id: 100.1.1.185
-      asn: 4200000000
+      asn: 4200000054
       peers:
         4200100000:
           - fc00::6e1
@@ -1249,7 +1249,7 @@ configuration:
     tornum: 55
     bgp:
       router-id: 100.1.1.193
-      asn: 4200000000
+      asn: 4200000055
       peers:
         4200100000:
           - fc00::701
@@ -1267,7 +1267,7 @@ configuration:
     tornum: 56
     bgp:
       router-id: 100.1.1.201
-      asn: 4200000000
+      asn: 4200000056
       peers:
         4200100000:
           - fc00::721


### PR DESCRIPTION
…… (#19202)
Cherry-pick of: https://github.com/sonic-net/sonic-mgmt/pull/19202

What is the motivation for this PR?
To add support for ipv6 testbeds. Have the as number increment for ipv6 bgp.

How did you do it?
By adding the asn_increment for asn_v6 in ansible/generate_topo.py

How did you verify/test it?
Generated the topology ansible/vars/topo_t1-isolated-v6-d56u1-lag.yml