### PR TITLE
 Align the QoS sai test to the features of Per-Queue, Per-Priority, a…

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -83,20 +83,25 @@ class QosBase:
         return self.buffer_model
 
     @pytest.fixture(scope='class', autouse=True)
-    def dutTestParams(self, duthosts, dut_test_params_qos, tbinfo, get_src_dst_asic_and_duts):
+    def dutTestParams(self, duthosts, dut_test_params_qos, tbinfo, get_src_dst_asic_and_duts,
+                      lossy_queue_traffic_direction):
         """
             Prepares DUT host test params
             Returns:
                 dutTestParams (dict): DUT host test params
         """
         # update router mac
+        duthost = get_src_dst_asic_and_duts['src_dut']
         if "t0-backend" in dut_test_params_qos["topo"]:
-            duthost = get_src_dst_asic_and_duts['src_dut']
             dut_test_params_qos["basicParams"]["router_mac"] = duthost.shell(
                     'sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" mac')['stdout']
 
         elif dut_test_params_qos["topo"] in self.SUPPORTED_T0_TOPOS:
-            dut_test_params_qos["basicParams"]["router_mac"] = ''
+            if lossy_queue_traffic_direction in ["src_uplink_dst_downlink", "src_downlink_dst_uplink"]:
+                dut_test_params_qos["basicParams"]["router_mac"] = duthost.shell(
+                    'sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" mac')['stdout']
+            else:
+                dut_test_params_qos["basicParams"]["router_mac"] = ''
 
             if "dualtor" in tbinfo["topo"]["name"]:
                 # For dualtor qos test scenario, DMAC of test traffic is default vlan interface's MAC address.
@@ -116,7 +121,6 @@ class QosBase:
                               "Dual-TOR miss default VLAN MAC address")
         else:
             try:
-                duthost = get_src_dst_asic_and_duts['src_dut']
                 asic = duthost.asic_instance().asic_index
                 dut_test_params_qos['basicParams']["router_mac"] = duthost.shell(
                     'sonic-db-cli -n asic{} CONFIG_DB hget "DEVICE_METADATA|localhost" mac'.format(asic))['stdout']
@@ -789,7 +793,8 @@ class QosSaiBase(QosBase):
         yield rtn_dict
 
     def __buildTestPorts(self, request, testPortIds, testPortIps, src_port_ids, dst_port_ids,
-                         get_src_dst_asic_and_duts, uplinkPortIds, sysPortMap=None):
+                         get_src_dst_asic_and_duts, uplinkPortIds, sysPortMap=None,
+                         downlinkPortIds=None, is_supported_per_dir=False, lossy_queue_traffic_direction=''):
         """
             Build map of test ports index and IPs
 
@@ -797,7 +802,6 @@ class QosSaiBase(QosBase):
                 request (Fixture): pytest request object
                 testPortIds (list): List of QoS SAI test port IDs
                 testPortIps (list): List of QoS SAI test port IPs
-
             Returns:
                 testPorts (dict): Map of test ports index and IPs
                 sysPortMap (dict): Map of system port IDs and Qos SAI test port IDs
@@ -853,6 +857,10 @@ class QosSaiBase(QosBase):
             srcPorts = [testPortIds[0][0].index(uplinkPortIds[0])]
             dstPorts = [testPortIds[0][0].index(x) for x in uplinkPortIds[1:4]]
             logging.debug("Test Port dst:{}, src:{}".format(dstPorts, srcPorts))
+
+        if is_supported_per_dir:
+            srcPorts, dstPorts, src_port_ids, dst_port_ids = self.get_src_and_dst_ports_when_support_per_dir(
+                uplinkPortIds, downlinkPortIds, lossy_queue_traffic_direction)
 
         pytest_assert(len(dst_test_port_ids) >= 1 and len(src_test_port_ids) >= 1, "Provide at least 2 test ports")
         logging.debug(
@@ -940,8 +948,10 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def dutConfig(
-        self, request, duthosts, configure_ip_on_ptf_intfs, get_src_dst_asic_and_duts,
-        lower_tor_host, tbinfo, dualtor_ports_for_duts, dut_qos_maps):  # noqa F811
+            self, request, duthosts, configure_ip_on_ptf_intfs, get_src_dst_asic_and_duts,
+            lower_tor_host, tbinfo, dualtor_ports_for_duts, dut_qos_maps,  # noqa: F811
+            is_supported_per_dir, lossy_queue_traffic_direction
+    ):
         """
             Build DUT host config pertaining to QoS SAI tests
 
@@ -1024,8 +1034,8 @@ class QosSaiBase(QosBase):
             use_separated_upkink_dscp_tc_map = separated_dscp_to_tc_map_on_uplink(dut_qos_maps)
             for portConfig in intf_map:
                 intf = portConfig["attachto"].split(".")[0]
+                portIndex = src_mgFacts["minigraph_ptf_indices"][intf]
                 if ipaddress.ip_interface(portConfig['peer_addr']).ip.version == 4:
-                    portIndex = src_mgFacts["minigraph_ptf_indices"][intf]
                     if portIndex in testPortIds[src_dut_index][src_asic_index]:
                         portIpMap = {'peer_addr': portConfig["peer_addr"]}
                         if 'vlan' in portConfig:
@@ -1046,8 +1056,14 @@ class QosSaiBase(QosBase):
                             uplinkPortIds.append(portIndex)
                             uplinkPortIps.append(portConfig["peer_addr"])
                             uplinkPortNames.append(intf)
+                    if is_supported_per_dir:
+                        neighName = src_mgFacts["minigraph_neighbors"].get(intf, {}).get("name", "").lower()
+                        if 't1' in neighName:
+                            uplinkPortIds.append(portIndex)
+                            uplinkPortIps.append(portConfig["peer_addr"])
+                            uplinkPortNames.append(intf)
 
-            if isMellanoxDevice(src_dut):
+            if isMellanoxDevice(src_dut) and not is_supported_per_dir:
                 dualtor_dut_ports = dualtor_ports_for_duts if topo in self.SUPPORTED_PTF_TOPOS else None
                 testPortIds[src_dut_index][src_asic_index] = self.select_port_ids_for_mellnaox_device(
                     src_dut, src_mgFacts, testPortIds[src_dut_index][src_asic_index], dualtor_dut_ports)
@@ -1059,6 +1075,11 @@ class QosSaiBase(QosBase):
             # restore currently assigned IPs
             if len(dutPortIps[src_dut_index][src_asic_index]) != 0:
                 testPortIps.update(dutPortIps)
+
+            if is_supported_per_dir:
+                for portIndex, _ in testPortIps[src_dut_index][src_asic_index].items():
+                    if portIndex not in uplinkPortIds:
+                        downlinkPortIds.append(portIndex)
 
             if 'backend' in topo:
                 # since backend T0 utilize dot1q encap pkts, testPortIds need to be repopulated with the
@@ -1097,7 +1118,8 @@ class QosSaiBase(QosBase):
                     if (use_separated_upkink_dscp_tc_map or
                         (get_src_dst_asic_and_duts["src_asic"]
                          .sonichost.facts["hwsku"]
-                         in ["Cisco-8101-O8C48", "Cisco-8101-O8V48", "Cisco-8102-28FH-DPU-O-T1"])):
+                         in ["Cisco-8101-O8C48", "Cisco-8101-O8V48",
+                             "Cisco-8102-28FH-DPU-O-T1"]) or is_supported_per_dir):
                         neighName = src_mgFacts["minigraph_neighbors"].get(portName, {}).get("name", "").lower()
                         if 't0' in neighName:
                             downlinkPortIds.append(portIndex)
@@ -1111,7 +1133,7 @@ class QosSaiBase(QosBase):
                 testPortIds[src_dut_index][dut_asic.asic_index] = sorted(
                     dutPortIps[src_dut_index][dut_asic.asic_index].keys())
 
-                if isMellanoxDevice(src_dut):
+                if isMellanoxDevice(src_dut) and not is_supported_per_dir:
                     # For T1 in dualtor scenario, we always select the dualtor ports as source ports
                     dualtor_dut_ports = dualtor_ports_for_duts if 't1' in tbinfo['topo']['type'] else None
                     testPortIds[src_dut_index][dut_asic.asic_index] = self.select_port_ids_for_mellnaox_device(
@@ -1300,9 +1322,9 @@ class QosSaiBase(QosBase):
         dualTor = request.config.getoption("--qos_dual_tor")
         if dualTor:
             testPortIds = dualTorPortIndexes
-
         testPorts = self.__buildTestPorts(request, testPortIds, testPortIps, src_port_ids, dst_port_ids,
-                                          get_src_dst_asic_and_duts, uplinkPortIds, sysPortMap)
+                                          get_src_dst_asic_and_duts, uplinkPortIds, sysPortMap,
+                                          downlinkPortIds, is_supported_per_dir, lossy_queue_traffic_direction)
         # Update the uplink/downlink ports to testPorts
         testPorts.update({
             "uplink_port_ids": uplinkPortIds,
@@ -1905,8 +1927,8 @@ class QosSaiBase(QosBase):
 
     @pytest.fixture(scope='class', autouse=True)
     def populateArpEntries(
-        self, duthosts, get_src_dst_asic_and_duts,
-        ptfhost, dutTestParams, dutConfig, releaseAllPorts, handleFdbAging, tbinfo, lower_tor_host # noqa F811
+        self, duthosts, get_src_dst_asic_and_duts, lossy_queue_traffic_direction,
+        ptfhost, dutTestParams, dutConfig, releaseAllPorts, handleFdbAging, tbinfo, lower_tor_host  # noqa: F811
     ):
         """
             Update ARP entries of QoS SAI test ports
@@ -1929,6 +1951,9 @@ class QosSaiBase(QosBase):
         if "t2" in dutTestParams["topo"]:
             yield
             return
+
+        if "t0" in dutTestParams["topo"] and lossy_queue_traffic_direction == "src_uplink_dst_downlink":
+            dutTestParams["basicParams"]["t0_src_uplink_dst_downlink"] = True
 
         self.populate_arp_entries(
             get_src_dst_asic_and_duts, ptfhost, dutTestParams,
@@ -2147,11 +2172,9 @@ class QosSaiBase(QosBase):
             if is_lossy_queue_only:
                 is_lossy_queue_only = True
                 queue_table_postfix_list = ['0', '1', '2', '3', '4', '5']
-                queue_to_dscp_map = {'0': '0', '1': '1', '2': '3', '3': '5', '4': '11', '5': '31'}
-                # for queue 0-3, the weight is 1, for queue 4 and 5, the weight is 4,
-                # because the queue 0~3 have the same dynamic threshold config
-                # so for the different dynamic threshold config, we have the same possibility to test it
-                queues = random.choices(queue_table_postfix_list, weights=(1, 1, 1, 1, 4, 4), k=1)[0]
+                queue_to_dscp_map = self.get_queue_to_dscp_map(duthost)
+                queue_weights_list = self.get_queue_weights_based_dynamic_th(duthost, queue_table_postfix_list)
+                queues = random.choices(queue_table_postfix_list, weights=queue_weights_list, k=1)[0]
             else:
                 queues = "0-2"
 
@@ -2165,9 +2188,9 @@ class QosSaiBase(QosBase):
             queues
         )
         if is_lossy_queue_only:
-            egress_lossy_profile['lossy_dscp'] = queue_to_dscp_map[queues]
+            egress_lossy_profile['lossy_dscp'] = random.choice(queue_to_dscp_map[queues])
             egress_lossy_profile['lossy_queue'] = queues
-        logger.info(f"queues:{queues}, egressLossyProfile: {egress_lossy_profile}")
+        logger.info(f"queues: {queues}, egressLossyProfile: {egress_lossy_profile}")
 
         yield egress_lossy_profile
 
@@ -2804,3 +2827,96 @@ def set_port_cir(interface, rate):
 
         yield
         return
+
+    @pytest.fixture(scope='class', autouse=True)
+    def is_supported_per_dir(self, get_src_dst_asic_and_duts, tbinfo):  # noqa F811
+        supported_per_dir_platform = ["Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512S2",
+                                      "Mellanox-SN5600-C224O8", "Mellanox-SN5600-C256S1"]
+        is_supported_per_dir = \
+            get_src_dst_asic_and_duts["src_asic"].sonichost.facts["hwsku"] in supported_per_dir_platform
+        logging.info(f"is_supported_per_dir: {is_supported_per_dir}")
+        yield is_supported_per_dir
+
+    @pytest.fixture(scope='class', autouse=True)
+    def lossy_queue_traffic_direction(self, is_supported_per_dir):
+        if is_supported_per_dir:
+            lossy_queue_dir_test_list = [
+                'src_uplink_dst_downlink', 'src_downlink_dst_uplink', 'src_downlink_dst_downlink']
+            lossy_queue_dir_test = random.choice(lossy_queue_dir_test_list)
+            logging.info(f"lossy_queue_dir_test: {lossy_queue_dir_test}")
+        else:
+            lossy_queue_dir_test = 'not care the traffic direction'
+            logging.info(f"Device not support per dir: {lossy_queue_dir_test}")
+        yield lossy_queue_dir_test
+
+    def get_src_and_dst_ports_when_support_per_dir(self, uplinkPortIds, downlinkPortIds, lossy_queue_traffic_direction):
+        if 'src_uplink_dst_downlink' == lossy_queue_traffic_direction:
+            src_port_ids = uplinkPortIds
+            dst_port_ids = downlinkPortIds
+        elif 'src_downlink_dst_uplink' == lossy_queue_traffic_direction:
+            src_port_ids = downlinkPortIds
+            dst_port_ids = uplinkPortIds
+        elif 'src_downlink_dst_downlink' == lossy_queue_traffic_direction:
+            src_port_ids = downlinkPortIds
+            dst_port_ids = downlinkPortIds
+            if len(downlinkPortIds) == 1:
+                pytest.skip('Not enough ports for downlink_downlink test')
+            else:
+                dst_port_ids = [downlinkPortIds[0]] * 3
+                src_port_ids = [downlinkPortIds[1]]
+
+        srcPorts = src_port_ids
+
+        if len(dst_port_ids) == 1:
+            dst_port_ids.append(dst_port_ids[0])
+            dst_port_ids.append(dst_port_ids[0])
+        elif len(dst_port_ids) == 2:
+            dst_port_ids.append(dst_port_ids[0])
+        dstPorts = dst_port_ids
+        logging.info(f"lossy_queue_dir_test: {lossy_queue_traffic_direction}. srcPorts: {srcPorts}, \
+                     dstPorts: {dstPorts}, src_port_ids: {src_port_ids}, dst_port_ids: {dst_port_ids}")
+        return srcPorts, dstPorts, src_port_ids, dst_port_ids
+
+    def get_queue_to_dscp_map(self, duthost):
+        """
+        Get queue to DSCP mapping from DUT host
+        """
+        config_facts = duthost.asic_instance().config_facts(source="running")["ansible_facts"]
+        dscp_to_tc_map = config_facts['DSCP_TO_TC_MAP']['AZURE']
+        queue_to_dscp_map = {}
+        for dscp, tc in dscp_to_tc_map.items():
+            queue_to_dscp_map.setdefault(tc, [])
+            queue_to_dscp_map[tc].append(dscp)
+        logging.info(f"queue_to_dscp_map: {queue_to_dscp_map}")
+        return queue_to_dscp_map
+
+    def get_queue_weights_based_dynamic_th(self, duthost, queue_table_postfix_list):
+        """
+        Get queue weights based on queue's dynamic th
+        e.g.  when queue_table_postfix_list = ['0', '1', '2', '3', '4', '5']
+        # for queue 1-3 has the same dynamic th -7,
+        # for queue 4 and 0 has the same dynamic th 0
+        # for queue 5 has the dynamic th -3
+        # so, for queue 1-3, the weight is 1/3, for queue 4 and 0, the weight is 1/2,
+        # for queue 5, the weight is 1/1
+        # so the weights_list is [1/2, 1/3, 1/3, 1/3, 1/2, 1/1]
+        # Based on the weights_list, every dynamic th has the same chance to be tested
+        """
+        queue_dynamic_th_map = {}
+        weights_list = []
+        for queue in queue_table_postfix_list:
+            key_str = f"BUFFER_PROFILE_TABLE:queue{queue}_downlink_lossy_profile"
+            dynamic_th_res = duthost.run_redis_cmd(argv=["redis-cli", "-n", 0, "HGET", key_str, "dynamic_th"])
+            if dynamic_th_res:
+                queue_dynamic_th_map[queue] = dynamic_th_res[0]
+        logging.info(f"queue_dynamic_th_map: {queue_dynamic_th_map}")
+
+        dynamic_th_list = list(queue_dynamic_th_map.values())
+        if len(queue_table_postfix_list) == len(dynamic_th_list):
+            weights_list.extend(
+                1/dynamic_th_list.count(queue_dynamic_th_map[queue]) for queue in queue_table_postfix_list)
+        else:
+            weights_list = [1] * len(queue_table_postfix_list)
+        logging.info(f"weights_list: {weights_list}")
+
+        return weights_list

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -701,6 +701,7 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
         self.dst_dut_index = self.test_params['dst_dut_index']
         self.dst_asic_index = self.test_params.get('dst_asic_index', None)
         self.testbed_type = self.test_params['testbed_type']
+        self.t0_src_uplink_dst_downlink = self.test_params.get('t0_src_uplink_dst_downlink', False)
 
     def tearDown(self):
         sai_base_test.ThriftInterfaceDataPlane.tearDown(self)
@@ -767,7 +768,7 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
                         send_packet(self, dst_port_id, arpreq_pkt)
 
             # ptf don't know the address of neighbor, use ping to learn relevant arp entries instead of send arp request
-            if self.test_port_ips:
+            if self.test_port_ips and not self.t0_src_uplink_dst_downlink:
                 ips = [ip for ip in get_peer_addresses(self.test_port_ips)]
                 if ips:
                     cmd = 'for ip in {}; do ping -c 4 -i 0.2 -W 1 -q $ip > /dev/null 2>&1 & done'.format(' '.join(ips))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

1. Align the QoS test to the features of Per-Queue, Per-Priority, and Per-Direction.

-  For per direction, we increase three scenarios (src_uplink_dst_downlink, src_downlink_dst_uplink, src_downlink_dst_downlink) and select the src and dst testing ports based on these scenarios.
- When the topology is T0 and the scenarios are src_uplink_dst_downlink and src_downlink_dst_uplink, we need to set the router_mac to the DUT ASIC MAC; otherwise, the packet will not be routed to the correct port.
- For per queue, the original code already includes coverage for each queue.

3. PR: https://github.com/sonic-net/sonic-buildimage/pull/22869



Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
 Align the QoS sai test to the features of Per-Queue, Per-Priority, and Per-Direction https://github.com/sonic-net/sonic-buildimage/pull/22869

#### How did you do it?
Since the the feature is per direction, we have three scenarios

- src_uplink_dst_downlink, 
- src_downlink_dst_uplink, 
- src_downlink_dst_downlink

Then select the src and dst test port based the case type.

For per queue, the original code already includes coverage for each queue.

#### How did you verify/test it?
Run the tests on the following platforms:

- Mellanox-SN5640-C448O16 
- Mellanox-SN5640-C512S2
- Mellanox-SN5600-C224O8
- Mellanox-SN5600-C256S1

#### Any platform specific information?

- Mellanox-SN5640-C448O16 
- Mellanox-SN5640-C512S2
- Mellanox-SN5600-C224O8
- Mellanox-SN5600-C256S1

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
