### PR TITLE
Manual cherry-pick PR: [QoS] dynamic skip of buffer tests for lossy only systems #17004

### DIFF
--- a/tests/qos/conftest.py
+++ b/tests/qos/conftest.py
@@ -132,3 +132,40 @@ def combine_qos_parameter():
 
     with open(output_file, "w") as ofp:
         yaml.dump(combined_yaml, ofp, default_flow_style=False)
+
+
+@pytest.fixture(scope="session")
+def is_buffer_model_dynamic(duthost):
+    """Detect the current buffer model (dynamic or traditional).
+       Called only once when the module is initialized.
+    Args:
+        duthost: The DUT host fixture
+    """
+    buffer_model = duthost.shell(
+        'redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model')['stdout']
+    yield (buffer_model == 'dynamic')
+
+
+@pytest.fixture(scope="session")
+def is_lossy_only_pool(duthost):
+    """Detect the current buffer pool.
+       Called only once when the module is initialized.
+       Cable length for all ports 0m - is lossy only
+    Args:
+        duthost: The DUT host fixture
+    """
+    cables_len_data = duthost.shell("redis-cli -n 4 hgetall 'CABLE_LENGTH|AZURE'")['stdout'].splitlines()
+    all_zero_m = all(cables_len_data[i + 1] == "0m" for i in range(0, len(cables_len_data), 2))
+    yield all_zero_m
+
+
+@pytest.fixture(scope="function")
+def skip_traditional_model(is_buffer_model_dynamic):
+    if not is_buffer_model_dynamic:
+        pytest.skip("Skip test in traditional model")
+
+
+@pytest.fixture(scope="function")
+def skip_lossy_buffer_only(is_lossy_only_pool):
+    if is_lossy_only_pool:
+        pytest.skip("Skip test for lossy only pool")

--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -60,19 +60,6 @@ KEY_2_LOSSLESS_QUEUE = "2_lossless_queues"
 KEY_4_LOSSLESS_QUEUE = "4_lossless_queues"
 
 
-def detect_buffer_model(duthost):
-    """Detect the current buffer model (dynamic or traditional) and store it for further use.
-       Called only once when the module is initialized
-
-    Args:
-        duthost: The DUT host object
-    """
-    global BUFFER_MODEL_DYNAMIC
-    buffer_model = duthost.shell(
-        'redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model')['stdout']
-    BUFFER_MODEL_DYNAMIC = (buffer_model == 'dynamic')
-
-
 def detect_ingress_pool_number(duthost):
     """Detect the number of ingress buffer pools and store it for further use.
        Called only once when the module is initialized
@@ -322,7 +309,7 @@ def configure_shared_headroom_pool(duthost, enable):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def setup_module(duthosts, rand_one_dut_hostname, request):
+def setup_module(duthosts, rand_one_dut_hostname, request, is_buffer_model_dynamic):
     """Set up module. Called only once when the module is initialized
 
     Args:
@@ -330,9 +317,10 @@ def setup_module(duthosts, rand_one_dut_hostname, request):
     """
     global DEFAULT_SHARED_HEADROOM_POOL_ENABLED
     global DEFAULT_OVER_SUBSCRIBE_RATIO
+    global BUFFER_MODEL_DYNAMIC
+    BUFFER_MODEL_DYNAMIC = is_buffer_model_dynamic
 
     duthost = duthosts[rand_one_dut_hostname]
-    detect_buffer_model(duthost)
     if not is_mellanox_device(duthost) and not is_marvell_teralynx_device(duthost):
         load_lossless_headroom_data(duthost)
         yield
@@ -393,11 +381,6 @@ def setup_module(duthosts, rand_one_dut_hostname, request):
     if bgp_neighbors:
         duthost.shell("config bgp startup all")
         time.sleep(60)
-
-
-def skip_traditional_model():
-    if not BUFFER_MODEL_DYNAMIC:
-        pytest.skip("Skip test in traditional model")
 
 
 def init_log_analyzer(duthost, marker, expected, ignored=None):
@@ -962,7 +945,8 @@ def pg_to_test(request):
 
 
 def test_change_speed_cable(duthosts, rand_one_dut_hostname, conn_graph_facts,      # noqa F811
-                            port_to_test, speed_to_test, mtu_to_test, cable_len_to_test):
+                            port_to_test, speed_to_test, mtu_to_test, cable_len_to_test,
+                            skip_traditional_model, skip_lossy_buffer_only):
     """The testcase for changing the speed and cable length of a port
 
     Change the variables of the port, including speed, mtu and cable length,
@@ -1000,8 +984,6 @@ def test_change_speed_cable(duthosts, rand_one_dut_hostname, conn_graph_facts,  
         mtu_to_test: To what mtu will the port's be changed
         cable_len_to_test: To what cable length will the port's be changed
     """
-    skip_traditional_model()
-
     duthost = duthosts[rand_one_dut_hostname]
     supported_speeds = duthost.shell(
         'redis-cli -n 6 hget "PORT_TABLE|{}" supported_speeds'.format(port_to_test))['stdout']
@@ -1303,7 +1285,8 @@ def _parse_buffer_profile_params(param, cmd, name):
     return cli_str, new_size, xoff
 
 
-def test_headroom_override(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_test):    # noqa F811
+def test_headroom_override(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_test,     # noqa F811
+                           skip_traditional_model, skip_lossy_buffer_only):
     """Test case for headroom override
 
     Verify the headroom override behavior.
@@ -1327,8 +1310,6 @@ def test_headroom_override(duthosts, rand_one_dut_hostname, conn_graph_facts, po
     Args:
         port_to_test: On which port will the test be performed
     """
-    skip_traditional_model()
-
     duthost = duthosts[rand_one_dut_hostname]
     if not TESTPARAM_HEADROOM_OVERRIDE:
         pytest.skip(
@@ -1493,7 +1474,8 @@ def check_buffer_profiles_for_shp(duthost, shp_enabled=True):
         20, 2, 0, _check_buffer_profiles_for_shp, duthost, shp_enabled))
 
 
-def test_shared_headroom_pool_configure(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_test):   # noqa F811
+def test_shared_headroom_pool_configure(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_test,    # noqa F811
+                                        skip_traditional_model, skip_lossy_buffer_only):
     """Test case for shared headroom pool configuration
 
     Test case to verify the variant commands of shared headroom pool configuration and
@@ -1518,8 +1500,6 @@ def test_shared_headroom_pool_configure(duthosts, rand_one_dut_hostname, conn_gr
         7. Testcase: remove both over subscribe ratio and shared headroom pool size
         8. Restore configuration
     """
-    skip_traditional_model()
-
     duthost = duthosts[rand_one_dut_hostname]
 
     pool_size_before_shp = duthost.shell(
@@ -1671,7 +1651,8 @@ def test_shared_headroom_pool_configure(duthosts, rand_one_dut_hostname, conn_gr
                          shp_size_before_shp, None)
 
 
-def test_lossless_pg(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_test, pg_to_test):      # noqa F811
+def test_lossless_pg(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_test, pg_to_test,       # noqa F811
+                     skip_traditional_model, skip_lossy_buffer_only):
     """Test case for non default dynamic th
 
     Test case to verify the static profile with non default dynamic th
@@ -1694,8 +1675,6 @@ def test_lossless_pg(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_
         port_to_test: On which port will the test be performed
         pg_to_test: To what PG will the profiles be applied
     """
-    skip_traditional_model()
-
     duthost = duthosts[rand_one_dut_hostname]
     original_speed = duthost.shell(
         'redis-cli -n 4 hget "PORT|{}" speed'.format(port_to_test))['stdout']
@@ -1850,7 +1829,8 @@ def test_lossless_pg(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_
                          original_shp_size, None)
 
 
-def test_port_admin_down(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_test):      # noqa F811
+def test_port_admin_down(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_test,       # noqa F811
+                         skip_traditional_model, skip_lossy_buffer_only):
     """The test case for admin down ports
 
     For administratively down ports, all PGs should be removed from the ASIC
@@ -1978,8 +1958,6 @@ def test_port_admin_down(duthosts, rand_one_dut_hostname, conn_graph_facts, port
             pytest_assert(not object_list_in_appl_db,
                           "There shouldn't be any object in {} on an administratively down port but we got {}"
                           .format(table, object_list_in_appl_db))
-
-    skip_traditional_model()
 
     param = TESTPARAM_HEADROOM_OVERRIDE.get("add")
     if not param:
@@ -2217,7 +2195,8 @@ def test_port_admin_down(duthosts, rand_one_dut_hostname, conn_graph_facts, port
                          original_shp_size, None)
 
 
-def test_port_auto_neg(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_test):        # noqa F811
+def test_port_auto_neg(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_test,         # noqa F811
+                       skip_traditional_model, skip_lossy_buffer_only):
     """The test case for auto negotiation enabled ports
 
     For those ports, the speed which is taken into account for buffer calculating is no longer the configure speed but
@@ -2257,8 +2236,6 @@ def test_port_auto_neg(duthosts, rand_one_dut_hostname, conn_graph_facts, port_t
     def _get_max_speed_from_list(speed_list_str):
         speed_list = natsorted(speed_list_str.split(','))
         return speed_list[-1]
-
-    skip_traditional_model()
 
     duthost = duthosts[rand_one_dut_hostname]
     supported_speeds = duthost.shell(
@@ -2389,7 +2366,8 @@ def test_port_auto_neg(duthosts, rand_one_dut_hostname, conn_graph_facts, port_t
 
 @pytest.mark.disable_loganalyzer
 @pytest.mark.parametrize("disable_shp", [True, False])
-def test_exceeding_headroom(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_test, disable_shp):       # noqa F811
+def test_exceeding_headroom(duthosts, rand_one_dut_hostname, conn_graph_facts, port_to_test, disable_shp,        # noqa F811
+                            skip_traditional_model, skip_lossy_buffer_only):
     """The test case is to verify If the accumulative headroom(shared headroom) of a port exceeds the maximum threshold,
     the relevant configuration should not be applied successfully, and there will are the corresponding error logs.
 
@@ -2409,8 +2387,6 @@ def test_exceeding_headroom(duthosts, rand_one_dut_hostname, conn_graph_facts, p
 
         In each step, it also checks whether the expected error message is found.
     """
-    skip_traditional_model()
-
     duthost = duthosts[rand_one_dut_hostname]
     max_headroom_size = duthost.shell(
         'redis-cli -n 6 hget "BUFFER_MAX_PARAM_TABLE|{}" max_headroom_size'.format(port_to_test))['stdout']
@@ -2665,14 +2641,12 @@ def _recovery_to_dynamic_buffer_model(duthost):
     config_reload(duthost, config_source='config_db')
 
 
-def test_buffer_model_test(duthosts, rand_one_dut_hostname, conn_graph_facts):      # noqa F811
+def test_buffer_model_test(duthosts, rand_one_dut_hostname, conn_graph_facts, skip_traditional_model):      # noqa F811
     """Verify whether the buffer model is expected after configuration operations:
     The following items are verified
      - Whether the buffer model is traditional after executing config load_minigraph
      - Whether the buffer model is dynamic after recovering the buffer model to dynamic
     """
-    skip_traditional_model()
-
     duthost = duthosts[rand_one_dut_hostname]
     try:
         logging.info('[Config load_minigraph]')
@@ -2692,7 +2666,8 @@ def test_buffer_model_test(duthosts, rand_one_dut_hostname, conn_graph_facts):  
         _recovery_to_dynamic_buffer_model(duthost)
 
 
-def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tbinfo, dualtor_ports):   # noqa F811
+def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tbinfo, dualtor_ports,    # noqa F811
+                           skip_lossy_buffer_only):
     """The testcase to verify whether buffer template has been correctly rendered and applied
 
     1. For all ports in the config_db,


### PR DESCRIPTION
Manual cherry-pick of PR [#17004](https://github.com/sonic-net/sonic-mgmt/pull/17004)

Added dynamic skip of buffer tests in test_buffer.py on lossy only system