### PR TITLE
[test_default_route]: Fix missed changing for deafult route

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -66,7 +66,7 @@ def get_upstream_neigh(tb, device_neigh_metadata):
     for neigh_name, neigh_cfg in list(topo_cfg_facts.items()):
         if not is_in_neighbor(neigh_types, neigh_name):
             continue
-        if neigh_type == 'T3' and device_neigh_metadata[neigh_name]['type'] == 'AZNGHub':
+        if 'T3' in neigh_types and device_neigh_metadata[neigh_name]['type'] == 'AZNGHub':
             continue
         interfaces = neigh_cfg.get('interfaces', {})
         ipv4_addr = None


### PR DESCRIPTION
Fix an error introduced by PR: https://github.com/Azure/sonic-mgmt.msft/pull/591

```
def get_upstream_neigh(tb, device_neigh_metadata):
  neigh_types = get_all_upstream_neigh_type(tb['topo']['type'])
....
 if neigh_type == 'T3' and device_neigh_metadata[neigh_name]['type'] == 'AZNGHub':
            continue 
 NameError: name 'neigh_type' is not defined
```