### PR TITLE
[202405] Fix devutils and snmp pdu for docker-sonic-mgmt upgrade (#20846)

### DIFF
--- a/ansible/devutil/ssh_utils.py
+++ b/ansible/devutil/ssh_utils.py
@@ -1,5 +1,8 @@
 import paramiko
-from paramiko.py3compat import u
+try:
+    from paramiko.util import u
+except ImportError:
+    from paramiko.py3compat import u
 import termios
 import tty
 import select

--- a/ansible/devutil/task_runner.py
+++ b/ansible/devutil/task_runner.py
@@ -29,6 +29,10 @@ class TaskRunner(object):
             try:
                 result = {'result': future.result()}
             except Exception as e:
+                import traceback
+                print(f"Exception caught in task '{name}': {repr(e)}")
+                print("Traceback:")
+                print(traceback.format_exc())
                 result = {'result': repr(e)}
 
             yield name, result

--- a/tests/common/plugins/ansible_fixtures.py
+++ b/tests/common/plugins/ansible_fixtures.py
@@ -1,6 +1,9 @@
 """ This module provides few pytest-ansible fixtures overridden """
 import pytest
-from pytest_ansible.host_manager import get_host_manager
+try:
+    from pytest_ansible.host_manager.utils import get_host_manager  # pytest_ansible 25.8.0
+except ImportError:
+    from pytest_ansible.host_manager import get_host_manager        # pytest_ansible 4.0
 
 
 # Here we override ansible_adhoc fixture from pytest-ansible plugin to overcome

--- a/tests/common/plugins/pdu_controller/pdu_manager.py
+++ b/tests/common/plugins/pdu_controller/pdu_manager.py
@@ -18,7 +18,13 @@
 """
 
 import logging
-from .snmp_pdu_controllers import get_pdu_controller
+import pysnmp
+if pysnmp.version[0] >= 5:
+    # Use pysnmp 5.x+ compatible implementation (includes 7.x)
+    from .snmp_pdu_controllers import get_pdu_controller
+else:
+    # Use pysnmp 4.x compatible implementation
+    from .snmp_pdu_controllers_legacy import get_pdu_controller
 
 logger = logging.getLogger(__name__)
 

--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers_legacy.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers_legacy.py
@@ -3,57 +3,15 @@ This module contains classes for PDU controllers that supports the SNMP manageme
 
 The classes must implement the PduControllerBase interface defined in controller_base.py.
 """
-import asyncio
 import logging
 import jinja2
 
 from .controller_base import PduControllerBase
 
 from pysnmp.proto import rfc1902
-from pysnmp.hlapi.v3arch.asyncio import (
-    SnmpEngine, CommunityData, UsmUserData, UdpTransportTarget, ContextData,
-    ObjectType, ObjectIdentity, next_cmd, get_cmd, set_cmd, walk_cmd,
-    usmHMACSHAAuthProtocol, usmHMACMD5AuthProtocol, usmAesCfb128Protocol, usmDESPrivProtocol
-)
+from pysnmp.entity.rfc3413.oneliner import cmdgen
 
 logger = logging.getLogger(__name__)
-
-
-def sync_next_cmd(engine, auth, target_host_port, context, *object_types, **kwargs):
-    """Synchronous wrapper for next_cmd with async transport target creation"""
-    async def _async_next_cmd():
-        transport_target = await UdpTransportTarget.create(target_host_port)
-        return await next_cmd(engine, auth, transport_target, context, *object_types, **kwargs)
-    return asyncio.run(_async_next_cmd())
-
-
-def sync_get_cmd(engine, auth, target_host_port, context, *object_types, **kwargs):
-    """Synchronous wrapper for get_cmd with async transport target creation"""
-    async def _async_get_cmd():
-        transport_target = await UdpTransportTarget.create(target_host_port)
-        return await get_cmd(engine, auth, transport_target, context, *object_types, **kwargs)
-    return asyncio.run(_async_get_cmd())
-
-
-def sync_set_cmd(engine, auth, target_host_port, context, *object_types, **kwargs):
-    """Synchronous wrapper for set_cmd with async transport target creation"""
-    async def _async_set_cmd():
-        transport_target = await UdpTransportTarget.create(target_host_port)
-        return await set_cmd(engine, auth, transport_target, context, *object_types, **kwargs)
-    return asyncio.run(_async_set_cmd())
-
-
-def sync_walk_cmd(engine, auth, target_host_port, context, *object_types, **kwargs):
-    """Synchronous wrapper for walk_cmd with async transport target creation"""
-    async def _async_walk_cmd():
-        transport_target = await UdpTransportTarget.create(target_host_port)
-        results = []
-        # Set lexicographicMode=False by default for walk operations
-        kwargs.setdefault('lexicographicMode', False)
-        async for result in walk_cmd(engine, auth, transport_target, context, *object_types, **kwargs):
-            results.append(result)
-        return results
-    return asyncio.run(_async_walk_cmd())
 
 
 class snmpPduController(PduControllerBase):
@@ -94,6 +52,11 @@ class snmpPduController(PduControllerBase):
         APC_RPDU_PORT_NAME_BASE_OID = "1.3.6.1.4.1.318.1.1.12.3.3.1.1.2"
         APC_RPDU_PORT_STATUS_BASE_OID = "1.3.6.1.4.1.318.1.1.12.3.5.1.1.4"
         APC_RPDU_PORT_CONTROL_BASE_OID = "1.3.6.1.4.1.318.1.1.12.3.3.1.1.4"
+        # MIB OID for 'Raritan PDU'
+        RARITAN_PORT_NAME_BASE_OID = "1.3.6.1.4.1.13742.6.3.5.3.1.3"
+        RARITAN_PORT_STATUS_BASE_OID = "1.3.6.1.4.1.13742.6.4.1.2.1.3"
+        RARITAN_PORT_CONTROL_BASE_OID = "1.3.6.1.4.1.13742.6.4.1.2.1.2"
+        RARITAN_PORT_POWER_BASE_OID = "1.3.6.1.4.1.13742.6.5.4.3.1.4"
         self.STATUS_ON = "1"
         self.STATUS_OFF = "0"
         self.CONTROL_ON = "1"
@@ -137,6 +100,16 @@ class snmpPduController(PduControllerBase):
             self.PORT_CONTROL_BASE_OID = APC_RPDU_PORT_CONTROL_BASE_OID
             self.has_lanes = False
             self.max_lanes = 1
+        elif self.pduType == "Raritan":
+            self.PORT_NAME_BASE_OID = RARITAN_PORT_NAME_BASE_OID
+            self.PORT_STATUS_BASE_OID = RARITAN_PORT_STATUS_BASE_OID
+            self.PORT_CONTROL_BASE_OID = RARITAN_PORT_CONTROL_BASE_OID
+            self.PORT_POWER_BASE_OID = RARITAN_PORT_POWER_BASE_OID
+            self.STATUS_ON = "7"
+            self.STATUS_OFF = "8"
+            self.CONTROL_OFF = "0"
+            self.has_lanes = False
+            self.max_lanes = 1
         else:
             pass
 
@@ -144,36 +117,26 @@ class snmpPduController(PduControllerBase):
         self.port_oid_dict[port_oid] = {'label': label}
         self.port_label_dict[label] = {'port_oid': port_oid}
 
-    def _probe_lane(self, lane_id, snmp_auth):
+    def _probe_lane(self, lane_id, cmdGen, snmp_auth):
         pdu_port_base = self.PORT_NAME_BASE_OID
         query_oid = '.' + pdu_port_base
         if self.has_lanes:
             query_oid = query_oid + '.' + str(lane_id)
 
-        results = sync_walk_cmd(
-            SnmpEngine(),
+        errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
             snmp_auth,
-            (self.controller, 161),
-            ContextData(),
-            ObjectType(ObjectIdentity(query_oid)),
-            lexicographicMode=False
+            cmdgen.UdpTransportTarget((self.controller, 161)),
+            cmdgen.MibVariable(query_oid)
         )
-
-        for errorIndication, errorStatus, errorIndex, varBinds in results:
-            if errorIndication:
-                logger.debug("Failed to get ports controlling PSUs of DUT, exception: " + str(errorIndication))
-                continue
-            elif errorStatus:
-                logger.debug('SNMP error: %s at %s' % (
-                    errorStatus.prettyPrint(),
-                    errorIndex and varBinds[int(errorIndex) - 1][0] or '?')
-                )
-                continue
-            else:
+        if errorIndication:
+            logger.debug("Failed to get ports controlling PSUs of DUT, exception: " + str(errorIndication))
+        else:
+            for varBinds in varTable:
                 for oid, val in varBinds:
+                    oid = oid.getOid() if hasattr(oid, 'getOid') else oid
                     current_oid = str(oid)
                     port_oid = current_oid.replace(pdu_port_base, '')
-                    label = str(val).lower()
+                    label = val.prettyPrint().lower()
                     logger.info("Found port {} with label {}".format(port_oid, label))
                     self._build_outlet_maps(port_oid, label)
 
@@ -187,9 +150,13 @@ class snmpPduController(PduControllerBase):
         if not self.pduType:
             logger.error('PDU type is unknown: pdu_ip {}'.format(self.controller))
             return
+        if not hasattr(self, 'ro_snmp_auth'):
+            logger.error('Does not have readonly snmp_auth')
+            return
 
+        cmdGen = cmdgen.CommandGenerator()
         for lane_id in range(1, self.max_lanes + 1):
-            self._probe_lane(lane_id, self.ro_snmp_auth)
+            self._probe_lane(lane_id, cmdGen, self.ro_snmp_auth)
 
     def _render_value(self, value, context):
         if '{{' in value and '}}' in value:
@@ -205,7 +172,7 @@ class snmpPduController(PduControllerBase):
                     logger.error("If pdu_{}_snmp_version is v2c, pdu_snmp_{}community should be provided"
                                  .format(perm, perm))
                     return False
-                snmp_auth = CommunityData(self._render_value(pdu['pdu_snmp_{}community'.format(perm)], context))
+                snmp_auth = cmdgen.CommunityData(self._render_value(pdu['pdu_snmp_{}community'.format(perm)], context))
             elif version == 'v3':
                 if 'pdu_{}_snmp_user'.format(perm) not in pdu:
                     logger.error("If pdu_{}_snmp_version is v3, pdu_{}_snmp_user should be provided".format(perm, perm))
@@ -215,39 +182,38 @@ class snmpPduController(PduControllerBase):
                                  .format(perm, perm))
                     return False
                 if pdu['pdu_{}_snmp_auth_type'.format(perm)] == "sha":
-                    auth_type = usmHMACSHAAuthProtocol
+                    auth_type = cmdgen.usmHMACSHAAuthProtocol
                 elif pdu['pdu_{}_snmp_auth_type'.format(perm)] == "md5":
-                    auth_type = usmHMACMD5AuthProtocol
+                    auth_type = cmdgen.usmHMACMD5AuthProtocol
                 else:
                     logger.error("Unknown auth_type {}, only accepts sha, md5"
                                  .format(pdu['pdu_{}_snmp_auth_type'.format(perm)]))
                     return False
                 if 'pdu_{}_snmp_priv_type'.format(perm) in pdu and 'pdu_{}_snmp_priv_pass'.format(perm) in pdu:
                     if pdu['pdu_{}_snmp_priv_type'.format(perm)] == "aes":
-                        priv_type = usmAesCfb128Protocol
+                        priv_type = cmdgen.usmAesCfb128Protocol
                     elif pdu['pdu_{}_snmp_priv_type'.format(perm)] == "des":
-                        priv_type = usmDESPrivProtocol
+                        priv_type = cmdgen.usmDESPrivProtocol
                     else:
                         logger.error("Unknown priv_type {}, only accepts aes, des"
                                      .format(pdu['pdu_{}_snmp_priv_type'.format(perm)]))
                         return False
-                    snmp_auth = UsmUserData(
-                        self._render_value(pdu['pdu_{}_snmp_user'.format(perm)], context),
-                        authProtocol=auth_type,
-                        authKey=self._render_value(pdu['pdu_{}_snmp_auth_pass'.format(perm)], context),
-                        privProtocol=priv_type,
-                        privKey=self._render_value(pdu['pdu_{}_snmp_priv_pass'.format(perm)], context)
-                    )
+                    snmp_auth = cmdgen.UsmUserData(self._render_value(pdu['pdu_{}_snmp_user'.format(perm)], context),
+                                                   authProtocol=auth_type,
+                                                   authKey=self._render_value(pdu['pdu_{}_snmp_auth_pass'.format(perm)],
+                                                                              context),
+                                                   privProtocol=priv_type,
+                                                   privKey=self._render_value(pdu['pdu_{}_snmp_priv_pass'.format(perm)],
+                                                                              context))
                 else:
-                    snmp_auth = UsmUserData(
-                        pdu['pdu_{}_snmp_user'.format(perm)],
-                        authProtocol=auth_type,
-                        authKey=self._render_value(pdu['pdu_{}_snmp_auth_pass'.format(perm)], context)
-                    )
+                    snmp_auth = cmdgen.UsmUserData(pdu['pdu_{}_snmp_user'.format(perm)],
+                                                   authProtocol=auth_type,
+                                                   authKey=self._render_value(pdu['pdu_{}_snmp_auth_pass'.format(perm)],
+                                                                              context))
 
         else:
             snmp_community = pdu['snmp_{}community'.format(perm)]
-            snmp_auth = CommunityData(self._render_value(snmp_community, context))
+            snmp_auth = cmdgen.CommunityData(self._render_value(snmp_community, context))
         setattr(self, "{}_snmp_auth".format(perm), snmp_auth)
         return True
 
@@ -255,12 +221,8 @@ class snmpPduController(PduControllerBase):
         logger.info("Initializing " + self.__class__.__name__)
         PduControllerBase.__init__(self)
         self.controller = controller
-        self.snmp_rocommunity = pdu['snmp_rocommunity']
-        if 'secret_group_vars' in pdu['snmp_rwcommunity']:
-            context = {'secret_group_vars': pdu['secret_group_vars']}
-            self.snmp_rwcommunity = jinja2.Template(pdu['snmp_rwcommunity']).render(context)
-        else:
-            self.snmp_rwcommunity = pdu['snmp_rwcommunity']
+        self._get_pdu_snmp_creds(pdu, "ro")
+        self._get_pdu_snmp_creds(pdu, "rw")
         self.pduType = 'Sentry4' if hwsku == 'Sentry' and psu_peer_type == 'Pdu' else hwsku
         self.port_oid_dict = {}
         self.port_label_dict = {}
@@ -284,15 +246,17 @@ class snmpPduController(PduControllerBase):
         if not self.pduType:
             logger.error('Unable to turn on: PDU type is unknown: pdu_ip {}'.format(self.controller))
             return False
+        if not hasattr(self, 'rw_snmp_auth'):
+            logger.error("Does not have readwrite snmp_auth")
+            return False
 
-        port_oid = self.PORT_CONTROL_BASE_OID + outlet
-        errorIndication, errorStatus, errorIndex, varBinds = sync_set_cmd(
-            SnmpEngine(),
-            self.rw_snmp_auth,
-            (self.controller, 161),
-            ContextData(),
-            ObjectType(ObjectIdentity(port_oid), rfc1902.Integer(self.CONTROL_ON))
-        )
+        port_oid = '.' + self.PORT_CONTROL_BASE_OID + outlet
+        errorIndication, errorStatus, _, _ = \
+            cmdgen.CommandGenerator().setCmd(
+                self.rw_snmp_auth,
+                cmdgen.UdpTransportTarget((self.controller, 161)),
+                (port_oid, rfc1902.Integer(self.CONTROL_ON))
+            )
         if errorIndication or errorStatus != 0:
             logger.debug("Failed to turn on outlet %s, exception: %s" % (str(outlet), str(errorStatus)))
             return False
@@ -315,23 +279,22 @@ class snmpPduController(PduControllerBase):
             logger.error('Unable to turn off: PDU type is unknown: pdu_ip {}'.format(self.controller))
             return False
         if not hasattr(self, 'rw_snmp_auth'):
-            logger.error("Does not have readwrite snmp_auth")
+            logger.error("Does not have readwritew snmp_auth")
             return False
 
-        port_oid = self.PORT_CONTROL_BASE_OID + outlet
-        errorIndication, errorStatus, errorIndex, varBinds = sync_set_cmd(
-            SnmpEngine(),
-            self.rw_snmp_auth,
-            (self.controller, 161),
-            ContextData(),
-            ObjectType(ObjectIdentity(port_oid), rfc1902.Integer(self.CONTROL_OFF))
-        )
+        port_oid = '.' + self.PORT_CONTROL_BASE_OID + outlet
+        errorIndication, errorStatus, _, _ = \
+            cmdgen.CommandGenerator().setCmd(
+                self.rw_snmp_auth,
+                cmdgen.UdpTransportTarget((self.controller, 161)),
+                (port_oid, rfc1902.Integer(self.CONTROL_OFF))
+            )
         if errorIndication or errorStatus != 0:
             logger.debug("Failed to turn off outlet %s, exception: %s" % (str(outlet), str(errorStatus)))
             return False
         return True
 
-    def _get_one_outlet_power(self, snmp_auth, port_id, status):
+    def _get_one_outlet_power(self, cmdGen, snmp_auth, port_id, status):
         if not self.PORT_POWER_BASE_OID:
             return
 
@@ -340,50 +303,47 @@ class snmpPduController(PduControllerBase):
         # a = pduID (almost always "1" unless you are linking the PDUs)
         # b = outletId (the number of the outlet on the PDU)
         # c = sensorID (1=amps, 4=volts, 5=watts)
-        query_id = self.PORT_POWER_BASE_OID + port_id
+        query_id = '.' + self.PORT_POWER_BASE_OID + port_id
         if self.pduType == "Raritan":
             query_id = query_id + ".5"  # 5 = watts for Raritan PDU
-
-        errorIndication, errorStatus, errorIndex, varBinds = sync_get_cmd(
-            SnmpEngine(),
+        errorIndication, errorStatus, errorIndex, varBinds = cmdGen.getCmd(
             snmp_auth,
-            (self.controller, 161),
-            ContextData(),
-            ObjectType(ObjectIdentity(query_id))
+            cmdgen.UdpTransportTarget((self.controller, 161)),
+            cmdgen.MibVariable(query_id)
         )
         if errorIndication:
             logger.debug("Failed to get outlet power level of DUT outlet, exception: " + str(errorIndication))
-            return
 
         for oid, val in varBinds:
+            oid = oid.getOid() if hasattr(oid, 'getOid') else oid
             current_oid = str(oid)
             current_val = str(val)
             port_oid = current_oid.replace(self.PORT_POWER_BASE_OID, '')
+            if self.pduType == "Raritan":
+                port_oid = port_oid.rsplit('.', 1)[0]  # Remove the ".5" suffix
             if port_oid == port_id:
                 if current_val != "":
                     status['output_watts'] = current_val
                 return
 
-    def _get_one_outlet_status(self, snmp_auth, port_id):
-        query_id = self.PORT_STATUS_BASE_OID + port_id
-        errorIndication, errorStatus, errorIndex, varBinds = sync_get_cmd(
-            SnmpEngine(),
+    def _get_one_outlet_status(self, cmdGen, snmp_auth, port_id):
+        query_id = '.' + self.PORT_STATUS_BASE_OID + port_id
+        errorIndication, errorStatus, errorIndex, varBinds = cmdGen.getCmd(
             snmp_auth,
-            (self.controller, 161),
-            ContextData(),
-            ObjectType(ObjectIdentity(query_id))
+            cmdgen.UdpTransportTarget((self.controller, 161)),
+            cmdgen.MibVariable(query_id)
         )
         if errorIndication:
-            logger.debug("Failed to get outlet status of PDU, exception: " + str(errorIndication))
-            return None
+            logger.debug("Failed to outlet status of PDU, exception: " + str(errorIndication))
 
         for oid, val in varBinds:
+            oid = oid.getOid() if hasattr(oid, 'getOid') else oid
             current_oid = str(oid)
             current_val = str(val)
             port_oid = current_oid.replace(self.PORT_STATUS_BASE_OID, '')
             if port_oid == port_id:
                 status = {"outlet_id": port_oid, "outlet_on": True if current_val == self.STATUS_ON else False}
-                self._get_one_outlet_power(snmp_auth, port_id, status)
+                self._get_one_outlet_power(cmdGen, snmp_auth, port_id, status)
                 return status
 
         return None
@@ -405,8 +365,12 @@ class snmpPduController(PduControllerBase):
                  The outlet in returned result is integer starts from 0.
         """
         results = []
+
         if not self.pduType:
             logger.error('Unable to retrieve status: PDU type is unknown: pdu_ip {}'.format(self.controller))
+            return results
+        if not hasattr(self, 'ro_snmp_auth'):
+            logger.error('Does not have readonly snmp_auth')
             return results
 
         if not outlet and not hostname:
@@ -423,8 +387,9 @@ class snmpPduController(PduControllerBase):
             if not ports:
                 logger.error("{} device is not attached to any outlet of PDU {}".format(hn, self.controller))
 
+        cmdGen = cmdgen.CommandGenerator()
         for port in ports:
-            status = self._get_one_outlet_status(self.ro_snmp_auth, port)
+            status = self._get_one_outlet_status(cmdGen, self.ro_snmp_auth, port)
             if status:
                 results.append(status)
 


### PR DESCRIPTION
Cherry-pick #20846 to 202405 branch.

What is the motivation for this PR?
The docker-sonic-mgmt will be upgraded to Ubuntu 24.04 based. The python packages will be upgraded together. Due to breaking changes in the packages, the devutils and snmp pdu controller need to be fixed to address the compability issues.

How did you do it?
Major changes in this PR:

Updated snmp_pdu_controllers.py to use pysnmp 7.1.21 APIs. Moved the current snmp_pdu_controllers.py based on pysnmp 4.x API to snmp_pdu_controllers_legacy.py. Updated the pdu_manager.py to import correct snmp pdu controller based on pysnmp versions. Other changes:

Improve the import in ssh_utils.py to make it compatible with old and new paramiko package. Add code to show traceback in task_runner.py to help troubleshooting. Improve the import in ansible_fixture.py to be compatible with old and new pytest_ansible. All the changes are compatible with old and new docker-sonic-mgmt.

How did you verify/test it?
Tested devutils using old and new docker-sonic-mgmt Tested pytest collect using old and new docker-sonic-mgmt