### PR TITLE
[202412] Update qos sai tests due to splitting buffer queue configuration for lossy queue only device

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2146,9 +2146,12 @@ class QosSaiBase(QosBase):
                     logger.info(f"{srcport} has only lossy queue")
             if is_lossy_queue_only:
                 is_lossy_queue_only = True
-                queue_table_postfix_list = ['0-3', '4', '5']
-                queue_to_dscp_map = {'0-3': '1', '4': '11', '5': '31'}
-                queues = random.choice(queue_table_postfix_list)
+                queue_table_postfix_list = ['0', '1', '2', '3', '4', '5']
+                queue_to_dscp_map = {'0': '0', '1': '1', '2': '3', '3': '5', '4': '11', '5': '31'}
+                # for queue 0-3, the weight is 1, for queue 4 and 5, the weight is 4,
+                # because the queue 0~3 have the same dynamic threshold config
+                # so for the different dynamic threshold config, we have the same possibility to test it
+                queues = random.choices(queue_table_postfix_list, weights=(1, 1, 1, 1, 4, 4), k=1)[0]
             else:
                 queues = "0-2"
 
@@ -2163,7 +2166,7 @@ class QosSaiBase(QosBase):
         )
         if is_lossy_queue_only:
             egress_lossy_profile['lossy_dscp'] = queue_to_dscp_map[queues]
-            egress_lossy_profile['lossy_queue'] = '1' if queues == '0-3' else queues
+            egress_lossy_profile['lossy_queue'] = queues
         logger.info(f"queues:{queues}, egressLossyProfile: {egress_lossy_profile}")
 
         yield egress_lossy_profile


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Update qos sai tests due to splitting buffer queue configuration for lossy queue only port. The design PR is: https://github.com/sonic-net/sonic-buildimage/pull/22474

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Update qos sai tests due to splitting buffer queue configuration for lossy queue only device

#### How did you do it?
Align qos sai tests according to the PR of https://github.com/sonic-net/sonic-buildimage/pull/22474

#### How did you verify/test it?
Run the qos sai tests related to lossy queue.

#### Any platform specific information?
SN5610/SN5600/SN5640

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
