### PR TITLE
[test_pfcwd_status][test_pfcwd_interval] fix syntax to skip pfcwd related tests for hwsku SN5640 and Arista7060X6PE (#19751)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1084,20 +1084,22 @@ generic_config_updater/test_packet_trimming_config.py:
 
 generic_config_updater/test_pfcwd_interval.py:
   skip:
-    reason: "This test can only support mellanox platforms"
+    reason: "This test can only support mellanox platforms. This test is not run on this hwsku currently"
+    conditions_logical_operator: or
     conditions:
       - "asic_type not in ['mellanox']"
+      - hwsku in ['Mellanox-SN5600-C224O8', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C512S2',
+                   'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']
 
 generic_config_updater/test_pfcwd_status.py:
   skip:
-    reason: "This test is not run on this topo type or version or topology currently"
-    conditions_logical_operator: "OR"
+    reason: "This test is not run on this topo type or version or topology or hwsku currently"
+    conditions_logical_operator: or
     conditions:
       - "topo_type in ['m0', 'mx']"
       - "release in ['202211']"
-      - "'t2' in topo_name"
-      - "hwsku in ['Mellanox-SN5600-C224O8', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5600-C224O8',
-                   'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']"
+      - hwsku in ['Mellanox-SN5600-C224O8', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C512S2',
+                   'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']
 
 generic_config_updater/test_pg_headroom_update.py:
   skip:


### PR DESCRIPTION
What is the motivation for this PR?
skipped generic_config_updater.test_pfcwd_status and generic_config_updater/test_pfcwd_interval for non-supported hwsku SN5640 and Arista7060X6PE. Resolve 202412 conflicts in https://github.com/sonic-net/sonic-mgmt/pull/19751 

How did you do it?
Add non-supported hwsku to conditional markers

How did you verify/test it?
Veried it in sonic mgmt test generic_config_updater.test_pfcwd_status and generic_config_updater/test_pfcwd_interval:
```
========================================================================================== short test summary info =========================================================================================== SKIPPED [1] generic_config_updater/test_pfcwd_interval.py:143: This test can only support mellanox platforms ======================================================================================= 1 skipped, 1 warning in 40.49s =======================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_pfcwd_interval_config_updates[False-nonexistent-replace]>

========================================================================================== short test summary info =========================================================================================== SKIPPED [2] generic_config_updater/test_pfcwd_status.py:219: This test is not run on this topo type or version or topology currently SKIPPED [2] generic_config_updater/test_pfcwd_status.py:268: This test is not run on this topo type or version or topology currently ======================================================================================= 4 skipped, 1 warning in 39.89s ======================================================================================= 
```
Any platform specific information?
str4-sn5640-2

Supported testbed topology if it's a new test case? t0-isolated-d32u32s2