### PR TITLE
Skip warm reboot related tests in 202412

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1047,10 +1047,9 @@ platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset:
 #######################################
 ####    test_advanced_reboot      #####
 #######################################
-platform_tests/test_advanced_reboot.py::**:
+platform_tests/test_advanced_reboot.py:
   skip:
     reason: "Skip all advanced reboot tests on 202412 (warm reboot not required for backend ToRs)"
-    conditions_logical_operator: or
     conditions:
       - "release in ['202412']"
 
@@ -1357,19 +1356,17 @@ bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot:
 ##############################
 #####   test_wr_arp.py   #####
 ##############################
-tests/arp/test_wr_arp.py::**:
+arp/test_wr_arp.py:
   skip:
     reason: "Skip all ARP warm-reboot tests on 202412"
-    conditions_logical_operator: or
     conditions:
       - "release in ['202412']"
 
 ###################################
 #####   test_warm_reboot.py   #####
 ###################################
-tests/snappi_tests/reboot/test_warm_reboot.py::**:
+snappi_tests/reboot/test_warm_reboot.py:
   skip:
     reason: "Skip all Snappi warm-reboot tests on 202412"
-    conditions_logical_operator: or
     conditions:
       - "release in ['202412']"


### PR DESCRIPTION
In PR https://github.com/Azure/sonic-mgmt.msft/pull/693, it skipped warm reboot related tests in 202412, but the usage is not correct. In this PR, we change them into correct format. 