### PR TITLE
[Cherry-pick]Skip PSUs listed under skip_modules

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -35,19 +35,20 @@ def get_dut_psu_line_pattern(dut):
     elif dut.facts['platform'] == "x86_64-dellemc_z9332f_d1508-r0":
         psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(N/A)")
     else:
-        """
-        Changed the pattern to match space (s+) and non-space (S+) only.
-        w+ cannot match following examples properly:
-
-        example 1:
-            PSU 1  PWR-500AC-R  L8180S01HTAVP  N/A            N/A            N/A          OK        green
-            PSU 2  PWR-500AC-R  L8180S01HFAVP  N/A            N/A            N/A          OK        green
-        example 2:
-            PSU 1  N/A      N/A               12.05           3.38        40.62  OK        green
-            PSU 2  N/A      N/A               12.01           4.12        49.50  OK        green
-
-        """
-        psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off|N/A)")
+        # Changed the pattern to match different PSU name formats and status patterns.
+        # Supports various PSU naming conventions:
+        #
+        # example 1:
+        #     psu1   PWR-500AC-R  L8180S01HTAVP  N/A            N/A            N/A          OK        green
+        #     psu2   PWR-500AC-R  L8180S01HFAVP  N/A            N/A            N/A          OK        green
+        # example 2:
+        #     psutray0.psu0  N/A      N/A               12.05           3.38        40.62  OK        green
+        #     psutray0.psu1  N/A      N/A               12.01           4.12        49.50  OK        green
+        # example 3:
+        #     PSU 9  PSU6.3KW-20A-HV  DTM273501QU      1.00  55.052         11.359         626.386      OK        green
+        #
+        psu_line_pattern = re.compile(
+            r"^(PSU\s+\d+|\S+)\s+.*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off|N/A)")
     return psu_line_pattern
 
 

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -15,6 +15,7 @@ from tests.common.helpers.psu_helpers import turn_on_all_outlets, get_grouped_pd
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import wait_until, get_sup_node_or_random_node
 from tests.common.platform.device_utils import get_dut_psu_line_pattern
+from tests.platform_tests.cli.util import get_skip_mod_list
 from .thermal_control_test_helper import ThermalPolicyFileContext,\
     check_cli_output_with_mocker, restart_thermal_control_daemon, check_thermal_algorithm_status,\
     mocker_factory, disable_thermal_policy  # noqa F401
@@ -202,18 +203,49 @@ def check_vendor_specific_psustatus(dut, psu_status_line, psu_line_pattern):
         check_psu_sysfs(dut, psu_id, psu_status)
 
 
+def get_psu_name_and_check_skip(psu_identifier, skip_psu_list):
+    """
+    @summary: Convert PSU identifier to standardized name and check if it should be skipped
+    @param psu_identifier: Raw PSU identifier from platform (e.g., "1", "psu1", "psutray0.psu0")
+    @param skip_psu_list: List of PSU names to skip
+    @return: Tuple of (psu_name, should_skip)
+    """
+    # Handle different PSU identifier formats:
+    # 1. "psu1" - already contains psu prefix
+    # 2. "1" - just a number, needs PSU prefix
+    # 3. "psutray0.psu0" - complex format with psu in it
+    if 'psu' in psu_identifier.lower():
+        psu_name = psu_identifier
+    else:
+        psu_name = "PSU {}".format(psu_identifier)
+
+    # Check if PSU should be skipped (case-insensitive comparison)
+    should_skip = any(psu_name.lower() == skip_psu.lower() for skip_psu in skip_psu_list)
+    logging.info(f"PSU name '{psu_name}' should be skipped: {should_skip}")
+
+    return psu_name, should_skip
+
+
 def check_all_psu_on(dut, psu_test_results):
     """
-        @summary: check all PSUs are in 'OK' status.
+        @summary: Check that all non-skipped PSUs are in 'OK' status.
         @param dut: dut host instance.
         @param psu_test_results: dictionary of all PSU names, values are not important.
+        @return: True if all non-skipped PSUs are on (no powered off PSUs), otherwise False.
     """
     power_off_psu_list = []
+
+    # Get list of PSUs to skip from inventory configuration
+    skip_psu_list = get_skip_mod_list(dut, ['psus'])
 
     if "201811" in dut.os_version or "201911" in dut.os_version:
         cli_psu_status = dut.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:
             fields = line.split()
+            # Skip PSUs that are in the skip list
+            if fields[1] in skip_psu_list:
+                logging.info("Skip PSU {} as it is in skip list".format(fields[1]))
+                continue
             if " ".join(fields[2:]) != 'NOT PRESENT':
                 psu_test_results[fields[1]] = line
             if " ".join(fields[2:]) == "NOT OK":
@@ -223,14 +255,18 @@ def check_all_psu_on(dut, psu_test_results):
         cli_psu_status = dut.command(CMD_PLATFORM_PSUSTATUS_JSON)
         psu_info_list = json.loads(cli_psu_status["stdout"])
         for psu_info in psu_info_list:
+            if psu_info["name"] in skip_psu_list:
+                logging.info("Skip PSU {} as it is in skip list".format(psu_info["name"]))
+                continue
             if psu_info["status"] != 'NOT PRESENT':
                 psu_test_results[psu_info['name']] = psu_info
             if psu_info["status"] == "NOT OK":
-                power_off_psu_list.append(psu_info["index"])
+                power_off_psu_list.append(psu_info["name"])
 
     if power_off_psu_list:
-        logging.warn('Powered off PSUs: {}'.format(power_off_psu_list))
+        logging.warning('Powered off PSUs: {}'.format(power_off_psu_list))
 
+    # Return True if all PSUs are on (no powered off PSUs), otherwise False
     return len(power_off_psu_list) == 0
 
 
@@ -287,8 +323,19 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
     # Group outlets/PDUs by PSU and toggle PDUs by PSU
     psu_to_pdus = get_grouped_pdus_by_psu(pdu_ctrl)
 
+    # Get list of PSUs to skip from inventory configuration
+    skip_psu_list = get_skip_mod_list(duthost, ['psus'])
+    logging.info(f"PSUs to skip during PDU testing: {skip_psu_list}")
+    logging.info(f"PSUs to check: {psu_to_pdus.keys()}")
+
     try:
         for psu in psu_to_pdus.keys():
+            logging.info(f"Checking PSU identifier: {psu}")
+            # Skip PSUs that are in the skip list
+            if psu in skip_psu_list:
+                logging.info(f"Skipping PSU {psu} as it's in the skip list")
+                continue
+
             outlets = psu_to_pdus[psu]
             psu_under_test = None
 
@@ -303,6 +350,11 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
             for line in cli_psu_status["stdout_lines"][2:]:
                 psu_match = psu_line_pattern.match(line)
                 pytest_assert(psu_match, "Unexpected PSU status output")
+                # Skip PSUs that are in the skip list
+                psu_name, should_skip = get_psu_name_and_check_skip(psu_match.group(1), skip_psu_list)
+                if should_skip:
+                    logging.info(f"Skipping PSU {psu_name} as it's in the skip list")
+                    continue
                 # also make sure psustatus is not 'NOT PRESENT', which cannot be turned on/off
                 if psu_match.group(2) != "OK" and psu_match.group(2) != "NOT PRESENT":
                     psu_under_test = psu_match.group(1)
@@ -318,6 +370,12 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
             for line in cli_psu_status["stdout_lines"][2:]:
                 psu_match = psu_line_pattern.match(line)
                 pytest_assert(psu_match, "Unexpected PSU status output")
+                # Skip PSUs that are in the skip list
+                psu_name, should_skip = get_psu_name_and_check_skip(psu_match.group(1), skip_psu_list)
+                # Skip PSUs that are in the skip list when checking status
+                if should_skip:
+                    logging.info(f"Skipping PSU {psu_name} as it's in the skip list")
+                    continue
                 if psu_match.group(1) == psu_under_test:
                     pytest_assert(psu_match.group(2) == "OK",
                                   "Unexpected PSU status after turned it on")
@@ -328,8 +386,12 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
         turn_on_all_outlets(pdu_ctrl)
 
     for psu in psu_test_results:
-        pytest_assert(psu_test_results[psu],
-                      "Test psu status of PSU %s failed" % psu)
+        pytest_assert(
+            psu_test_results[psu],
+            "Test psu status failed for PSU '{}'. Observed status: {}".format(
+                psu, psu_test_results[psu] if psu_test_results[psu] is not True else "OK"
+            )
+        )
 
 
 @pytest.mark.disable_loganalyzer


### PR DESCRIPTION
Cheery-picking PR#https://github.com/sonic-net/sonic-mgmt/pull/19737 for msft-202405 branch

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Skip PSUs listed under skip_modules, to avoid false alarms during test_platform_info.py tests
For Cisco 8808 chassis, PSUs are installed by rows and not by single PSU.
Therefore, when row of PSU is installed and if any PSU in that row is not plugged in with PDU, status of PSU will be displayed as 'NOT OK'.
currently, if we have "NOT OK" status, test_platform_info will automatically skip the test and resulting a failure.

This PR is to address this issue, by skipping PSUs based on inventory file declaration.

Summary:
This pull request enhances the PSU testing framework by introducing the ability to skip specific PSUs based on an inventory configuration. The changes ensure that skipped PSUs are excluded from status checks and power toggle tests, improving test reliability and configurability.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Ignore known non-issue syslog
#### How did you do it?
Ignore the new format
#### How did you verify/test it?
E2E
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
