### PR TITLE
[202412] Skip test_memory_checker.py in 202412 branch only

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1600,6 +1600,15 @@ mclag/test_mclag_l3.py:
       - "asic_type in ['vs']"
 
 #######################################
+#####      memory_checker         #####
+#######################################
+memory_checker/test_memory_checker.py:
+  skip:
+    reason: "Skip this test as it won't impact gnmi show command"
+    conditions:
+      - "release in ['202412']"
+
+#######################################
 #####            mpls             #####
 #######################################
 mpls/test_mpls.py:

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -257,10 +257,10 @@ def remove_and_restart_container(memory_checker_dut_and_container):
 
 
 def get_test_container(duthost):
-    test_container = "telemetry"
-    cmd = "docker images | grep -w sonic-gnmi"
+    test_container = "gnmi"
+    cmd = "docker images | grep -w sonic-telemetry"
     if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-        test_container = "gnmi"
+        test_container = "telemetry"
     return test_container
 
 

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -258,10 +258,6 @@ def remove_and_restart_container(memory_checker_dut_and_container):
 
 def get_test_container(duthost):
     test_container = "telemetry"
-
-    if "202412" in duthost.os_version:
-        return test_container
-
     cmd = "docker images | grep -w sonic-gnmi"
     if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
         test_container = "gnmi"


### PR DESCRIPTION
The `memory_checker/test_memory_checker.py` script primarily checks the gnmi and telemetry containers. In the public build, the telemetry container is absent, and the gnmi container has known issues. Therefore, in the 202412 branch, we will skip this test entirely.