### PR TITLE
Fix platform counterpoll watermark test

### DIFF
--- a/tests/platform_tests/counterpoll/counterpoll_constants.py
+++ b/tests/platform_tests/counterpoll/counterpoll_constants.py
@@ -12,6 +12,7 @@ class CounterpollConstants:
     STATUS = 'status'
     STDOUT = 'stdout'
     PG_DROP = 'pg-drop'
+    WRED_QUEUE = 'wredqueue'
     PG_DROP_STAT_TYPE = 'PG_DROP_STAT'
     QUEUE_STAT_TYPE = 'QUEUE_STAT'
     QUEUE = 'queue'
@@ -25,6 +26,7 @@ class CounterpollConstants:
     QUEUE_WATERMARK_STAT_TYPE = 'QUEUE_WATERMARK_STAT'
     PG_WATERMARK_STAT_TYPE = 'PG_WATERMARK_STAT'
     BUFFER_POOL_WATERMARK_STAT_TYPE = 'BUFFER_POOL_WATERMARK_STAT'
+    WRED_ECN_QUEUE_STAT_TYPE = 'WRED_ECN_QUEUE_STAT'
     ACL = 'acl'
     ACL_TYPE = "ACL"
     COUNTERPOLL_MAPPING = {PG_DROP_STAT_TYPE: PG_DROP,
@@ -35,6 +37,7 @@ class CounterpollConstants:
                            BUFFER_POOL_WATERMARK_STAT_TYPE: WATERMARK,
                            QUEUE_WATERMARK_STAT_TYPE: WATERMARK,
                            PG_WATERMARK_STAT_TYPE: WATERMARK,
+                           WRED_ECN_QUEUE_STAT_TYPE: WRED_QUEUE,
                            ACL_TYPE: ACL}
     PORT_BUFFER_DROP_INTERVAL = '10000'
     COUNTERPOLL_INTERVAL = {PORT_BUFFER_DROP: 10000}


### PR DESCRIPTION
With the recent submodule sonic-utilities update #[2807](https://github.com/sonic-net/sonic-utilities/pull/2807), 'test_counterpoll_watermark.py' test fails with the following error,

```
>               pytest_assert(expected in verified_output_dict[counterpoll], "{} is {}. expected to be {}"
                              .format(counterpoll, verified_output_dict[counterpoll], expected))
E               Failed: queue is enable. expected to be disable
```

- This PR helps in fixing the above issue by updating the WRED_ECN_QUEUE_STAT constant to the counterpoll constants file.

- Verified the fix and made sure test passes without any issues. Results below.

<img width="226" height="74" alt="image" src="https://github.com/user-attachments/assets/cec2dd5b-92c0-4d3b-8bc9-ba8f96aba7c7" />



