### PR TITLE
Update J2CP QoS test parameters for PR23848 (Backport PR20806)

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -108,22 +108,22 @@ qos_params:
                     pkts_num_trig_egr_drp: 2396745
                     pkts_num_fill_egr_min: 0
                     cell_size: 4096
-            400000_50m:
+            400000_30m:
                 pkts_num_leak_out: 140
                 internal_hdr_size: 48
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764336
-                    pkts_num_trig_ingr_drp: 765653
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 775751
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 764336
-                    pkts_num_trig_ingr_drp: 765653
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 775751
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [3, 4]
@@ -132,30 +132,32 @@ qos_params:
                     src_port_ids: [0, 2, 4, 6, 8, 10, 12, 14, 16]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 764223
-                    pkts_num_hdrm_full: 1317
-                    pkts_num_hdrm_partial: 1300
-                    margin: 300
+                    packet_size: 1246
+                    cell_size: 4096
+                    pkts_num_trig_pfc: 60391
+                    pkts_num_hdrm_full: 1153
+                    pkts_num_hdrm_partial: 1143
+                    margin: 30
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764336
-                    pkts_num_trig_ingr_drp: 765653
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 775751
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764336
+                    pkts_num_trig_pfc: 762403
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 764336
+                    pkts_num_trig_pfc: 762403
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -169,7 +171,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 764336
+                    pkts_num_trig_pfc: 762403
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -187,7 +189,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 765653
+                    pkts_num_trig_ingr_drp: 775751
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -196,7 +198,7 @@ qos_params:
                     queue: 3
                     pkts_num_fill_ingr_min: 0
                     pkts_num_trig_pfc: 28160
-                    pkts_num_trig_ingr_drp: 765653
+                    pkts_num_trig_ingr_drp: 775751
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:
@@ -222,15 +224,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764336
-                    pkts_num_trig_ingr_drp: 1477730
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 1476277
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 764336
-                    pkts_num_trig_ingr_drp: 1477730
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 1476277
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [3, 4]
@@ -239,30 +241,32 @@ qos_params:
                     src_port_ids: [0, 2, 4, 6, 8, 10, 12, 14, 16]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 700628
-                    pkts_num_hdrm_full: 713397
-                    pkts_num_hdrm_partial: 713300
-                    margin: 100
+                    packet_size: 1246
+                    cell_size: 4096
+                    pkts_num_trig_pfc: 60391
+                    pkts_num_hdrm_full: 61692
+                    pkts_num_hdrm_partial: 61682
+                    margin: 10
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764336
-                    pkts_num_trig_ingr_drp: 1477730
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 1476277
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764336
+                    pkts_num_trig_pfc: 762403
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 764336
+                    pkts_num_trig_pfc: 762403
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -276,7 +280,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 764336
+                    pkts_num_trig_pfc: 762403
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -294,7 +298,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 1477730
+                    pkts_num_trig_ingr_drp: 1476277
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -482,22 +486,22 @@ qos_params:
                     pkts_num_trig_egr_drp: 2396745
                     pkts_num_fill_egr_min: 0
                     cell_size: 4096
-            400000_50m:
+            400000_30m:
                 pkts_num_leak_out: 140
                 internal_hdr_size: 48
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764223
-                    pkts_num_trig_ingr_drp: 765540
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 775751
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 764223
-                    pkts_num_trig_ingr_drp: 765540
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 775751
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [3, 4]
@@ -506,30 +510,32 @@ qos_params:
                     src_port_ids: [0, 2, 4, 6, 8, 10, 12, 14, 16]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 764223
-                    pkts_num_hdrm_full: 1317
-                    pkts_num_hdrm_partial: 1300
-                    margin: 300
+                    packet_size: 1246
+                    cell_size: 4096
+                    pkts_num_trig_pfc: 60391
+                    pkts_num_hdrm_full: 1153
+                    pkts_num_hdrm_partial: 1143
+                    margin: 30
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764223
-                    pkts_num_trig_ingr_drp: 765540
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 775751
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764223
+                    pkts_num_trig_pfc: 762403
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 764223
+                    pkts_num_trig_pfc: 762403
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -543,7 +549,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 764223
+                    pkts_num_trig_pfc: 762403
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -561,7 +567,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 765540
+                    pkts_num_trig_ingr_drp: 775751
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -570,7 +576,7 @@ qos_params:
                     queue: 3
                     pkts_num_fill_ingr_min: 0
                     pkts_num_trig_pfc: 28160
-                    pkts_num_trig_ingr_drp: 765540
+                    pkts_num_trig_ingr_drp: 775751
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:
@@ -596,15 +602,15 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764223
-                    pkts_num_trig_ingr_drp: 1477617
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 1476277
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 764223
-                    pkts_num_trig_ingr_drp: 1477617
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 1476277
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [3, 4]
@@ -613,30 +619,32 @@ qos_params:
                     src_port_ids: [0, 2, 4, 6, 8, 10, 12, 14, 16]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 700525
-                    pkts_num_hdrm_full: 713397
-                    pkts_num_hdrm_partial: 713300
-                    margin: 100
+                    packet_size: 1246
+                    cell_size: 4096
+                    pkts_num_trig_pfc: 60391
+                    pkts_num_hdrm_full: 61692
+                    pkts_num_hdrm_partial: 61682
+                    margin: 10
                 wm_pg_headroom:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764223
-                    pkts_num_trig_ingr_drp: 1477617
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 1476277
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764223
+                    pkts_num_trig_pfc: 762403
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 764223
+                    pkts_num_trig_pfc: 762403
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -650,7 +658,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 764223
+                    pkts_num_trig_pfc: 762403
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -668,7 +676,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 1477617
+                    pkts_num_trig_ingr_drp: 1476277
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3


### PR DESCRIPTION
This PR is a backport of https://github.com/sonic-net/sonic-mgmt/pull/20806 for the msft-202503 branch.

https://github.com/sonic-net/sonic-buildimage/pull/23848 must be merged and backported to msft-202503 as well.

Edit:
backported buildimage PR: https://github.com/Azure/sonic-buildimage-msft/pull/1738