### PR TITLE
Added new topologies to testcases.yml file

### DIFF
--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -49,7 +49,7 @@ testcases:
     continuous_reboot:
       filename: continuous_reboot.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-56-o8v48, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t1-28-lag]
+      topologies: [t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-56-o8v48, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t1-28-lag, t0-isolated-d16u16s1, t1-isolated-d28u1, t0-isolated-d32u32s2, t0-isolated-v6-d32u32s2, t1-isolated-d56u2, t1-isolated-v6-d56u1-lag, t0-isolated-d256u256s2, t1-isolated-d448u15-lag]
 
     copp:
       filename: copp.yml
@@ -259,7 +259,7 @@ testcases:
 
     reboot:
       filename: reboot.yml
-      topologies: [dualtor, dualtor-64-breakout, dualtor-aa-64-breakout, t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-28-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [dualtor, dualtor-64-breakout, dualtor-aa-64-breakout, t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-28-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64, t0-isolated-d16u16s1, t1-isolated-d28u1, t0-isolated-d32u32s2, t0-isolated-v6-d32u32s2, t1-isolated-d56u2, t1-isolated-v6-d56u1-lag, t0-isolated-d256u256s2, t1-isolated-d448u15-lag]
 
     repeat_harness:
       filename: repeat_harness.yml


### PR DESCRIPTION
Summary:
Added isolated topologies to support continuous_reboot and reboot test cases.
Manual Cherry pick of https://github.com/sonic-net/sonic-mgmt/pull/19964

Type of change
 Bug fix
 Testbed and Framework(new/improvement)
 New Test case
 Skipped for non-supported platforms
 Test case improvement
Back port request
 202205
 202305
 202311
 202405
 202411
 202505
Approach
What is the motivation for this PR?
Add the new topologies to the file, and update the test_facts class

How did you do it?
Added the new isolated topologies to the list of reboot and continuous_reboot

How did you verify/test it?
Any platform specific information?
Supported testbed topology if it's a new test case?
Documentation