### PR TITLE
[ansible]: Set sysctl args and ptf memory for full topology (#21097)

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -175,8 +175,8 @@
       capabilities:
         - net_admin
       privileged: yes
-      memory: 16G
-      memory_swap: 32G
+      memory: 32G
+      memory_swap: 64G
     become: yes
 
   - name: Update ptf password

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -237,6 +237,50 @@
     sysctl_set: yes
   become: yes
 
+- name: Increase neighbor gc_thresh1
+  sysctl:
+    sysctl_set: yes
+    name: "{{ item }}"
+    value: "8192"
+  become: yes
+  with_items:
+    - net.ipv4.neigh.default.gc_thresh1
+    - net.ipv6.neigh.default.gc_thresh1
+
+- name: Increase neighbor gc_thresh2
+  sysctl:
+    sysctl_set: yes
+    name: "{{ item }}"
+    value: "16384"
+  become: yes
+  with_items:
+    - net.ipv4.neigh.default.gc_thresh2
+    - net.ipv6.neigh.default.gc_thresh2
+
+- name: Increase neighbor gc_thresh3
+  sysctl:
+    sysctl_set: yes
+    name: "{{ item }}"
+    value: "32768"
+  become: yes
+  with_items:
+    - net.ipv4.neigh.default.gc_thresh3
+    - net.ipv6.neigh.default.gc_thresh3
+
+- name: increase kernel pid max
+  sysctl:
+    name: "kernel.pid_max"
+    value: "4194304"
+    sysctl_set: yes
+  become: yes
+
+- name: Increase fs limitation
+  sysctl:
+    name: "fs.inotify.max_user_instances"
+    value: "62800"
+    sysctl_set: yes
+  become: yes
+
 - name: Setup external front port
   include_tasks: external_port.yml
   when: external_port is defined

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -124,8 +124,8 @@
       capabilities:
         - net_admin
       privileged: yes
-      memory: 16G
-      memory_swap: 32G
+      memory: 32G
+      memory_swap: 64G
     become: yes
 
   - name: Update ptf password


### PR DESCRIPTION
What is the motivation for this PR?
We want to add a full topo with 448 neighbors; the previous configuration and memory limitation cannot meet its requirement.

How did you do it?
Increase the memory limitation of PTF and increase the max number of inotify user instances.

How did you verify/test it?
Check it locally