### PR TITLE
Ignore SRV6 ERR log

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -336,6 +336,10 @@ r, ".* ERR gbsyncd#syncd: /arsonic/packages/broncos-sai/build/PAI_\d+\.\d+/src/b
 # Ignore SAI_NEXT_HOP_GROUP_ATTR_TYPE unsupported
 r, ".* ERR swss#orchagent:.*queryAttributeEnumValuesCapability:.*returned value \d+ is not allowed on SAI_NEXT_HOP_GROUP_ATTR_TYPE"
 
+# Ignore SRV6 error
+r, ".* ERR syncd#syncd: .* SAI_API_SRV6:_brcm_sai_srv6_config_get:\d+ SRV6 unsupported or not enabled on this device"
+r, ".* ERR syncd#syncd: .* SAI_API_SWITCH:sai_object_type_get_availability:\d+ availablity my_sid failed with error -2."
+
 # https://msazure.visualstudio.com/One/_workitems/edit/33479668
 r, ".* ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB.*"
 r, ".* ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs.*"


### PR DESCRIPTION
Temporary solution for tests failing from recent regression as a result of upgrading to a newer SAI.
Original PR: https://github.com/sonic-net/sonic-mgmt/pull/20049