### PR TITLE
Use "get_vms_by_dut_interfaces" function to get VMs for multi-server …

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -745,7 +745,7 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
     for server in servers:
         vm_base = int(server['vm_base'][2:])
         vm_name_fmt = 'VM%0{}d'.format(len(server['vm_base']) - 2)
-        vms = MultiServersUtils.parse_topology_vms(
+        vms = MultiServersUtils.get_vms_by_dut_interfaces(
                 tbinfo['topo']['properties']['topology']['VMs'],
                 server['dut_interfaces']
             ) if 'dut_interfaces' in server else tbinfo['topo']['properties']['topology']['VMs']


### PR DESCRIPTION
Manually cherry-pick PR https://github.com/sonic-net/sonic-mgmt/pull/19724 to 202412 branch

Use `get_vms_by_dut_interfaces` function to get VMs for multi-server

No function `parse_topology_vms` in module `MultiServersUtils`. Based on @w1nda suggestion, use function `get_vms_by_dut_interfaces` instead of it