### PR TITLE
Cancel fake storm on 7060X6

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -76,7 +76,9 @@ def fake_storm(request, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         fake_storm: False/True
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    return False if (isMellanoxDevice(duthost) or is_cisco_device(duthost)) \
+    return False if (isMellanoxDevice(duthost) or
+                     is_cisco_device(duthost) or
+                     "7060X6" in duthost.facts['hwsku'].upper()) \
         else request.config.getoption('--fake-storm')
 
 

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -936,7 +936,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
             self.timers['pfc_wd_wait_for_restore_time'] = int(pfc_wd_restore_time_large / 1000 * 2)
             actions = ['dontcare', 'drop', 'forward']
             # A temporary workaround for TH5 platform as forward action is not working
-            if duthost.sonichost._facts['asic_type'] == "cisco-8000" or "7060X6" in duthost.facts['hwsku']:
+            if duthost.sonichost._facts['asic_type'] == "cisco-8000" or "7060X6" in duthost.facts['hwsku'].upper():
                 actions = ['dontcare', 'drop']
             for action in actions:
                 try:


### PR DESCRIPTION
This PR is to cancel fake_storm on TH5 platform.

The change will be included in https://github.com/sonic-net/sonic-mgmt/pull/19954/files