### PR TITLE
Increase the pre_reboot_timeout for fwutil ONIE/BIOS test for SN4280

### DIFF
--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -102,6 +102,8 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, component, au
             else:
                 # For BIOS/ONIE, most time is spend after the reboot in ONIE
                 pre_reboot_timeout = 120
+                if duthost.facts["platform"] == "x86_64-nvidia_sn4280-r0":
+                    pre_reboot_timeout += 360
                 post_reboot_timeout = timeout
             localhost.wait_for(host=hn, port=22, state='stopped', delay=1, timeout=pre_reboot_timeout)
             # Wait for 30s in case there is ssh flap


### PR DESCRIPTION
Description of PR
Increase the pre_reboot_timeout for fwutil ONIE/BIOS test for SN4280


What is the motivation for this PR?
The switch shutdown time during the auto reboot fwutil tests(ONIE/BIOS) is longer due to
PR:https://github.com/sonic-net/sonic-buildimage/pull/24165. We need increase the timeout.
This sonic-buildimage PR#24165 will be removed in 202511 and master branch later, so the test change is only for 202506.

How did you do it?
Increase the timeout by additional 360s which is the same timeout used in DPU reboot tests for a DPU reboot.

How did you verify/test it?
Run the ONIE/BIOS test cases with Nvidia SN4280, all passed.