### PR TITLE
Fix bug when PORT key is missing on flex counter table

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -129,6 +129,11 @@ class GenerateGoldenConfigDBModule(object):
                 golden_config_db["DEVICE_METADATA"]["localhost"]["default_pfcwd_status"] = "disable"
                 golden_config_db["DEVICE_METADATA"]["localhost"]["buffer_model"] = "traditional"
 
+        # set counterpoll interval to 2000ms as workaround for Slowness observed in nexthop group and member programming.
+        if "FLEX_COUNTER_TABLE" in ori_config_db:
+            golden_config_db["FLEX_COUNTER_TABLE"] = ori_config_db["FLEX_COUNTER_TABLE"]
+            golden_config_db["FLEX_COUNTER_TABLE"]["PORT"]["POLL_INTERVAL"] = "2000"
+
         return json.dumps(golden_config_db, indent=4)
 
     def check_version_for_bmp(self):

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -132,7 +132,7 @@ class GenerateGoldenConfigDBModule(object):
         # set counterpoll interval to 2000ms as workaround for Slowness observed in nexthop group and member programming.
         if "FLEX_COUNTER_TABLE" in ori_config_db:
             golden_config_db["FLEX_COUNTER_TABLE"] = ori_config_db["FLEX_COUNTER_TABLE"]
-            golden_config_db["FLEX_COUNTER_TABLE"]["PORT"]["POLL_INTERVAL"] = "2000"
+            golden_config_db["FLEX_COUNTER_TABLE"].setdefault("PORT", {})["POLL_INTERVAL"] = "2000"
 
         return json.dumps(golden_config_db, indent=4)
 

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -134,7 +134,7 @@ class GenerateGoldenConfigDBModule(object):
             golden_config_db["FLEX_COUNTER_TABLE"] = ori_config_db["FLEX_COUNTER_TABLE"]
             golden_config_db["FLEX_COUNTER_TABLE"].setdefault("PORT", {})["POLL_INTERVAL"] = "2000"
 
-            return json.dumps(golden_config_db, indent=4)
+        return json.dumps(golden_config_db, indent=4)
 
     def check_version_for_bmp(self):
         output_version = device_info.get_sonic_version_info()

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -129,7 +129,7 @@ class GenerateGoldenConfigDBModule(object):
                 golden_config_db["DEVICE_METADATA"]["localhost"]["default_pfcwd_status"] = "disable"
                 golden_config_db["DEVICE_METADATA"]["localhost"]["buffer_model"] = "traditional"
 
-        # set counterpoll interval to 2000ms as workaround for Slowness observed in nexthop group and member programming.
+        # set counterpoll interval to 2000ms as workaround for Slowness observed in nexthop group/member programming.
         if "FLEX_COUNTER_TABLE" in ori_config_db:
             golden_config_db["FLEX_COUNTER_TABLE"] = ori_config_db["FLEX_COUNTER_TABLE"]
             golden_config_db["FLEX_COUNTER_TABLE"].setdefault("PORT", {})["POLL_INTERVAL"] = "2000"


### PR DESCRIPTION
After the following Change: https://github.com/Azure/sonic-mgmt.msft/pull/723
On some cases, when trying to override the counterpoll interval, the user gets a key error:
```

importlib._bootstrap>\\", line 621, in _exec\\n  File \\"<frozen importlib._bootstrap_external>\\", line 940, in 
exec_module\\n  File \\"<frozen importlib._bootstrap>\\", line 241, in _call_with_frames_removed\\n  File 
\\"/tmp/ansible_generate_golden_config_db_payload_9x6dtuml/__main__.py\\", line 341, in <module>\\n  File 
\\"/tmp/ansible_generate_golden_config_db_payload_9x6dtuml/__main__.py\\", line 337, in main\\n  File 
\\"/tmp/ansible_generate_golden_config_db_payload_9x6dtuml/__main__.py\\", line 324, in generate\\n  File 
\\"/tmp/ansible_generate_golden_config_db_payload_9x6dtuml/__main__.py\\", line 135, in 
generate_full_lossy_golden_config_db\\nKeyError: 'PORT'\\n",

```

To fix it, I added a setdefault method to create the key if it doesnt exist.
