### PR TITLE
adjust test_techsupport.py to support IPv6 

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -10,7 +10,7 @@ from random import randint
 from collections import defaultdict
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
-from tests.common.utilities import wait_until, check_msg_in_syslog
+from tests.common.utilities import is_ipv6_only_topology, wait_until, check_msg_in_syslog
 from log_messages import LOG_EXPECT_ACL_RULE_CREATE_RE, LOG_EXPECT_ACL_RULE_REMOVE_RE, LOG_EXCEPT_MIRROR_SESSION_REMOVE
 from pkg_resources import parse_version
 
@@ -50,6 +50,8 @@ SESSION_INFO = {
     'gre': "0x8949",
     'queue': "0"
 }
+
+IPV6_IPS = {'src_ip': "2001::1", 'dst_ip': "2001::2"}
 
 DPU_PLATFORM_DUMP_FILES = ["sysfs_tree", "sys_version", "dmesg",
                            "dmidecode", "lsmod", "lspci", "top", "bin/platform-dump.sh"]
@@ -221,7 +223,8 @@ def gre_version(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
 
 
 @pytest.fixture(scope='function')
-def mirroring(duthosts, enum_rand_one_per_hwsku_frontend_hostname, neighbor_ip, mirror_setup, gre_version):
+def mirroring(duthosts, enum_rand_one_per_hwsku_frontend_hostname, neighbor_ip,
+              mirror_setup, gre_version, request, tbinfo):
     """
     fixture gathers all configuration fixtures
     :param duthost: DUT host
@@ -236,13 +239,23 @@ def mirroring(duthosts, enum_rand_one_per_hwsku_frontend_hostname, neighbor_ip, 
     }
     logger.info('Extra variables for MIRROR table:\n{}'.format(pprint.pformat(extra_vars)))
     duthost.host.options['variable_manager'].extra_vars.update(extra_vars)
+    cmd = "config mirror_session add {} {} {} {} {} {} {}"
+    if is_ipv6_only_topology(tbinfo):
+        SESSION_INFO['src_ip'] = IPV6_IPS['src_ip']
+        SESSION_INFO['dst_ip'] = IPV6_IPS['dst_ip']
+        cmd = "redis-cli -n 4 hset \"MIRROR_SESSION|{}\" src_ip {} dst_ip {} dscp {} ttl {} type {} queue {}"
 
+    cmd = cmd.format(
+        SESSION_INFO['name'],
+        SESSION_INFO['src_ip'],
+        neighbor_ip,
+        SESSION_INFO['dscp'],
+        SESSION_INFO['ttl'],
+        SESSION_INFO['gre'],
+        SESSION_INFO['queue']
+    )
     duthost.template(src=os.path.join(TEMPLATE_DIR, ACL_RULE_PERSISTENT_TEMPLATE), dest=acl_rule_file)
-    duthost.command('config mirror_session add {} {} {} {} {} {} {}'.format(SESSION_INFO['name'],
-                                                                            SESSION_INFO['src_ip'], neighbor_ip,
-                                                                            SESSION_INFO['dscp'], SESSION_INFO['ttl'],
-                                                                            SESSION_INFO['gre'], SESSION_INFO['queue'])
-                    )
+    duthost.command(cmd)
 
     logger.info('Loading acl mirror rules ...')
     load_rule_cmd = "acl-loader update full {} --session_name={}".format(acl_rule_file, SESSION_INFO['name'])
@@ -536,7 +549,7 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     return cmds_to_check
 
 
-def check_cmds(cmd_group_name, cmd_group_to_check, cmdlist, strbash_in_cmdlist):
+def check_cmds(cmd_group_name, cmd_group_to_check, cmdlist, strbash_in_cmdlist, tbinfo=None):
     """
     Check commands within a group against the command list
 
@@ -548,6 +561,9 @@ def check_cmds(cmd_group_name, cmd_group_to_check, cmdlist, strbash_in_cmdlist):
     for cmd_name in cmd_group_to_check:
         found = False
         cmd_str = cmd_name if isinstance(cmd_name, str) else cmd_name.pattern
+        if tbinfo and is_ipv6_only_topology(tbinfo) and 'ipv4' in cmd_str:
+            logger.info("Skipping IPv4 command {} on IPv6-only topology".format(cmd_str))
+            continue
         logger.info("Checking for {}".format(cmd_str))
 
         for command in cmdlist:
@@ -574,7 +590,7 @@ def check_cmds(cmd_group_name, cmd_group_to_check, cmdlist, strbash_in_cmdlist):
 
 
 def test_techsupport_commands(
-        duthosts, enum_rand_one_per_hwsku_frontend_hostname, commands_to_check, skip_on_dpu):  # noqa F811
+        duthosts, enum_rand_one_per_hwsku_frontend_hostname, commands_to_check, skip_on_dpu, tbinfo):  # noqa F811
     """
     This test checks list of commands that will be run when executing
     'show techsupport' CLI against a standard expected list of commands
@@ -606,7 +622,7 @@ def test_techsupport_commands(
 
     for cmd_group_name, cmd_group_to_check in list(commands_to_check.items()):
         cmd_not_found.update(
-            check_cmds(cmd_group_name, cmd_group_to_check, cmd_list, strbash_in_cmdlist)
+            check_cmds(cmd_group_name, cmd_group_to_check, cmd_list, strbash_in_cmdlist, tbinfo)
         )
 
     error_message = ''


### PR DESCRIPTION
**Description of PR**
adjust test_techsupport.py to support IPv6 only topology

fixed mirroring fixture when ipv6 only topo is used
verified cmd to check is supported with new topo
CP [https://github.com/https://github.com/sonic-net/sonic-mgmt/pull/20680]

**What is the motivation for this PR?**
testing ipv6 only topology

**How did you do it?**
Adjusted the test to handle this topology, fixed mirroring fixture when ipv6 only topo is used
and verified that tested cmd are supported with v6 only topo

**How did you verify/test it?**
internal regression