### PR TITLE
[202412][PR: 18233] [TACACS] Fix auditd TACACS config re-init check failed issue.

### DIFF
--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -85,7 +85,11 @@ def change_and_wait_aaa_config_update(duthost, command, last_timestamp=None, tim
     # Wait auditd reload config finish
     def log_exist(duthost):
         latest_timestamp = get_auditd_config_reload_timestamp(duthost)
-        return latest_timestamp != last_timestamp
+        reload = latest_timestamp != last_timestamp
+        if not reload:
+            # Send the HUP signal to auditd-tacplus to trigger a config reload
+            duthost.shell("sudo kill -1 $(pidof audisp-tacplus)")
+        return reload
 
     exist = wait_until(timeout, 1, 0, log_exist, duthost)
     pytest_assert(exist, "Not found aaa config update log: {}".format(command))


### PR DESCRIPTION
Cherry pick this PR to fix tacacs/test_authorization.py

https://elastictest.org/scheduler/testplan/68b4123825bf71d31953a834?testcase=tacacs%2Ftest_authorization.py&type=console&searchTestCase=tacacs%2Ftest_authorization.p

<img width="1735" height="1377" alt="image" src="https://github.com/user-attachments/assets/463e9166-7b9d-487e-a014-518e4f4d1fba" />
