### PR TITLE
Skip gnmi related tests in 202412 release.

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -498,6 +498,9 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     skip_condition.append("acms")
     if tbinfo["topo"]["type"] != "t0":
         skip_condition.append("radv")
+    if "202412" in duthost.os_version:
+        skip_condition.append("gnmi")
+
 
     # bgp0 -> bgp, bgp -> bgp, p4rt -> p4rt
     feature_name = ''.join(re.match(CONTAINER_NAME_REGEX, container_name).groups()[:-1])

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -498,7 +498,7 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     skip_condition.append("acms")
     if tbinfo["topo"]["type"] != "t0":
         skip_condition.append("radv")
-    if "202412" in duthost.os_version and duthost.facts['asic_type'] == 'vs':
+    if "202412" in duthost.os_version:
         skip_condition.append("gnmi")
 
     # bgp0 -> bgp, bgp -> bgp, p4rt -> p4rt

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -498,7 +498,7 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     skip_condition.append("acms")
     if tbinfo["topo"]["type"] != "t0":
         skip_condition.append("radv")
-    if "202412" in duthost.os_version:
+    if "202412" in duthost.os_version and duthost.facts['asic_type'] == 'vs':
         skip_condition.append("gnmi")
 
 

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -501,7 +501,6 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     if "202412" in duthost.os_version and duthost.facts['asic_type'] == 'vs':
         skip_condition.append("gnmi")
 
-
     # bgp0 -> bgp, bgp -> bgp, p4rt -> p4rt
     feature_name = ''.join(re.match(CONTAINER_NAME_REGEX, container_name).groups()[:-1])
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1112,6 +1112,12 @@ generic_config_updater/test_pg_headroom_update.py:
 #######################################
 #####           gnmi              #####
 #######################################
+gnmi:
+  skip:
+    reason: Skip all gnmi tests on 202412 vs testbed
+    conditions:
+      - "asic_type in ['vs'] and release in ['202412']"
+
 gnmi/test_gnmi_configdb.py:
   skip:
     reason: "This feature is not supported for multi asic. Skipping these test for T2 and multi asic."
@@ -1119,12 +1125,15 @@ gnmi/test_gnmi_configdb.py:
     conditions:
       - "'t2' in topo_name"
       - "is_multi_asic==True"
+      - "asic_type in ['vs'] and release in ['202412']"
 
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_full_01:
   skip:
     reason: "The test refers to a stale implementation of GNOI.System.Reboot."
+    conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/17436"
+      - "asic_type in ['vs'] and release in ['202412']"
 
 gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1113,8 +1113,8 @@ generic_config_updater/test_pg_headroom_update.py:
 #####           gnmi              #####
 #######################################
 gnmi:
-  skip:
-    reason: Skip all gnmi tests on 202412 vs testbed
+  xfail:
+    reason: Xfail all gnmi tests on 202412 vs testbed, since it won't impact gnmi show command
     conditions:
       - "asic_type in ['vs'] and release in ['202412']"
 
@@ -1125,19 +1125,28 @@ gnmi/test_gnmi_configdb.py:
     conditions:
       - "'t2' in topo_name"
       - "is_multi_asic==True"
+  xfail:
+    reason: Xfail all gnmi tests on 202412 vs testbed, since it won't impact gnmi show command
+    conditions:
       - "asic_type in ['vs'] and release in ['202412']"
 
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_full_01:
   skip:
     reason: "The test refers to a stale implementation of GNOI.System.Reboot."
-    conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/17436"
+  xfail:
+    reason: Xfail all gnmi tests on 202412 vs testbed, since it won't impact gnmi show command
+    conditions:
       - "asic_type in ['vs'] and release in ['202412']"
 
 gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart:
   skip:
     reason: "Test noisy due to restart issue not relevant to GNOI. Disabling them to rewrite."
+  xfail:
+    reason: Xfail all gnmi tests on 202412 vs testbed, since it won't impact gnmi show command
+    conditions:
+      - "asic_type in ['vs'] and release in ['202412']"
 
 #######################################
 #####           hash              #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1113,10 +1113,10 @@ generic_config_updater/test_pg_headroom_update.py:
 #####           gnmi              #####
 #######################################
 gnmi:
-  xfail:
+  skip:
     reason: Xfail all gnmi tests on 202412 vs testbed, since it won't impact gnmi show command
     conditions:
-      - "asic_type in ['vs'] and release in ['202412']"
+      - "release in ['202412']"
 
 gnmi/test_gnmi_configdb.py:
   skip:
@@ -1125,28 +1125,19 @@ gnmi/test_gnmi_configdb.py:
     conditions:
       - "'t2' in topo_name"
       - "is_multi_asic==True"
-  xfail:
-    reason: Xfail all gnmi tests on 202412 vs testbed, since it won't impact gnmi show command
-    conditions:
-      - "asic_type in ['vs'] and release in ['202412']"
+      - "release in ['202412']"
 
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_full_01:
   skip:
     reason: "The test refers to a stale implementation of GNOI.System.Reboot."
+    conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/17436"
-  xfail:
-    reason: Xfail all gnmi tests on 202412 vs testbed, since it won't impact gnmi show command
-    conditions:
-      - "asic_type in ['vs'] and release in ['202412']"
+      - "release in ['202412']"
 
 gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart:
   skip:
     reason: "Test noisy due to restart issue not relevant to GNOI. Disabling them to rewrite."
-  xfail:
-    reason: Xfail all gnmi tests on 202412 vs testbed, since it won't impact gnmi show command
-    conditions:
-      - "asic_type in ['vs'] and release in ['202412']"
 
 #######################################
 #####           hash              #####

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -259,7 +259,7 @@ def remove_and_restart_container(memory_checker_dut_and_container):
 def get_test_container(duthost):
     test_container = "telemetry"
 
-    if "202412" in duthost.os_version and duthost.facts['asic_type'] == 'vs':
+    if "202412" in duthost.os_version:
         return test_container
 
     cmd = "docker images | grep -w sonic-gnmi"

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -259,7 +259,7 @@ def remove_and_restart_container(memory_checker_dut_and_container):
 def get_test_container(duthost):
     test_container = "telemetry"
     cmd = "docker images | grep -w sonic-gnmi"
-    if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
+    if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0 and "202412" not in duthost.os_version:
         test_container = "gnmi"
     return test_container
 

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -258,8 +258,12 @@ def remove_and_restart_container(memory_checker_dut_and_container):
 
 def get_test_container(duthost):
     test_container = "telemetry"
+
+    if "202412" in duthost.os_version and duthost.facts['asic_type'] == 'vs':
+        return test_container
+
     cmd = "docker images | grep -w sonic-gnmi"
-    if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0 and "202412" not in duthost.os_version:
+    if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
         test_container = "gnmi"
     return test_container
 

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -555,7 +555,7 @@ def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, 
     # Skip 'radv' container on devices whose role is not T0.
     if tbinfo["topo"]["type"] != "t0":
         skip_containers.append("radv")
-    if "202412" in duthost.os_version and duthost.facts['asic_type'] == 'vs':
+    if "202412" in duthost.os_version:
         skip_containers.append("gnmi")
     skip_containers = skip_containers + skip_vendor_specific_container
 

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -555,7 +555,7 @@ def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, 
     # Skip 'radv' container on devices whose role is not T0.
     if tbinfo["topo"]["type"] != "t0":
         skip_containers.append("radv")
-    if "202412" in duthost.os_version:
+    if "202412" in duthost.os_version and duthost.facts['asic_type'] == 'vs':
         skip_containers.append("gnmi")
     skip_containers = skip_containers + skip_vendor_specific_container
 

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -555,6 +555,8 @@ def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, 
     # Skip 'radv' container on devices whose role is not T0.
     if tbinfo["topo"]["type"] != "t0":
         skip_containers.append("radv")
+    if "202412" in duthost.os_version:
+        skip_containers.append("gnmi")
     skip_containers = skip_containers + skip_vendor_specific_container
 
     containers_in_namespaces = get_containers_namespace_ids(duthost, skip_containers)


### PR DESCRIPTION
Skip gnmi related tests in 202412 release. We will skip in both vs and physical testbeds. 