### PR TITLE
[202412][PR: 19334] Parallelize bind/unbind topology to optimize large topology deployment

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -228,8 +228,10 @@ def adaptive_temporary_interface(vm_set_name, interface_name, reserved_space=0):
 
 class VMTopology(object):
 
-    def __init__(self, vm_names, vm_properties, fp_mtu, max_fp_num, topo, worker, is_dpu=False, dut_interfaces=None):
+    def __init__(self, vm_names, vm_properties, fp_mtu, max_fp_num, topo, worker, current_vm_name=None,
+                 is_dpu=False, dut_interfaces=None):
         self.vm_names = vm_names
+        self.current_vm_name = current_vm_name
         self.vm_properties = vm_properties
         self.fp_mtu = fp_mtu
         self.max_fp_num = max_fp_num
@@ -264,9 +266,17 @@ class VMTopology(object):
                 if self.dut_interfaces:
                     topo_vms = MultiServersUtils.get_vms_by_dut_interfaces(topo_vms, self.dut_interfaces)
 
-                for k, v in topo_vms.items():
-                    if self.vm_base_index + v['vm_offset'] < len(self.vm_names):
-                        self.VMs[k] = v
+                # This parameter is used for parallel
+                if self.current_vm_name:
+                    for k, v in topo_vms.items():
+                        expected_vm_name = self.vm_names[self.vm_base_index + v['vm_offset']]
+                        if expected_vm_name == self.current_vm_name:
+                            self.VMs[k] = v
+                            break
+                else:
+                    for k, v in topo_vms.items():
+                        if self.vm_base_index + v['vm_offset'] < len(self.vm_names):
+                            self.VMs[k] = v
         else:
             if 'DPUs' in self.topo and len(self.topo['DPUs']) > 0:
                 self.vm_base = vm_base
@@ -607,10 +617,9 @@ class VMTopology(object):
             self.pid = api_server_pid
 
         if VMTopology.intf_exists(int_if, pid=self.pid):
-            VMTopology.cmd("nsenter -t %s -n ip addr flush dev %s" %
-                           (self.pid, int_if))
-            VMTopology.cmd("nsenter -t %s -n ip addr add %s dev %s" %
-                           (self.pid, mgmt_ip_addr, int_if))
+            if not VMTopology.ip_exists(int_if, mgmt_ip_addr, pid=self.pid):
+                VMTopology.cmd("nsenter -t %s -n ip addr add %s dev %s" %
+                               (self.pid, mgmt_ip_addr, int_if))
             if extra_mgmt_ip_addr is not None:
                 for ip_addr in extra_mgmt_ip_addr:
                     if ip_addr != "":
@@ -620,18 +629,17 @@ class VMTopology(object):
                 if api_server_pid:
                     VMTopology.cmd(
                         "nsenter -t %s -n ip route del default" % (self.pid))
-                VMTopology.cmd(
-                    "nsenter -t %s -n ip route add default via %s dev %s" % (self.pid, mgmt_gw, int_if))
+                if not VMTopology.route_exists(mgmt_gw, pid=self.pid):
+                    VMTopology.cmd(
+                        "nsenter -t %s -n ip route add default via %s dev %s" % (self.pid, mgmt_gw, int_if))
             if mgmt_ipv6_addr:
-                VMTopology.cmd(
-                    "nsenter -t %s -n ip -6 addr flush dev %s" % (self.pid, int_if))
-                VMTopology.cmd("nsenter -t %s -n ip -6 addr add %s dev %s" %
-                               (self.pid, mgmt_ipv6_addr, int_if))
+                if not VMTopology.ip_exists(int_if, mgmt_ipv6_addr, pid=self.pid, ipv6=True):
+                    VMTopology.cmd("nsenter -t %s -n ip -6 addr add %s dev %s" %
+                                   (self.pid, mgmt_ipv6_addr, int_if))
             if mgmt_ipv6_addr and mgmt_gw_v6:
-                VMTopology.cmd(
-                    "nsenter -t %s -n ip -6 route flush default" % (self.pid))
-                VMTopology.cmd(
-                    "nsenter -t %s -n ip -6 route add default via %s dev %s" % (self.pid, mgmt_gw_v6, int_if))
+                if not VMTopology.route_exists(mgmt_gw_v6, pid=self.pid, ipv6=True):
+                    VMTopology.cmd(
+                        "nsenter -t %s -n ip -6 route add default via %s dev %s" % (self.pid, mgmt_gw_v6, int_if))
 
     def add_ip_to_netns_if(self, int_if, ip_addr, ipv6_addr=None, default_gw=None, default_gw_v6=None):
         """Add ip address to netns interface."""
@@ -1028,7 +1036,7 @@ class VMTopology(object):
             VMTopology.cmd("brctl delif %s %s" % (br_name, port1))
         if port2 in if_to_br:
             VMTopology.cmd("brctl delif %s %s" % (br_name, port2))
-        VMTopology.cmd('brctl delbr %s' % br_name)
+        VMTopology.cmd('brctl delbr %s || true' % br_name, shell=True, split_cmd=False)
 
     def bind_vm_link(self, br_name, port1, port2):
         if VMTopology.intf_not_exists(br_name):
@@ -1074,7 +1082,7 @@ class VMTopology(object):
 
         if VMTopology.intf_exists(self.bp_bridge):
             VMTopology.iface_down(self.bp_bridge)
-            VMTopology.cmd('brctl delbr %s' % self.bp_bridge)
+            VMTopology.cmd('brctl delbr %s || true' % self.bp_bridge, shell=True, split_cmd=False)
 
     def bind_vs_dut_ports(self, br_name, dut_ports):
         # dut_ports is a list of port on each DUT that has to be bound together. eg. 30,30,30 - will bind ports
@@ -1509,7 +1517,7 @@ class VMTopology(object):
 
         # Delete its peer in default namespace
         if VMTopology.intf_exists(ext_if):
-            VMTopology.cmd("ip link delete dev %s" % ext_if)
+            VMTopology.cmd("ip link delete dev %s || true" % ext_if, shell=True, split_cmd=False)
 
     def remove_ptf_mgmt_port(self):
         ext_if = PTF_MGMT_IF_TEMPLATE % self.vm_set_name
@@ -1612,6 +1620,54 @@ class VMTopology(object):
             return False
 
     @staticmethod
+    def _ip_cmd(intf, pid=None, netns=None, ipv6=False):
+        addr_cmd = 'ip addr show'
+        if ipv6:
+            addr_cmd = 'ip -6 addr show'
+
+        if pid:
+            cmdline = 'nsenter -t %s -n %s dev %s' % (pid, addr_cmd, intf)
+        elif netns:
+            cmdline = 'ip netns exec %s %s dev %s' % (netns, addr_cmd, intf)
+        else:
+            cmdline = '%s dev %s' % (addr_cmd, intf)
+        return cmdline
+
+    @staticmethod
+    def ip_exists(intf, ip_addr, pid=None, netns=None, ipv6=False):
+        cmdline = VMTopology._ip_cmd(intf, pid=pid, netns=netns, ipv6=ipv6)
+
+        try:
+            output = VMTopology.cmd(cmdline, retry=3)
+            return ip_addr in output
+        except Exception:
+            return False
+
+    @staticmethod
+    def _route_cmd(pid=None, netns=None, ipv6=False):
+        addr_cmd = 'ip route show default'
+        if ipv6:
+            addr_cmd = 'ip -6 route show default'
+
+        if pid:
+            cmdline = 'nsenter -t %s -n %s' % (pid, addr_cmd)
+        elif netns:
+            cmdline = 'ip netns exec %s %s' % (netns, addr_cmd)
+        else:
+            cmdline = '%s' % (addr_cmd)
+        return cmdline
+
+    @staticmethod
+    def route_exists(gw, pid=None, netns=None, ipv6=False):
+        cmdline = VMTopology._route_cmd(pid=pid, netns=netns, ipv6=ipv6)
+
+        try:
+            output = VMTopology.cmd(cmdline, retry=3)
+            return gw in output
+        except Exception:
+            return False
+
+    @staticmethod
     def iface_up(iface_name, pid=None, netns=None):
         return VMTopology.iface_updown(iface_name, 'up', pid, netns)
 
@@ -1626,7 +1682,7 @@ class VMTopology(object):
         elif netns is not None:
             return VMTopology.cmd('ip netns exec %s ip link set %s %s' % (netns, iface_name, state))
         else:
-            return VMTopology.cmd('ip link set %s %s' % (iface_name, state))
+            return VMTopology.cmd('ip link set %s %s || true' % (iface_name, state), shell=True, split_cmd=False)
 
     @staticmethod
     def iface_disable_txoff(iface_name, pid=None):
@@ -1716,7 +1772,7 @@ class VMTopology(object):
 
     @staticmethod
     def get_ovs_br_ports(bridge):
-        out = VMTopology.cmd('ovs-vsctl list-ports %s' % bridge)
+        out = VMTopology.cmd('ovs-vsctl list-ports %s || true' % bridge, shell=True, split_cmd=False)
         ports = set()
         for port in out.split('\n'):
             if port != "":
@@ -2083,6 +2139,7 @@ def main():
             vm_set_name=dict(required=False, type='str'),
             topo=dict(required=False, type='dict'),
             vm_names=dict(required=True, type='list'),
+            current_vm_name=dict(required=False, type='str'),
             vm_base=dict(required=False, type='str'),
             vm_type=dict(required=False, type='str'),
             vm_properties=dict(required=False, type='dict', default={}),
@@ -2113,6 +2170,7 @@ def main():
     cmd = module.params['cmd']
     vm_set_name = module.params['vm_set_name']
     vm_names = module.params['vm_names']
+    current_vm_name = module.params['current_vm_name']
     fp_mtu = module.params['fp_mtu']
     max_fp_num = module.params['max_fp_num']
     vm_properties = module.params['vm_properties']
@@ -2130,7 +2188,8 @@ def main():
 
         topo = module.params['topo']
         worker = VMTopologyWorker(use_thread_worker, thread_worker_count)
-        net = VMTopology(vm_names, vm_properties, fp_mtu, max_fp_num, topo, worker, is_dpu, dut_interfaces)
+        net = VMTopology(vm_names, vm_properties, fp_mtu, max_fp_num, topo, worker, current_vm_name,
+                         is_dpu, dut_interfaces)
 
         if cmd == 'create':
             net.create_bridges()

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -211,30 +211,22 @@
     when: vm_type is defined and vm_type == "ceos"
 
   - name: Bind topology {{ topo }} to VMs. base vm = {{ VM_base }}
-    vm_topology:
-      cmd: "bind"
-      vm_set_name: "{{ vm_set_name }}"
-      topo: "{{ topology }}"
-      vm_names: "{{ VM_targets }}"
-      vm_base: "{{ VM_base }}"
-      vm_type: "{{ vm_type }}"
-      vm_properties: "{{ vm_properties if vm_properties is defined else omit }}"
-      ptf_mgmt_ip_addr: "{{ ptf_ip }}"
-      ptf_mgmt_ipv6_addr: "{{ ptf_ipv6 }}"
-      ptf_mgmt_ip_gw: "{{ mgmt_gw }}"
-      ptf_mgmt_ipv6_gw: "{{ mgmt_gw_v6 | default(None) }}"
-      ptf_extra_mgmt_ip_addr: "{{ ptf_extra_mgmt_ip.split(',') | default([]) }}"
-      ptf_bp_ip_addr: "{{ ptf_bp_ip }}"
-      ptf_bp_ipv6_addr: "{{ ptf_bp_ipv6 }}"
-      mgmt_bridge: "{{ mgmt_bridge }}"
-      duts_fp_ports: "{{ duts_fp_ports }}"
-      duts_mgmt_port: "{{ duts_mgmt_port }}"
-      duts_name: "{{ duts_name.split(',') }}"
-      fp_mtu: "{{ fp_mtu_size }}"
-      max_fp_num: "{{ max_fp_num }}"
-      netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
-      dut_interfaces: "{{ dut_interfaces | default('') }}"
+    include_tasks: bind_vm.yml
+    loop: "{{ VM_targets|flatten(levels=1) }}"
+    loop_control:
+      loop_var: current_vm_name
+
+  - name: Wait for bind tasks to complete
     become: yes
+    async_status:
+      jid: "{{ async_bind_job_results[current_vm_name] }}"
+    loop: "{{ VM_targets|flatten(levels=1) }}"
+    loop_control:
+      loop_var: current_vm_name
+    register: async_bind_topology_poll_results
+    until: async_bind_topology_poll_results.finished
+    retries: 30
+    delay: 60
 
   - name: Bind topology {{ topo }} to DPUs.
     vm_topology:

--- a/ansible/roles/vm_set/tasks/bind_vm.yml
+++ b/ansible/roles/vm_set/tasks/bind_vm.yml
@@ -1,0 +1,38 @@
+- name: Bind VM {{ current_vm_name }}
+  vm_topology:
+    cmd: "bind"
+    vm_set_name: "{{ vm_set_name }}"
+    topo: "{{ topology }}"
+    vm_names: "{{ VM_targets }}"
+    current_vm_name: "{{ current_vm_name }}"
+    vm_base: "{{ VM_base }}"
+    vm_type: "{{ vm_type }}"
+    vm_properties: "{{ vm_properties if vm_properties is defined else omit }}"
+    ptf_mgmt_ip_addr: "{{ ptf_ip }}"
+    ptf_mgmt_ipv6_addr: "{{ ptf_ipv6 }}"
+    ptf_mgmt_ip_gw: "{{ mgmt_gw }}"
+    ptf_mgmt_ipv6_gw: "{{ mgmt_gw_v6 | default(None) }}"
+    ptf_extra_mgmt_ip_addr: "{{ ptf_extra_mgmt_ip.split(',') | default([]) }}"
+    ptf_bp_ip_addr: "{{ ptf_bp_ip }}"
+    ptf_bp_ipv6_addr: "{{ ptf_bp_ipv6 }}"
+    mgmt_bridge: "{{ mgmt_bridge }}"
+    duts_fp_ports: "{{ duts_fp_ports }}"
+    duts_midplane_ports: "{{ duts_midplane_ports }}"
+    duts_inband_ports: "{{ duts_inband_ports }}"
+    duts_mgmt_port: "{{ duts_mgmt_port }}"
+    duts_name: "{{ duts_name.split(',') }}"
+    fp_mtu: "{{ fp_mtu_size }}"
+    max_fp_num: "{{ max_fp_num }}"
+    netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
+    dut_interfaces: "{{ dut_interfaces | default('') }}"
+    is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
+    batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
+  become: yes
+  throttle: 1
+  async: 3600
+  poll: 0
+  register: async_bind_topology_result_item
+
+- name: Save job id for {{ current_vm_name }}
+  set_fact:
+    async_bind_job_results: "{{ async_bind_job_results | default({}) | combine({ current_vm_name: async_bind_topology_result_item.ansible_job_id }) }}"

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -46,19 +46,23 @@
       loop_var: dut_name
 
   - name: Unbind topology {{ topo }} to VMs. base vm = {{ VM_base }}
-    vm_topology:
-      cmd: "unbind"
-      vm_set_name: "{{ vm_set_name }}"
-      topo: "{{ topology }}"
-      vm_names: "{{ VM_hosts }}"
-      vm_base: "{{ VM_base }}"
-      vm_type: "{{ vm_type }}"
-      duts_fp_ports: "{{ duts_fp_ports }}"
-      duts_mgmt_port: "{{ duts_mgmt_port }}"
-      duts_name: "{{ duts_name.split(',') }}"
-      max_fp_num: "{{ max_fp_num }}"
-      dut_interfaces: "{{ dut_interfaces | default('') }}"
+    include_tasks: unbind_vm.yml
+    loop: "{{ VM_hosts | flatten(levels=1) }}"
+    loop_control:
+      loop_var: current_vm_name
+
+  - name: Wait for unbind tasks to complete
     become: yes
+    async_status:
+      jid: "{{ async_unbind_job_results[current_vm_name] }}"
+    loop: "{{ VM_hosts | flatten(levels=1) }}"
+    loop_control:
+      loop_var: current_vm_name
+    register: async_unbind_topology_poll_results
+    until: async_unbind_topology_poll_results.finished
+    retries: 30
+    delay: 60
+
 
   - name: Unbind topology {{ topo }} to DPU VMs. base vm = {{ VM_base }}
     vm_topology:
@@ -159,7 +163,7 @@
   when: container_type == "IxANVL-CONF-TESTER"
 
 - name: Destroy VMs network in parallel
-  include_tasks: destory_vm_network.yml
+  include_tasks: destroy_vm_network.yml
   loop: "{{ VM_targets|flatten(levels=1) }}"
   loop_control:
     loop_var: vm_name

--- a/ansible/roles/vm_set/tasks/unbind_vm.yml
+++ b/ansible/roles/vm_set/tasks/unbind_vm.yml
@@ -1,0 +1,27 @@
+- name: Unbind VM {{ current_vm_name }}
+  vm_topology:
+    cmd: "unbind"
+    vm_set_name: "{{ vm_set_name }}"
+    topo: "{{ topology }}"
+    vm_names: "{{ VM_hosts }}"
+    current_vm_name: "{{ current_vm_name }}"
+    vm_base: "{{ VM_base }}"
+    vm_type: "{{ vm_type }}"
+    duts_fp_ports: "{{ duts_fp_ports }}"
+    duts_midplane_ports: "{{ duts_midplane_ports }}"
+    duts_inband_ports: "{{ duts_inband_ports }}"
+    duts_mgmt_port: "{{ duts_mgmt_port }}"
+    duts_name: "{{ duts_name.split(',') }}"
+    max_fp_num: "{{ max_fp_num }}"
+    dut_interfaces: "{{ dut_interfaces | default('') }}"
+    is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
+    batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
+  async: 3600
+  throttle: 1
+  poll: 0
+  register: async_unbind_topology_result_item
+  become: yes
+
+- name: Save job id for {{ current_vm_name }}
+  set_fact:
+    async_unbind_job_results: "{{ async_unbind_job_results | default({}) | combine({ current_vm_name: async_unbind_topology_result_item.ansible_job_id }) }}"


### PR DESCRIPTION
Cherry pick #19334

What is the motivation for this PR?
When deploying the large topology with 256 neighbors, we observed that the process add-topo can take over three hours, which is impractical. Upon analyzing the playbook execution time, we found that the task bind/unbind topology was executed serially, causing unnecessary delays as each task waited for the previous one to complete. This PR optimizes the workflow by parallelizing this tasks. Instead of waiting, each task is now triggered in the background, allowing subsequent tasks to start immediately. This significantly reduces the overall deployment time, now the time can be shorten to less than two hours.

How did you do it?
Summary of changes in this PR:
1. Introduced a new parameter for vm_name in the vm_topology.py script to identify and manage individual virtual machines during parallel execution.
2. Enhanced vm_topology.py to support parallelism by adding safety checks before operations such as adding or removing ports and IPs, preventing potential conflicts.
3. Appended || true to certain shell commands to ensure the workflow continues even if non-critical commands fail.
Refactored the unbind/bind VM logic into a separate YAML file. Since ovs-vsctl operations can be sensitive to timing, we’ve added delays between tasks to reduce race conditions.

How did you verify/test it?
I have tested locally, using 256 ports testbed. After some days' running, there is no failure.