### PR TITLE
[202509] Fix filter not found issue for ansible >= 2.14 (#20771)

### DIFF
--- a/ansible/roles/eos/templates/dpu-tor.j2
+++ b/ansible/roles/eos/templates/dpu-tor.j2
@@ -101,14 +101,14 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/m0-mx.j2
+++ b/ansible/roles/eos/templates/m0-mx.j2
@@ -94,7 +94,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
@@ -104,7 +104,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t0-8-lag-leaf.j2
+++ b/ansible/roles/eos/templates/t0-8-lag-leaf.j2
@@ -101,14 +101,14 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t0-backend-leaf.j2
+++ b/ansible/roles/eos/templates/t0-backend-leaf.j2
@@ -128,7 +128,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
@@ -138,7 +138,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t0-isolated-d2u254s1-tor.j2
+++ b/ansible/roles/eos/templates/t0-isolated-d2u254s1-tor.j2
@@ -94,18 +94,18 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
- router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t0-leaf-lag-2.j2
+++ b/ansible/roles/eos/templates/t0-leaf-lag-2.j2
@@ -101,14 +101,14 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -101,7 +101,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
@@ -112,7 +112,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} route-reflector-client
  neighbor {{ remote_ip }} additional-paths send any
 {% endif %}
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t0-mclag-leaf.j2
+++ b/ansible/roles/eos/templates/t0-mclag-leaf.j2
@@ -101,14 +101,14 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t0-v6-leaf.j2
+++ b/ansible/roles/eos/templates/t0-v6-leaf.j2
@@ -101,14 +101,14 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['bgp']['router-id'] |  ipaddr('address') }}
+ router-id {{ host['bgp']['router-id'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t1-28-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-28-lag-spine.j2
@@ -101,14 +101,14 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t1-28-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-28-lag-tor.j2
@@ -102,7 +102,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
@@ -112,7 +112,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t1-48-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-48-lag-spine.j2
@@ -101,13 +101,13 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t1-48-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-48-lag-tor.j2
@@ -102,7 +102,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
@@ -111,7 +111,7 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t1-56-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-56-lag-tor.j2
@@ -102,7 +102,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
@@ -112,7 +112,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t1-64-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-64-lag-tor.j2
@@ -102,7 +102,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
@@ -112,7 +112,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t1-8-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-spine.j2
@@ -99,14 +99,14 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t1-8-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-8-lag-tor.j2
@@ -100,7 +100,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
@@ -110,7 +110,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t1-backend-tor.j2
+++ b/ansible/roles/eos/templates/t1-backend-tor.j2
@@ -128,7 +128,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
@@ -138,7 +138,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -101,14 +101,14 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t1-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-lag-tor.j2
@@ -94,18 +94,18 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
- router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t1-smartswitch-ha-spine.j2
+++ b/ansible/roles/eos/templates/t1-smartswitch-ha-spine.j2
@@ -101,14 +101,14 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t1-smartswitch-ha-tor.j2
+++ b/ansible/roles/eos/templates/t1-smartswitch-ha-tor.j2
@@ -101,7 +101,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
@@ -111,7 +111,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t2-core.j2
+++ b/ansible/roles/eos/templates/t2-core.j2
@@ -120,7 +120,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
@@ -128,7 +128,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} maximum-routes 0
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t2-leaf.j2
+++ b/ansible/roles/eos/templates/t2-leaf.j2
@@ -107,7 +107,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
@@ -116,7 +116,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} allowas-in
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t2-vs-core.j2
+++ b/ansible/roles/eos/templates/t2-vs-core.j2
@@ -107,7 +107,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
@@ -115,7 +115,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} maximum-routes 0
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/eos/templates/t2-vs-leaf.j2
+++ b/ansible/roles/eos/templates/t2-vs-leaf.j2
@@ -107,7 +107,7 @@ interface {{ bp_ifname }}
  no shutdown
 !
 router bgp {{ host['bgp']['asn'] }}
- router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
 {% for asn, remote_ips in host['bgp']['peers'].items() %}
 {% for remote_ip in remote_ips %}
@@ -115,7 +115,7 @@ router bgp {{ host['bgp']['asn'] }}
  neighbor {{ remote_ip }} maximum-routes 0
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-{% if remote_ip | ipv6 %}
+{% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit

--- a/ansible/roles/sonicv2/templates/quagga/bgpd.conf.j2
+++ b/ansible/roles/sonicv2/templates/quagga/bgpd.conf.j2
@@ -27,7 +27,7 @@ router bgp {{ minigraph_bgp_asn }}
 {% for lo in minigraph_lo_interfaces %}
 {% if lo['addr'] | ipv4 %}
   network {{ lo['addr'] }}/32
-{% elif lo['addr'] | ipv6 %}
+{% elif lo['addr'] | ansible.utils.ipv6 %}
   address-family ipv6
     network {{ lo['addr'] }}/128
   exit-address-family
@@ -44,7 +44,7 @@ router bgp {{ minigraph_bgp_asn }}
 {% if bgp_session['asn'] != 0 %}
   neighbor {{ bgp_session['addr'] }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ bgp_session['addr'] }} description {{ bgp_session['name'] }}
-{% if bgp_session['addr'] | ipv6 %}
+{% if bgp_session['addr'] | ansible.utils.ipv6 %}
   address-family ipv6
     neighbor {{ bgp_session['addr'] }} activate
     maximum-paths 64

--- a/ansible/roles/sonicv2/templates/quagga/zebra.conf.j2
+++ b/ansible/roles/sonicv2/templates/quagga/zebra.conf.j2
@@ -34,7 +34,7 @@ route-map RM_SET_SRC permit 10
 {% set lo_ipv6_addrs = [] %}
 {% if minigraph_lo_interfaces is defined %}
 {%   for interface in minigraph_lo_interfaces %}
-{%     if interface['addr'] is defined and interface['addr']|ipv6 %}
+{%     if interface['addr'] is defined and interface['addr']| ansible.utils.ipv6 %}
 {%       if lo_ipv6_addrs.append(interface['addr']) %}
 {%       endif %}
 {%     endif %}

--- a/ansible/roles/test/tasks/everflow_testbed/get_session_info.yml
+++ b/ansible/roles/test/tasks/everflow_testbed/get_session_info.yml
@@ -26,5 +26,5 @@
 
 - name: Initialize session prefixes.
   set_fact:
-    session_prefix_1: "{{ addr_1|ipaddr('network') }}/{{ addr_1|ipaddr('prefix') }}"
-    session_prefix_2: "{{ addr_2|ipaddr('network') }}/{{ addr_2|ipaddr('prefix') }}"
+    session_prefix_1: "{{ addr_1|ansible.utils.ipaddr('network') }}/{{ addr_1|ansible.utils.ipaddr('prefix') }}"
+    session_prefix_2: "{{ addr_2|ansible.utils.ipaddr('network') }}/{{ addr_2|ansible.utils.ipaddr('prefix') }}"

--- a/ansible/roles/test/templates/bgp_no_export.j2
+++ b/ansible/roles/test/templates/bgp_no_export.j2
@@ -57,7 +57,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% for (name, prefix) in VLAN_INTERFACE %}
 {% if prefix | ipv4 %}
   network {{ prefix }}
-{% elif prefix | ipv6 %}
+{% elif prefix | ansible.utils.ipv6 %}
   address-family ipv6
    network {{ prefix }}
   exit-address-family
@@ -88,7 +88,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   exit-address-family
 {% endif %}
 {% endif %}
-{% if neighbor_addr | ipv6 %}
+{% if neighbor_addr | ansible.utils.ipv6 %}
   address-family ipv6
     neighbor {{ neighbor_addr }} activate
     maximum-paths 64

--- a/ansible/roles/test/templates/bgp_plain.j2
+++ b/ansible/roles/test/templates/bgp_plain.j2
@@ -52,7 +52,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% for (name, prefix) in VLAN_INTERFACE %}
 {% if prefix | ipv4 %}
   network {{ prefix }}
-{% elif prefix | ipv6 %}
+{% elif prefix | ansible.utils.ipv6 %}
   address-family ipv6
    network {{ prefix }}
   exit-address-family
@@ -76,7 +76,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
     maximum-paths 64
   exit-address-family
 {% endif %}
-{% if neighbor_addr | ipv6 %}
+{% if neighbor_addr | ansible.utils.ipv6 %}
   address-family ipv6
 {% if DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
     neighbor {{ neighbor_addr }} allowas-in 1

--- a/ansible/roles/vm_set/tasks/start_sid.yml
+++ b/ansible/roles/vm_set/tasks/start_sid.yml
@@ -36,8 +36,8 @@
       "MAC": "{{ '52:54:00' | random_mac }}",
       "CHIPTYPE": "{{ chip }}",
       "HOSTNAME": "{{ dut_name }}-0",
-      "IP": "{{ mgmt_ip_address | ipaddr('address') }}",
-      "MASK": "{{ mgmt_ip_address | ipaddr('netmask') }}",
+      "IP": "{{ mgmt_ip_address | ansible.utils.ipaddr('address') }}",
+      "MASK": "{{ mgmt_ip_address | ansible.utils.ipaddr('netmask') }}",
       "GATEWAY": "{{ vm_mgmt_gw }}",
       "SRVC_PORT": "12000"
     }

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -170,10 +170,10 @@
           <VlanID>{{ vlan_param['id'] }}</VlanID>
           <Tag>{{ vlan_param['tag'] }}</Tag>
 {% if 'prefix' in vlan_param %}
-          <Subnets>{{ vlan_param['prefix'] | ipaddr('network') }}/{{ vlan_param['prefix'] | ipaddr('prefix') }}</Subnets>
+          <Subnets>{{ vlan_param['prefix'] | ansible.utils.ipaddr('network') }}/{{ vlan_param['prefix'] | ansible.utils.ipaddr('prefix') }}</Subnets>
 {% endif %}
 {% if 'secondary_subnet' in vlan_param %}
-          <SecondarySubnets>{{ vlan_param['secondary_subnet'] | ipaddr('network') }}/{{ vlan_param['secondary_subnet'] | ipaddr('prefix') }}</SecondarySubnets>
+          <SecondarySubnets>{{ vlan_param['secondary_subnet'] | ansible.utils.ipaddr('network') }}/{{ vlan_param['secondary_subnet'] | ansible.utils.ipaddr('prefix') }}</SecondarySubnets>
 {% endif %}
 {% if 'mac' in vlan_param %}
           <MacAddress>{{ vlan_param['mac'] }}</MacAddress>


### PR DESCRIPTION
Cherry pick #20771 to 202509 branch.

What is the motivation for this PR?
Ansible 2.14+ enforces FQCN (with a few exceptions for “very core” filters like default, to_json, dictsort that are still built into Jinja2/Ansible). Directly using filters like ipaddr, ipv6 will fail with filter not found issue.

How did you do it?
This change fixed the issue by adding ansible.utils. to the ipaddr and ipv6 filters used in the templates.

How did you verify/test it?
Tested using ansible 2.13 and ansible 2.19.