### PR TITLE
Disable loganalyzer for voq_disrupts test

### DIFF
--- a/tests/voq/test_voq_disrupts.py
+++ b/tests/voq/test_voq_disrupts.py
@@ -22,6 +22,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 pytestmark = [
+    pytest.mark.disable_loganalyzer,
     pytest.mark.topology('t2')
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Cherry-Pick of https://github.com/sonic-net/sonic-mgmt/pull/15917

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Loganalyzer is disabled for `voq_disrupts` in both master and msft-202405. The rationale was to avoid reboot related error logs to interfere with the test's purpose.

#### How did you do it?
By adding the `pytest.mark.disable_loganalyzer` pytest mark

#### How did you verify/test it?
Verified by running voq_disrupts test with loganalyzer disabled.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
