### PR TITLE
[202503] Add loganalyzer regex to ignore sai_query_attribute_capability related errors (#20596)

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -31,6 +31,9 @@ r, ".* ERR monit.*Expected containers not running: telemetry.*"
 r, ".* sonic systemd.* kdump-tools.service - Kernel crash dump capture service.*"
 r, ".* ERR swss#orchagent: :- getPort: Failed to get cached bridge port ID.*"
 r, ".* ERR syncd#syncd: .* SAI_API_PORT:brcm_sai_get_port_attribute:\d+ Error -2 processing  port attribute ID: 17.*"
+r, ".* ERR mux#linkmgrd: MuxManager\.cpp:.*Unsupported link failure detection type for : software.*"
+r, ".* ERR syncd#syncd: \[none\] SAI_API_SWITCH:sai_query_attribute_capability:\d* Acl (entry|table) attribute capabilities failed with error -2."
+r, ".* ERR syncd#syncd: \[none\] SAI_API_SWITCH:sai_query_attribute_enum_values_capability:\d* Error in enum \d* capability query for obj type .* rv=-8"
 
 # Errors for config reload on broadcom platform on 202405
 r, ".* ERR syncd\d*#syncd.*_attribute_enum_values_capability.*count.*greater than capability-count 0.*"


### PR DESCRIPTION
Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/20596

What is the motivation for this PR?
Add regex to skip sai_query_attribute_capability related loganalyzer errors

How did you do it?
Added 2 regex to loganalyzer_common_ignore.txt file to ignore

sai_query_attribute_enum_values_capability "rv=-8", ignoring non-functional error in swss PR pipeline till
Fix switch capabilities enum query with metadata validation sonic-swss#3866 is merged sai_query_attribute_capability "error -2", ignoring till it gets fixed from SAI, CS00012422823 is raised
How did you verify/test it?
Tested on Arista-7050X3 running dualtor-aa topology