### PR TITLE
Skip platform_tests/test_reboot.py::test_warm_reboot in 202412 branch

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -290,11 +290,12 @@ bgp/test_bgp_slb.py:
 bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot:
   skip:
     reason: "Skip it on dual tor since it got stuck during warm reboot due to known issue on master and internal image
-             or over topologies which doesn't support slb."
+             or over topologies which doesn't support slb. / Skip warm-reboot related BGP test on 202412 (backend ToRs)"
     conditions_logical_operator: or
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56'] and https://github.com/sonic-net/sonic-mgmt/issues/9201"
       - "'backend' in topo_name or 'mgmttor' in topo_name or 'isolated' in topo_name"
+      - "release in ['202412']"
 
 bgp/test_bgp_speaker.py:
   skip:
@@ -3308,6 +3309,12 @@ snappi_tests/pfc/test_global_pause_with_snappi.py:
     conditions:
       - "asic_type in ['cisco-8000', 'vs']"
       - "topo_type in ['t2', 'multidut-tgen']"
+
+snappi_tests/reboot/test_warm_reboot.py:
+  skip:
+    reason: "Skip all Snappi warm-reboot tests on 202412"
+    conditions:
+      - "release in ['202412']"
 
 #######################################
 #####            snmp             #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1251,6 +1251,7 @@ platform_tests/test_reboot.py::test_warm_reboot:
     conditions:
       - "topo_type in ['m0', 'mx', 't1', 't2']"
       - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-buildimage/issues/16502"
+      - "release in ['202412']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:
@@ -1326,7 +1327,6 @@ platform_tests/test_service_warm_restart.py:
 #######################################
 #####test_thermal_state_db.py #####
 #######################################
-
 platform_tests/test_thermal_state_db.py:
   skip:
     reason: "Skip in case of Cisco platform for T2 profile due to temperarory bug."
@@ -1342,31 +1342,3 @@ platform_tests/test_xcvr_info_in_db.py::test_xcvr_info_in_db:
     conditions:
       - "platform in ['x86_64-cel_e1031-r0']"
       - https://github.com/sonic-net/sonic-buildimage/issues/18231
-
-#######################################################################
-#####   test_bgp_slb_neighbor_persistence_across_advanced_reboot  #####
-#######################################################################
-bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot:
-  skip:
-    reason: "Skip warm-reboot related BGP test on 202412 (backend ToRs)"
-    conditions_logical_operator: or
-    conditions:
-      - "release in ['202412']"
-
-##############################
-#####   test_wr_arp.py   #####
-##############################
-arp/test_wr_arp.py:
-  skip:
-    reason: "Skip all ARP warm-reboot tests on 202412"
-    conditions:
-      - "release in ['202412']"
-
-###################################
-#####   test_warm_reboot.py   #####
-###################################
-snappi_tests/reboot/test_warm_reboot.py:
-  skip:
-    reason: "Skip all Snappi warm-reboot tests on 202412"
-    conditions:
-      - "release in ['202412']"


### PR DESCRIPTION
In PR https://github.com/Azure/sonic-mgmt.msft/pull/693, we forgot to skip `platform_tests/test_reboot.py::test_warm_reboot`, which will still block the pipeline. In this PR, we skip this case. At the same time, we move the conditional marks into correct files.  