### PR TITLE
[202412] Fixed test failures in 'test_ecn_config_update.py'

### DIFF
--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -139,6 +139,60 @@ def get_wred_profiles(duthost):
     return wred_profiles
 
 
+# Determines how the value of each field should change to satisfy different constraints (explained below).
+def determine_delta_values(ecn_data, fields):
+    # Extra care should be taken when changing "green_min_threshold" and "green_max_threshold". "green_min_threshold"
+    # must always be less than "green_max_threshold". Also, "green_max_threshold" must be less than the available
+    # buffer pool size. Note that some platforms (e.g., Mellanox) round-up the value of "green_max_threshold" if
+    # it is not provided as a multiple of a certain number in the config. The rounded-up value must still be
+    # less than the buffer pool size. So to avoid potential issues, we never attempt to increase
+    # "green_max_threshold".
+    delta = {"green_min_threshold": 0, "green_max_threshold": 0, "green_drop_probability": 0}
+
+    min_threshold = int(ecn_data["green_min_threshold"])
+    max_threshold = int(ecn_data["green_max_threshold"])
+    if "green_min_threshold" in fields and "green_max_threshold" in fields:
+        # Both fields are being updated.
+        if min_threshold > 0:
+            delta["green_min_threshold"] = -1
+            delta["green_max_threshold"] = -1
+        else:  # min_threshold == 0
+            if max_threshold - min_threshold >= 2:
+                delta["green_min_threshold"] = 1
+                delta["green_max_threshold"] = -1
+            elif max_threshold > min_threshold:  # min_threshold == 0, max_threshold == 1
+                delta["green_min_threshold"] = 0
+                delta["green_max_threshold"] = -1
+            else:  # min_threshold == max_threshold == 0
+                delta["green_min_threshold"] = 0
+                delta["green_max_threshold"] = 0
+    elif "green_max_threshold" in fields:
+        # Only "green_max_threshold" is being updated.
+        if max_threshold > min_threshold:
+            delta["green_max_threshold"] = -1
+        else:  # max_threshold == min_threshold
+            delta["green_max_threshold"] = 0
+    elif "green_min_threshold" in fields:
+        # Only "green_min_threshold" is being updated.
+        if min_threshold > 0:
+            delta["green_min_threshold"] = -1
+        else:  # min_threshold == 0
+            if min_threshold < max_threshold:
+                delta["green_min_threshold"] = 1
+            else:
+                delta["green_min_threshold"] = 0
+
+    if "green_drop_probability" in fields:
+        probability = int(ecn_data["green_drop_probability"])
+        if 0 <= probability <= 99:
+            delta["green_drop_probability"] = 1
+        elif probability == 100:
+            delta["green_drop_probability"] = -1
+        else:
+            raise ValueError("Invalid probability value: {}".format(probability))
+    return delta
+
+
 @pytest.mark.parametrize("configdb_field", ["green_min_threshold", "green_max_threshold", "green_drop_probability",
                          "green_min_threshold,green_max_threshold,green_drop_probability"])
 @pytest.mark.parametrize("operation", ["replace"])
@@ -159,18 +213,11 @@ def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, opera
     for wred_profile in wred_profiles:
         ecn_data = duthost.shell(f"sonic-db-cli CONFIG_DB hgetall 'WRED_PROFILE|{wred_profile}'")["stdout"]
         ecn_data = ast.literal_eval(ecn_data)
+        delta = determine_delta_values(ecn_data, fields)
         new_values[wred_profile] = {}
         for field in fields:
             value = int(ecn_data[field])
-            if "probability" in field:
-                if 0 <= value <= 99:
-                    value += 1
-                elif value == 100:
-                    value -= 1
-                else:
-                    raise ValueError("Invalid probability value: {}".format(value))
-            else:
-                value += 1
+            value += delta[field]
             new_values[wred_profile][field] = value
 
             logger.info("value to be added to json patch: {}, operation: {}, field: {}"

--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -151,6 +151,8 @@ def determine_delta_values(ecn_data, fields):
 
     min_threshold = int(ecn_data["green_min_threshold"])
     max_threshold = int(ecn_data["green_max_threshold"])
+    assert 0 <= min_threshold <= max_threshold, \
+        f"Invalid thresholds: green_min_threshold={min_threshold}, green_max_threshold={max_threshold}"
     if "green_min_threshold" in fields and "green_max_threshold" in fields:
         # Both fields are being updated.
         if min_threshold > 0:
@@ -184,12 +186,11 @@ def determine_delta_values(ecn_data, fields):
 
     if "green_drop_probability" in fields:
         probability = int(ecn_data["green_drop_probability"])
+        assert 0 <= probability <= 100, f"Invalid green_drop_probability value: {probability}"
         if 0 <= probability <= 99:
             delta["green_drop_probability"] = 1
-        elif probability == 100:
+        else:  # probability == 100
             delta["green_drop_probability"] = -1
-        else:
-            raise ValueError("Invalid probability value: {}".format(probability))
     return delta
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixed nightly test failures in `test_ecn_config_update.py` on some platforms due to invalid new values for `green_min_threshold` or `green_max_threshold` fields.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Approach
#### What is the motivation for this PR?
Nightly test failures in `test_ecn_config_update.py` on some platforms.

#### How did you do it?
When changing the `green_min_threshold` or `green_max_threshold` field of a WRED profile, we must ensure that the new values are valid. In particular, these conditions should always be true:
1. `green_min_threshold <= green_max_threshold`.
2. `green_max_threshold <= buffer pool size`
On some platforms (e.g., Mellanox), `green_max_threshold` must be a multiple of a certain number (unit size). If it is not provided as a multiple of unit size in the config, then SAI rounds-up `green_max_threshold` to the first multiple of unit size. The rounded-up value must still be less than buffer pool size. Otherwise, the ASIC will reject the new value.
To ensure these constraints are not violated, we never increase `green_max_threshold`. A new functions named `determine_delta_values` will decide how much each field should change based on fields that are changed in the test and current field values in the WRED profile.

#### How did you verify/test it?
Ran the tests on a Mellanox device on which the tests previously failed. Here are the test results:
```
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_min_threshold] PASSED                                         [ 25%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_max_threshold] PASSED                                         [ 50%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_drop_probability] PASSED                                      [ 75%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_min_threshold,green_max_threshold,green_drop_probability] PASSED [100%]
```

#### Any platform specific information?
No. The test improvement is generic and applies to all platforms.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A