### PR TITLE
Cherry-pick fix for test_reload_configuration_checks and relocate platform test skip condition.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2904,12 +2904,10 @@ lldp/test_lldp.py::test_lldp_neighbor:
 
 lldp/test_lldp.py::test_lldp_neighbor_post_orchagent_reboot:
   xfail:
-    reason: "Xfail the test due to github issue: https://github.com/sonic-net/sonic-mgmt/issues/19658"
+    reason: "Xfail the test due to github issue: https://github.com/sonic-net/sonic-mgmt/issues/19658 / Test case has issue on the t0-isolated-d256u256s2 topo."
+    conditions_logical_operator: or
     conditions:
       - "topo_type in ['m0', 'mx', 'm1']"
-  xfail:
-    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
-    conditions:
       - "'t0-isolated-d256u256s2' in topo_name"
 
 lldp/test_lldp_syncd.py::test_lldp_entry_table_after_lldp_restart:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3187,31 +3187,6 @@ pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[IPv6-async_storm:
         - "release in ['202412']"
 
 #######################################
-#####     platform_tests          #####
-#######################################
-platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info:
-  xfail:
-    reason: "Testcase ignored on nvidia sn4700 and sn4280 due to github issue: https://github.com/sonic-net/sonic-buildimage/issues/23426"
-    conditions:
-    - "https://github.com/sonic-net/sonic-buildimage/issues/23426 and ('sn4700' in platform or 'sn4280' in platform)"
-
-platform_tests/test_reload_config.py::test_reload_configuration:
-  xfail:
-    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
-    conditions:
-      - "'t0-isolated-d256u256s2' in topo_name"
-
-platform_tests/test_reload_config.py::test_reload_configuration_checks:
-  skip:
-    reason: "Skip test_reload_configuration_checks on Cisco platform due to unstable results"
-    conditions:
-      - "asic_type in ['cisco-8000']"
-  xfail:
-    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
-    conditions:
-      - "'t0-isolated-d256u256s2' in topo_name"
-
-#######################################
 #####     process_monitoring      #####
 #######################################
 process_monitoring/test_critical_process_monitoring.py::test_orchagent_heartbeat:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -673,9 +673,11 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_dom_real_value:
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info:
   xfail:
-    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
+    reason: "Test case has issue on the t0-isolated-d256u256s2 topo. / Testcase ignored on nvidia sn4700 and sn4280 due to github issue: https://github.com/sonic-net/sonic-buildimage/issues/23426"
+    conditions_logical_operator: or
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name"
+      - "https://github.com/sonic-net/sonic-buildimage/issues/23426 and ('sn4700' in platform or 'sn4280' in platform)"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_threshold_info:
   skip:
@@ -1370,6 +1372,10 @@ platform_tests/test_reload_config.py::test_reload_configuration:
     conditions:
       - "asic_type in ['barefoot'] and hwsku in ['newport']"
       - "https://github.com/sonic-net/sonic-buildimage/issues/19879 and asic_type in ['vs']"
+  xfail:
+    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
+    conditions:
+      - "'t0-isolated-d256u256s2' in topo_name"
 
 platform_tests/test_reload_config.py::test_reload_configuration_checks:
   skip:
@@ -1379,6 +1385,11 @@ platform_tests/test_reload_config.py::test_reload_configuration_checks:
       - "asic_type in ['barefoot'] and hwsku in ['newport']"
       - "https://github.com/sonic-net/sonic-buildimage/issues/19879 and asic_type in ['vs']"
       - "asic_type in ['cisco-8000'] and release in ['202205', '202211', '202305', '202405']"
+      - "asic_type in ['cisco-8000']"
+  xfail:
+    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
+    conditions:
+      - "'t0-isolated-d256u256s2' in topo_name"
 
 #######################################
 ######  test_secure_upgrade.py  #######

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1384,7 +1384,6 @@ platform_tests/test_reload_config.py::test_reload_configuration_checks:
     conditions:
       - "asic_type in ['barefoot'] and hwsku in ['newport']"
       - "https://github.com/sonic-net/sonic-buildimage/issues/19879 and asic_type in ['vs']"
-      - "asic_type in ['cisco-8000'] and release in ['202205', '202211', '202305', '202405']"
       - "asic_type in ['cisco-8000']"
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."


### PR DESCRIPTION
The PR test is failing due to the test case test_reload_configuration_checks. The corresponding fix is available in the master branch (PR [#21193](https://github.com/sonic-net/sonic-mgmt/pull/21193)) and needs to be cherry-picked into the 202412 branch.
In addition, this PR moves the skip condition for the platform test to its respective YAML file.