### PR TITLE
[202503] Skip GCU tests on UT2 until multi-asic is supported

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -997,8 +997,10 @@ fib/test_fib.py::test_vxlan_hash:
 generic_config_updater:
   skip:
     reason: 'generic_config_updater is not a supported feature for T2'
+    conditions_logical_operator: or
     conditions:
       - "('t2' == topo_type) and (release in ['201811', '201911', '202012', '202205', '202211', '202305', '202311'])"
+      - "'t2_single_node' in topo_name"
 
 generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite:
   skip:


### PR DESCRIPTION
As discussed in https://github.com/sonic-net/sonic-mgmt/issues/21039 GCU tests don't work on multi-asic yet.
But it was enabled in 202503 here https://github.com/Azure/sonic-mgmt.msft/pull/762

Adding skip to avoid running GCU tests on UT2 topologies.

After adding this skip I ran `generic_config_updater/test_cacl.py` and saw all tests skipped
`SKIPPED [9] generic_config_updater/test_cacl.py: generic_config_updater is not a supported feature for T2`