### PR TITLE
[202506] Compatibility fixes for docker-sonic-mgmt based on Ubuntu 24.04 (#21045)

### DIFF
--- a/ansible/devutil/devices/ansible_hosts.py
+++ b/ansible/devutil/devices/ansible_hosts.py
@@ -63,15 +63,6 @@ except ImportError:
     pass
 
 
-try:
-    # Initialize ansible plugin loader to avoid issues with ansbile-core 2.18
-    from ansible.plugins.loader import init_plugin_loader
-    init_plugin_loader()
-except ImportError:
-    # Nothing need to do for ansible-core 2.13
-    pass
-
-
 class UnsupportedAnsibleModule(Exception):
     pass
 

--- a/ansible/library/snmp_facts.py
+++ b/ansible/library/snmp_facts.py
@@ -25,7 +25,6 @@ from ansible.module_utils.debug_utils import config_module_logging
 
 import asyncio
 import pysnmp
-import ipaddress
 
 from pyasn1.type import univ
 from pysnmp.proto import rfc1902

--- a/ansible/library/snmp_facts.py
+++ b/ansible/library/snmp_facts.py
@@ -25,6 +25,7 @@ from ansible.module_utils.debug_utils import config_module_logging
 
 import asyncio
 import pysnmp
+import ipaddress
 
 from pyasn1.type import univ
 from pysnmp.proto import rfc1902

--- a/tests/common/plugins/ansible_fixtures.py
+++ b/tests/common/plugins/ansible_fixtures.py
@@ -13,6 +13,14 @@ except ImportError:
     # Nothing need to do for ansible-core 2.13
     pass
 
+try:
+    # Initialize ansible plugin loader to avoid issues with ansbile-core 2.18
+    from ansible.plugins.loader import init_plugin_loader
+    init_plugin_loader()
+except ImportError:
+    # Nothing need to do for ansible-core 2.13
+    pass
+
 
 # Here we override ansible_adhoc fixture from pytest-ansible plugin to overcome
 # scope limitation issue; since we want to be able to use ansible_adhoc in module/class scope


### PR DESCRIPTION
This is to cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/21045
What is the motivation for this PR?
This PR is to continue the effort made by @yutongzhang-microsoft in #18339

The current docker-sonic-mgmt image is based on Ubuntu 20.04 which is end of support now. PR sonic-net/sonic-buildimage#24306 upgraded the base image of docker-sonic-mgmt to Ubuntu 24.04. Together, version of most packages are upgraded too. The upgrade introduced lots of compatibility issues. This PR is to fix all the compatibility issues.

All the fixes are backward compatible. The code change woks with both current and new docker-sonic-mgmt.

How did you do it?
Fix the snmp code caused by pysnmp upgrade.
Fix json dump of ansible result caused by pytest-ansible upgrade. How did you verify/test it?
Take advantage of the current sonic-mgmt PR testing. Verified that the code change works with new docker-sonic-mgmt in #20851 Verified that the code change works with the current docker-sonic-mgmt in this PR.