### PR TITLE
Cherry pick sonic-mgmt#20956 to 202503

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -977,9 +977,12 @@ fib/test_fib.py::test_ipinip_hash:
 
 fib/test_fib.py::test_nvgre_hash:
   skip:
-    reason: 'Nvgre hash test is not fully supported on VS and Broadcom platform; Not supported on M*'
+    reason: 'Nvgre hash test is not fully supported on VS and Broadcom platform; Not supported on M*. Skip on t1-isolated-d32/128 topos'
+    conditions_logical_operator: or
     conditions:
-      - "asic_type in ['vs', 'broadcom'] or topo_type in ['m0', 'mx']"
+      - "'-v6-' in topo_name"
+      - "asic_type in ['vs', 'broadcom'] or topo_type in ['m0', 'mx', 'm1']"
+      - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
   xfail:
     reason: 'Nvgre hash test is not fully supported on SPC1 platform due to known limitation'
     conditions:


### PR DESCRIPTION
Cherry picking https://github.com/sonic-net/sonic-mgmt/pull/20956 to Azure/sonic-mgmt.msft 202503 branch

Doing this by mirroring the skip conditions from the above PR to the `fib/test_fib.py::test_nvgre_hash` conditions in 202503 - which is only 1 entry compared to other branches.