### PR TITLE
Add explicit config for creating acl counter

### DIFF
--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -1419,7 +1419,8 @@ def configure_trimming_acl(duthost, test_ports):
         "ACL_TABLE_TYPE": {
             ACL_TABLE_TYPE_NAME: {
                 "ACTIONS": [
-                    "DISABLE_TRIM_ACTION"
+                    "DISABLE_TRIM_ACTION",
+                    "COUNTER"
                 ],
                 "BIND_POINTS": [
                     "PORT"


### PR DESCRIPTION
Orchagent will create an acl counter by default when creating an acl rule. In the packet trimming `test_acl_action_with_trimming` testcase it is applying some json configuration to create an acl table with the disable trim action. Because there is no counter action in this configuration the Broadcom SAI (and possibly other SAI implementations) fails to create the acl counter resulting in no acl rules being applied to the newly created acl table. This fix explicitly adds the counter as an acl table action, which allows the SAI to create both the counter and the acl rules which we want to test.