### PR TITLE
Manual Cherry-Pick PR: Set xfail to tests on IPv6 only topo by created bugs (#20750)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -462,6 +462,10 @@ configlet/test_add_rack.py:
     reason: "AddRack is not yet supported on multi-ASIC platform"
     conditions:
       - "is_multi_asic==True"
+  xfail:
+    reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20728"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20728 and '-v6-' in topo_name"
 
 container_hardening/test_container_hardening.py::test_container_privileged:
   skip:
@@ -2049,15 +2053,15 @@ generic_config_updater/test_srv6:
 
 generic_config_updater/test_vlan_interface.py::test_vlan_interface_tc1_suite:
   xfail:
-    reason: "xfail for IPv6-only topologies, still have IPv4 function used"
+    reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20727"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/19638 and '-v6-' in topo_name"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20727 and '-v6-' in topo_name"
 
 generic_config_updater/test_vlan_interface.py::test_vlan_interface_tc2_incremental_change:
-  xfail:
-    reason: "xfail for IPv6-only topologies, still have IPv4 function used"
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/19638 and '-v6-' in topo_name"
+   xfail:
+     reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20727"
+     conditions:
+       - "https://github.com/sonic-net/sonic-mgmt/issues/20727 and '-v6-' in topo_name"
 
 #######################################
 #####           gnmi              #####
@@ -2148,9 +2152,11 @@ hash/test_generic_hash.py::test_ecmp_hash:
     conditions:
       - "asic_type in ['broadcom', 'cisco-8000']"
   xfail:
-    reason: 'ECMP hash skipped due to issue https://github.com/sonic-net/sonic-mgmt/issues/18304'
+    reason: 'ECMP hash skipped due to issue https://github.com/sonic-net/sonic-mgmt/issues/18304 Or xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20733'
+    conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/18304 and 't0-isolated-d32u32s2' in topo_name and hwsku in ['Mellanox-SN5640-C512S2']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20733 and '-v6-' in topo_name"
 
 hash/test_generic_hash.py::test_ecmp_hash[CRC-INNER_DST_MAC-ipv4-ipv4-vxlan]:
   skip:
@@ -2176,6 +2182,10 @@ hash/test_generic_hash.py::test_lag_hash:
     reason: 'LAG hash not supported in broadcom SAI and Cisco 8000'
     conditions:
       - "asic_type in ['broadcom', 'cisco-8000']"
+  xfail:
+    reason: 'xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20733'
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20733 and '-v6-' in topo_name"
 
 hash/test_generic_hash.py::test_lag_hash[CRC-INNER_IP_PROTOCOL:
   skip:
@@ -2191,6 +2201,10 @@ hash/test_generic_hash.py::test_lag_member_flap:
       - "asic_gen == 'spc1'"
       - "asic_type in ['broadcom']"
       - https://github.com/sonic-net/sonic-mgmt/issues/13919
+  xfail:
+    reason: 'xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20733'
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20733 and '-v6-' in topo_name"
 
 hash/test_generic_hash.py::test_lag_member_flap[CRC-INNER_IP_PROTOCOL:
   skip:
@@ -2238,6 +2252,10 @@ hash/test_generic_hash.py::test_lag_member_remove_add:
       - "asic_gen == 'spc1'"
       - "asic_type in ['broadcom']"
       - https://github.com/sonic-net/sonic-mgmt/issues/13919
+  xfail:
+    reason: 'xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20733'
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20733 and '-v6-' in topo_name"
 
 hash/test_generic_hash.py::test_lag_member_remove_add[CRC-INNER_IP_PROTOCOL:
   skip:
@@ -2483,6 +2501,18 @@ ipfwd/test_mtu.py:
     conditions:
       - "topo_type not in ['t1', 't2']"
 
+ipfwd/test_nhop_group.py::test_nhop_group_member_count:
+  xfail:
+    reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20731"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20731 and '-v6-' in topo_name"
+
+ipfwd/test_nhop_group.py::test_nhop_group_member_order_capability:
+  xfail:
+    reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20731"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20731 and '-v6-' in topo_name"
+
 #######################################
 #####            ixia             #####
 #######################################
@@ -2676,6 +2706,10 @@ pc/test_po_update.py::test_po_update:
     reason: "Skip test due to there is no portchannel or no portchannel member exists in current topology."
     conditions:
       - "len(minigraph_portchannels) == 0 or len(minigraph_portchannels[list(minigraph_portchannels.keys())[0]]['members']) == 0"
+  xfail:
+    reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20729"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20729 and '-v6-' in topo_name"
 
 pc/test_po_update.py::test_po_update_io_no_loss:
   skip:
@@ -3228,6 +3262,12 @@ route/test_duplicate_route.py::test_duplicate_routes[4:
     conditions:
       - "'-v6-' in topo_name"
 
+route/test_route_bgp_ecmp.py:
+  xfail:
+    reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20730"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20730 and '-v6-' in topo_name"
+
 route/test_route_flap.py:
   skip:
     reason: "Test case has issue on the t0-56-povlan and dualtor-64 topo. Does not apply to standalone topos."
@@ -3667,6 +3707,12 @@ vlan/test_host_vlan.py::test_host_vlan_no_floodling:
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/19928 and '-v6-' in topo_name"
 
+vlan/test_vlan.py::test_vlan_tc3_send_invalid_vid:
+  xfail:
+    reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20726"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20726 and '-v6-' in topo_name"
+
 vlan/test_vlan.py::test_vlan_tc7_tagged_qinq_switch_on_outer_tag:
   skip:
     reason: "Unsupported platform."
@@ -3914,6 +3960,36 @@ vxlan/test_vxlan_route_advertisement.py:
     reason: "VxLAN route advertisement can only run on cisco and mnlx platforms."
     conditions:
       - "asic_type not in ['cisco-8000', 'mellanox', 'vs']"
+
+vxlan/test_vxlan_route_advertisement.py::Test_VxLAN_route_Advertisement::test_basic_route_advertisement[v4_in_v4]:
+  xfail:
+    reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20725"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20725 and '-v6-' in topo_name"
+
+vxlan/test_vxlan_route_advertisement.py::Test_VxLAN_route_Advertisement::test_basic_route_advertisement_with_community[v4_in_v4]:
+  xfail:
+    reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20725"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20725 and '-v6-' in topo_name"
+
+vxlan/test_vxlan_route_advertisement.py::Test_VxLAN_route_Advertisement::test_basic_route_advertisement_with_community_change[v4_in_v4]:
+  xfail:
+    reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20725"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20725 and '-v6-' in topo_name"
+
+vxlan/test_vxlan_route_advertisement.py::Test_VxLAN_route_Advertisement::test_route_advertisement_without_and_with_community[v4_in_v4]:
+  xfail:
+    reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20725"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20725 and '-v6-' in topo_name"
+
+vxlan/test_vxlan_route_advertisement.py::Test_VxLAN_route_Advertisement::test_scale_route_advertisement_with_community[v4_in_v4]:
+  xfail:
+    reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20725"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20725 and '-v6-' in topo_name"
 
 #######################################
 #####           wan_lacp          #####


### PR DESCRIPTION
Manual cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/20750

Added xfail to condition mark, for tests, which failed on IPv6 only topo.
Related tests and their created issues:
vxlan_route_adv - https://github.com/sonic-net/sonic-mgmt/issues/20725
test_vlan_tc3_send_invalid_vid - https://github.com/sonic-net/sonic-mgmt/issues/20726
vlan_interface_cases - https://github.com/sonic-net/sonic-mgmt/issues/20727
test_add_rack - https://github.com/sonic-net/sonic-mgmt/issues/20728
test_po_update - https://github.com/sonic-net/sonic-mgmt/issues/20729
test_route_bgp_ecmp - https://github.com/sonic-net/sonic-mgmt/issues/20730
nhop_group - https://github.com/sonic-net/sonic-mgmt/issues/20731
test_lag_member_remove_add - https://github.com/sonic-net/sonic-mgmt/issues/20733
test_lag_member_flap - https://github.com/sonic-net/sonic-mgmt/issues/20733
test_lag_hash - https://github.com/sonic-net/sonic-mgmt/issues/20733
test_ecmp_hash - https://github.com/sonic-net/sonic-mgmt/issues/20733