### PR TITLE
Support test_sfp.py::test_reset for Arista 7280 dr3 with Cloudlight Optics

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -315,22 +315,72 @@ class TestSfpApi(PlatformApiTestBase):
             return 0.3
         return 0
 
+    def should_skip_lpmode_check(self, xcvr_info_dict):
+        return any(
+            xcvr_info_dict.get("manufacturer", "").strip() == skip["manufacturer"] and
+            xcvr_info_dict.get("host_electrical_interface", "").strip() == skip["host_electrical_interface"]
+            for skip in self.LPMODE_SKIP_LIST
+        )
+
     def is_xcvr_support_lpmode(self, xcvr_info_dict):
-        """Returns True if transceiver is support low power mode, False if not supported"""
+        """Returns True if transceiver supports low power mode, False if not supported"""
         xcvr_type = xcvr_info_dict["type"]
         ext_identifier = xcvr_info_dict["ext_identifier"]
         if ("QSFP" not in xcvr_type and "OSFP" not in xcvr_type) or "Power Class 1" in ext_identifier:
             return False
 
-        # Temporarily add this logic to skip lpmode test for some transceivers with known issue
-        for xcvr_to_skip in self.LPMODE_SKIP_LIST:
-            if (xcvr_info_dict["manufacturer"].strip() == xcvr_to_skip["manufacturer"] and
-                    xcvr_info_dict["host_electrical_interface"].strip() == xcvr_to_skip["host_electrical_interface"]):
-                logger.info("Temporarily skipping {} due to known issue".format(
-                    xcvr_info_dict["manufacturer"]))
-                return False
+        if self.should_skip_lpmode_check(xcvr_info_dict):
+            logger.info("Temporarily skipping {} due to known issue".format(
+                xcvr_info_dict.get("manufacturer")))
+            return False
 
         return True
+    
+    def get_interfaces_to_flap_after_sfp_reset(self, port_index_to_info_dict, duthost):
+        interfaces_to_flap = []
+        admin_up_port_list = set(duthost.get_admin_up_ports())
+        for intf in self.sfp_setup['conn_interfaces']:
+            logger.info("Processing interface {} for flap after SFP reset".format(intf))
+            if intf not in admin_up_port_list:
+                # skip interfaces which are not in admin up state.
+                logger.info("Skipping interface {} as it is not in admin up state".format(intf))
+                continue
+
+            # skip if info_dict is not retrieved during reset, which also means reset was not performed.
+            sfp_port_idx = self.sfp_setup['physical_port_index_map'][intf]
+            if sfp_port_idx not in port_index_to_info_dict:
+                logger.info(
+                    "Skipping interface {} as SFP reset was not performed on port index {}".format(intf, sfp_port_idx)
+                )
+                continue
+
+            info_dict = port_index_to_info_dict[sfp_port_idx]
+            if self.is_xcvr_support_lpmode(info_dict) or self.should_skip_lpmode_check(info_dict):
+                logger.info("Flapping interface {} - xcvr supports lpmode and needs to be flapped".format(intf))
+                interfaces_to_flap.append(intf)
+        return interfaces_to_flap
+
+    def _shutdown_and_no_shutdown_ports(self, duthost, intf_list):
+        intf_to_flap_joined = ",".join(intf_list)
+        try:
+            if duthost.is_multi_asic:
+                for intf in intf_list:
+                    duthost.shutdown_interface(intf)
+            else:
+                duthost.shutdown_interface(intf_to_flap_joined)
+        except Exception as e:
+            logger.error("Failed to shutdown interfaces: {}".format(e))
+
+        shutdown_wait_scale_factor = max(1, len(intf_list)*0.01)
+        time.sleep(WAIT_TIME_AFTER_INTF_SHUTDOWN*shutdown_wait_scale_factor)
+        try:
+            if duthost.is_multi_asic:
+                for intf in intf_list:
+                    duthost.no_shutdown_interface(intf)
+            else:
+                duthost.no_shutdown_interface(intf_to_flap_joined)
+        except Exception as e:
+            logger.error("Failed to startup interfaces: {}".format(e))
 
     def is_xcvr_support_power_override(self, xcvr_info_dict):
         """Returns True if transceiver supports power override, False if not supported"""
@@ -693,7 +743,8 @@ class TestSfpApi(PlatformApiTestBase):
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
-            if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
+            if info_dict is None:
+                logger.warning("Skipping transceiver {} — no optic plugged in.".format(i))
                 continue
             port_index_to_info_dict[i] = info_dict
 
@@ -706,36 +757,16 @@ class TestSfpApi(PlatformApiTestBase):
         # allow the I2C interface to recover post sfp reset
         time.sleep(I2C_WAIT_TIME_AFTER_SFP_RESET)
 
-        # shutdown and bring up in batch so that we don't have to add delay for each interface.
-        intfs_changed = []
-        admin_up_port_list = duthost.get_admin_up_ports()
-        for intf in self.sfp_setup['conn_interfaces']:
-            if intf not in admin_up_port_list:
-                # skip interfaces which are not in admin up state.
-                continue
-
-            sfp_port_idx = self.sfp_setup['physical_port_index_map'][intf]
-            # skip if info_dict is not retrieved during reset, which also means reset was not performed.
-            if sfp_port_idx not in port_index_to_info_dict:
-                continue
-            info_dict = port_index_to_info_dict[sfp_port_idx]
-
-            # only flap interfaces where are CMIS optics,
-            # non-CMIS optics should stay up after sfp_reset(), no need to flap.
-            if "cmis_rev" in info_dict:
-                duthost.shutdown_interface(intf)
-                intfs_changed.append(intf)
-
-        time.sleep(WAIT_TIME_AFTER_INTF_SHUTDOWN)
-
-        for intf in intfs_changed:
-            duthost.no_shutdown_interface(intf)
-
-        _, port_up_wait_time = default_port_toggle_wait_time(duthost, len(intfs_changed))
-        if not wait_until(port_up_wait_time, 10, 0,
-                          check_interface_status_of_up_ports, duthost):
-            self.expect(False, "Not all interfaces are up after reset")
-
+        intf_list = self.get_interfaces_to_flap_after_sfp_reset(port_index_to_info_dict, duthost)
+        if intf_list:
+            logger.info("Flapping interfaces: {}".format(intf_list))
+            self._shutdown_and_no_shutdown_ports(duthost, intf_list)
+            _, port_up_wait_time = default_port_toggle_wait_time(duthost, len(intf_list))
+            if not wait_until(port_up_wait_time, 10, 0,
+                              check_interface_status_of_up_ports, duthost):
+                self.expect(False, "Not all interfaces are up after reset")
+        else:
+            logger.info("No interfaces to flap after SFP reset")
         self.assert_expectations()
 
     def test_tx_disable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa F811


### PR DESCRIPTION
Cherry pick conflicts, so created new pull request.
Pr's: 
https://github.com/sonic-net/sonic-mgmt/pull/18772
https://github.com/sonic-net/sonic-mgmt/pull/20120
https://github.com/sonic-net/sonic-mgmt/pull/19691

Adding a check for Cloudlight optics.
Adding multi asic support for test_reset
