### PR TITLE
adjust test_dip_sip.py to ipv6 only topology

### DIFF
--- a/tests/ipfwd/conftest.py
+++ b/tests/ipfwd/conftest.py
@@ -43,14 +43,14 @@ def get_lag_facts(dut, lag_facts, switch_arptable, mg_facts, ignore_lags,
                     if addr.version == 4:
                         selected_lag_facts[key + '_router_ipv4'] = intf['addr']
                         selected_lag_facts[key + '_host_ipv4'] = intf['peer_addr']
-                        selected_lag_facts[key + '_host_mac'] = \
-                            switch_arptable['arptable']['v4'][intf['peer_addr']]['macaddress']
+                        ipv4_mac = switch_arptable['arptable']['v4'][intf['peer_addr']]['macaddress']
+                        selected_lag_facts[key + '_host_mac'] = ipv4_mac
                     elif addr.version == 6:
                         selected_lag_facts[key + '_router_ipv6'] = intf['addr']
                         selected_lag_facts[key + '_host_ipv6'] = intf['peer_addr']
                         if not selected_lag_facts[key + '_host_mac']:
-                            selected_lag_facts[key + '_host_mac'] = \
-                                switch_arptable['arptable']['v6'][intf['peer_addr']]['macaddress']
+                            ipv6_mac = switch_arptable['arptable']['v6'][intf['peer_addr']]['macaddress']
+                            selected_lag_facts[key + '_host_mac'] = ipv6_mac
             logger.info("{} lag is {}".format(key, up_lag))
             break
 
@@ -94,14 +94,14 @@ def get_port_facts(dut, mg_facts, port_status, switch_arptable, ignore_intfs,
                     if addr.version == 4:
                         selected_port_facts[key + '_router_ipv4'] = intf['addr']
                         selected_port_facts[key + '_host_ipv4'] = intf['peer_addr']
-                        selected_port_facts[key + '_host_mac'] = \
-                            switch_arptable['arptable']['v4'][intf['peer_addr']]['macaddress']
+                        ipv4_mac = switch_arptable['arptable']['v4'][intf['peer_addr']]['macaddress']
+                        selected_port_facts[key + '_host_mac'] = ipv4_mac
                     elif addr.version == 6:
                         selected_port_facts[key + '_router_ipv6'] = intf['addr']
                         selected_port_facts[key + '_host_ipv6'] = intf['peer_addr']
                         if not selected_port_facts[key + '_host_mac']:
-                            selected_port_facts[key + '_host_mac'] = \
-                                switch_arptable['arptable']['v6'][intf['peer_addr']]['macaddress']
+                            ipv6_mac = switch_arptable['arptable']['v6'][intf['peer_addr']]['macaddress']
+                            selected_port_facts[key + '_host_mac'] = ipv6_mac
             if up_port:
                 logger.info("{} port is {}".format(key, up_port))
                 break

--- a/tests/ipfwd/conftest.py
+++ b/tests/ipfwd/conftest.py
@@ -48,6 +48,9 @@ def get_lag_facts(dut, lag_facts, switch_arptable, mg_facts, ignore_lags,
                     elif addr.version == 6:
                         selected_lag_facts[key + '_router_ipv6'] = intf['addr']
                         selected_lag_facts[key + '_host_ipv6'] = intf['peer_addr']
+                        if not selected_lag_facts[key + '_host_mac']:
+                            selected_lag_facts[key + '_host_mac'] = \
+                                switch_arptable['arptable']['v6'][intf['peer_addr']]['macaddress']
             logger.info("{} lag is {}".format(key, up_lag))
             break
 
@@ -96,6 +99,9 @@ def get_port_facts(dut, mg_facts, port_status, switch_arptable, ignore_intfs,
                     elif addr.version == 6:
                         selected_port_facts[key + '_router_ipv6'] = intf['addr']
                         selected_port_facts[key + '_host_ipv6'] = intf['peer_addr']
+                        if not selected_port_facts[key + '_host_mac']:
+                            selected_port_facts[key + '_host_mac'] = \
+                                switch_arptable['arptable']['v6'][intf['peer_addr']]['macaddress']
             if up_port:
                 logger.info("{} port is {}".format(key, up_port))
                 break

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -4,6 +4,7 @@ import logging
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # noqa F401
+from tests.common.utilities import is_ipv6_only_topology
 
 DEFAULT_HLIM_TTL = 64
 WAIT_EXPECTED_PACKET_TIMEOUT = 5
@@ -85,5 +86,8 @@ def run_test_ipv4(ptfadapter, facts):
 
 def test_dip_sip(tbinfo, ptfadapter, gather_facts, enum_rand_one_frontend_asic_index):
     ptfadapter.reinit()
-    run_test_ipv4(ptfadapter, gather_facts)
-    run_test_ipv6(ptfadapter, gather_facts)
+    if is_ipv6_only_topology(tbinfo):
+        run_test_ipv6(ptfadapter, gather_facts)
+    else:
+        run_test_ipv4(ptfadapter, gather_facts)
+        run_test_ipv6(ptfadapter, gather_facts)


### PR DESCRIPTION
### Description of PR
Adjust test_dip_sip.py to ipv6 only topology
Modified get_lag_facts and get_ports_facts to support ipv6 only topo, and adjusted the cases to run with this topo.
This PR is only for 202412 branch, because the following PR - https://github.com/sonic-net/sonic-mgmt/pull/17058 was not CP to this branch


### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Approach
#### What is the motivation for this PR?
fix test to run as expected on ipv6 only topo

#### How did you do it?
selected the ipv6 ip option for lags and ports facts
and only run ipv6 validation on the test itself.

#### How did you verify/test it?
internal nvidia regression


