### PR TITLE
[202503] Ignore availability my_sid error log

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -369,3 +369,6 @@ r, ".* ERR syncd#syncd: .*SAI_API_SWITCH:sai_query_stats_capability:874 stats ca
 r, ".* ERR syncd#syncd: .*SAI_API_QUEUE:_brcm_sai_xgs_pkt_trim_get_mapped_counter:\d+ packet trim stats not enabled"
 r, ".* ERR syncd#syncd: .*SAI_API_QUEUE:_brcm_sai_cosq_stat_get:\d+ Get Trim stats packets failed with error .*"
 r, ".* ERR syncd#syncd: .*SAI_API_QUEUE:_brcm_sai_xgs_queue_pkt_trim_get_clear_ctr:\d+ Get Trim mapped counter failed with error .*"
+
+# Ignore SRV6 error CSP CS00012419486
+r, ".* ERR syncd#syncd: .*SAI_API_SWITCH:sai_object_type_get_availability:\d+ availablity my_sid failed with error .*"


### PR DESCRIPTION
This PR is to ignore log pattern as below
```
ERR syncd#syncd: [none] SAI_API_SWITCH:sai_object_type_get_availability:1002 availablity my_sid failed with error -2.
```
The feature is not required for 202503 branch.
Issue will be tracked with CSP CS00012419486