### PR TITLE
[fix]: Fix test_custom_acl_table.py - packets on service ports (#20087)

### DIFF
--- a/tests/acl/custom_acl_table/test_custom_acl_table.py
+++ b/tests/acl/custom_acl_table/test_custom_acl_table.py
@@ -11,7 +11,7 @@ import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa F401
-from tests.common.utilities import get_upstream_neigh_type
+from tests.common.utilities import get_all_upstream_neigh_type
 from tests.common.utilities import get_neighbor_ptf_port_list
 
 logger = logging.getLogger(__name__)
@@ -286,8 +286,9 @@ def test_custom_acl(rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter,
                     dst_port_indices.append(mg_facts_unselected_dut['minigraph_ptf_indices'][member])
     else:
         topo = tbinfo["topo"]["type"]
-        upstream_neigh_type = get_upstream_neigh_type(topo)
-        dst_port_indices = get_neighbor_ptf_port_list(rand_selected_dut, upstream_neigh_type, tbinfo)
+        upstream_neigh_types = get_all_upstream_neigh_type(topo)
+        for upstream_neigh_type in upstream_neigh_types:
+            dst_port_indices.extend(get_neighbor_ptf_port_list(rand_selected_dut, upstream_neigh_type, tbinfo))
 
     test_pkts = build_testing_pkts(router_mac)
     for rule, pkt in list(test_pkts.items()):


### PR DESCRIPTION
Origin PR: https://github.com/sonic-net/sonic-mgmt/pull/20087

What is the motivation for this PR?
To the custom_acl_table test, the egress ports didn't include the service ports.

How did you do it?
Add the service port to the egress ports list

How did you verify/test it?
Check it in the testbed with service ports.