### PR TITLE
[202412][Log analyzer] Ignore lldp failed with 500 server error log 

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -354,3 +354,6 @@ r, ".* ERR pmon#chassis_db_init: Failed to load chassis due to ModuleNotFoundErr
 
 # https://github.com/sonic-net/sonic-buildimage/issues/23142
 r, ".* ERR ntpd.*: CLOCK: leapsecond file ('/usr/share/zoneinfo/leap-seconds.list'): .*"
+
+# Ignore lldp error log, don't have real impact
+r, ".* ERR container: docker cmd: stop for lldp failed with 500 Server Error.*"


### PR DESCRIPTION
## What is the motivation for this PR?
This is a manual cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/20058
To ignore LLDP-related error logs in the log analyzer—such as those shown below—which are observed only on 512-port devices and have no functional impact.
```
2025 Aug  2 00:04:20.447956 str5-7060x6-512-3 ERR container: docker cmd: stop for lldp failed with 500 Server Error for http+docker://localhost/v1.43/containers/5ff64ad7a6bee49abdc2aee23b458ebfdbf457e0cecc8f5f6550d0c11eddad9a/stop: Internal Server Error ("cannot stop container: 5ff64ad7a6bee49abdc2aee23b458ebfdbf457e0cecc8f5f6550d0c11eddad9a: tried to kill container, but did not receive an exit event")
```
## How did you do it?
Ignore lldp error log in loganalyzer.

## How did you verify/test it?
Verify it locally.

Signed-off-by: zitingguo-ms zitingguo@microsoft.com