### PR TITLE
[202509] Remove conditional skip for test_dup_route

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2887,12 +2887,6 @@ route/test_default_route.py:
     conditions:
       - "'standalone' in topo_name"
 
-route/test_duplicate_route.py:
-  skip:
-    reason: "Temporarily skip this test until testcase regression is fixed"
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/20231#issuecomment-3409128746"
-
 route/test_route_flap.py:
   skip:
     reason: "Test case has issue on the t0-56-povlan and dualtor-64 topo. Does not apply to standalone or t1-isolated-d128 topos."


### PR DESCRIPTION
**What's the motivation?**
Remove the conditional skip to expose the issue. (PR for 202505: https://github.com/sonic-net/sonic-mgmt/pull/21030)

**How did you do?**
Remove the conditional mark.

**How did you verify?**
Verified on M1 testbed.