### PR TITLE
[202503] Enable GCU test on DT2 topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -998,7 +998,7 @@ generic_config_updater:
   skip:
     reason: 'generic_config_updater is not a supported feature for T2'
     conditions:
-      - "'t2' in topo_name"
+      - "('t2' == topo_type) and (release in ['201811', '201911', '202012', '202205', '202211', '202305', '202311'])"
 
 generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite:
   skip:

--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -20,7 +20,7 @@ from tests.common.utilities import wait_until
 # SSH_ONLY    CTRLPLANE  SSH              SSH_ONLY       ingress
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 'mx', 't1'),
+    pytest.mark.topology('t0', 'm0', 'mx', 'm1', 't1', 't2', 'lt2', 'ft2'),
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/21016
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to enable GCU test on DT2 topologies, including LT2 and FT2.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
This PR is to enable GCU test on DT2 topologies, including LT2 and FT2.

#### How did you do it?
1. Update `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`
2. Update `tests/generic_config_updater/test_cacl.py` to add `LT2` and `FT2` into supported topologies.
 
#### How did you verify/test it?
The change is verified by running it on a physical testbed.
```
collected 86 items                                                                                                                                                                                                            

generic_config_updater/test_aaa.py::test_tc1_aaa_suite PASSED                                                                                                                                                           [  1%]
generic_config_updater/test_aaa.py::test_tc2_tacacs_global_suite PASSED                                                                                                                                                 [  2%]
generic_config_updater/test_aaa.py::test_tacacs_server_tc3_suite PASSED                                                                                                                                                 [  3%]
......

```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
