### PR TITLE
Remove unused parameters in remove_topo

### DIFF
--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -51,14 +51,10 @@
       vm_base: "{{ VM_base }}"
       vm_type: "{{ vm_type }}"
       duts_fp_ports: "{{ duts_fp_ports }}"
-      duts_midplane_ports: "{{ duts_midplane_ports }}"
-      duts_inband_ports: "{{ duts_inband_ports }}"
       duts_mgmt_port: "{{ duts_mgmt_port }}"
       duts_name: "{{ duts_name.split(',') }}"
       max_fp_num: "{{ max_fp_num }}"
       dut_interfaces: "{{ dut_interfaces | default('') }}"
-      is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
-      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
     become: yes
     when: not enable_async
 
@@ -75,13 +71,10 @@
       vm_base: "{{ VM_base }}"
       vm_type: "{{ vm_type }}"
       duts_fp_ports: "{{ duts_fp_ports }}"
-      duts_midplane_ports: "{{ duts_midplane_ports }}"
-      duts_inband_ports: "{{ duts_inband_ports }}"
       duts_mgmt_port: "{{ duts_mgmt_port }}"
       duts_name: "{{ duts_name.split(',') }}"
       max_fp_num: "{{ max_fp_num }}"
       dut_interfaces: "{{ dut_interfaces | default('') }}"
-      is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
     become: yes
     async: 3600
     poll: 0


### PR DESCRIPTION
Remove unused parameters in remove_topo.yml

The parameters added in https://github.com/Azure/sonic-mgmt.msft/pull/743

When previously removed in https://github.com/Azure/sonic-mgmt.msft/pull/622


Without this change we have the next error:
```fatal: [*****]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'duts_midplane_ports' is undefined\n\nThe error appears to be in '...../sonic-mgmt/ansible/roles/vm_set/tasks/remove_topo.yml'```
