### PR TITLE
[202503] Skip fast/warm reboot cases for t0-f2-d40u8 and t1-f2-d10u8

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -76,6 +76,7 @@ arp/test_wr_arp.py:
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/16502 and 'dualtor' in topo_name"
       - "'standalone' in topo_name"
+      - "'f2' in topo_name"
       - "release in ['202412']"
 
 #######################################
@@ -195,6 +196,7 @@ bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot:
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56'] and https://github.com/sonic-net/sonic-mgmt/issues/9201"
       - "'backend' in topo_name or 'mgmttor' in topo_name or 'isolated' in topo_name"
+      - "'f2' in topo_name"
 
 bgp/test_bgp_speaker.py:
   skip:
@@ -1736,6 +1738,7 @@ pfcwd/test_pfcwd_warm_reboot.py:
      conditions:
         - "'t2' in topo_name"
         - "'standalone' in topo_name"
+        - "'f2' in topo_name"
         - "topo_type in ['m0', 'mx']"
         - "release in ['202412']"
         - "asic_type in ['cisco-8000']"
@@ -1751,6 +1754,7 @@ pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm:
         - "topo_type in ['m0', 'mx']"
         - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16233"
         - "release in ['202412']"
+        - "'f2' in topo_name"
 
 #######################################
 #####     process_monitoring      #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1062,6 +1062,7 @@ platform_tests/test_advanced_reboot.py:
       - "platform in ['x86_64-arista_7050_qx32s']"
       - "'dualtor' in topo_name and release in ['202012']"
       - "asic_type in ['vs']"
+      - "'f2' in topo_name"
       - "release in ['202412']"
 
 platform_tests/test_advanced_reboot.py::test_fast_reboot_from_other_vendor:
@@ -1073,6 +1074,7 @@ platform_tests/test_advanced_reboot.py::test_fast_reboot_from_other_vendor:
       - "platform in ['x86_64-arista_7050_qx32s']"
       - "'dualtor' in topo_name and release in ['202012']"
       - "release in ['202412']"
+      - "'f2' in topo_name"
 
 platform_tests/test_advanced_reboot.py::test_warm_reboot:
   skip:
@@ -1081,6 +1083,7 @@ platform_tests/test_advanced_reboot.py::test_warm_reboot:
     conditions:
       - "asic_type in ['vs'] and 't0' not in topo_name"
       - "release in ['202412']"
+      - "'f2' in topo_name"
 
 platform_tests/test_advanced_reboot.py::test_warm_reboot_mac_jump:
   skip:
@@ -1089,6 +1092,7 @@ platform_tests/test_advanced_reboot.py::test_warm_reboot_mac_jump:
     conditions:
       - "asic_type in ['vs']"
       - "release in ['202412']"
+      - "'f2' in topo_name"
 
 platform_tests/test_advanced_reboot.py::test_warm_reboot_sad:
   skip:
@@ -1097,12 +1101,7 @@ platform_tests/test_advanced_reboot.py::test_warm_reboot_sad:
     conditions:
       - "asic_type in ['vs']"
       - "release in ['202412']"
-
-platform_tests/test_advanced_reboot.py::test_warm_reboot:
-  skip:
-    reason: "Skip in PR testing as taking too much time."
-    conditions:
-      - "asic_type in ['vs'] and 't0' not in topo_name"
+      - "'f2' in topo_name"
 
 #######################################
 #####   test_chassis_reboot.py  #####
@@ -1252,6 +1251,7 @@ platform_tests/test_reboot.py::test_fast_reboot:
       - "topo_type in ['m0', 'mx', 't1', 't2']"
       - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-buildimage/issues/16502"
       - "release in ['202412']"
+      - "'f2' in topo_name"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:
@@ -1276,6 +1276,7 @@ platform_tests/test_reboot.py::test_warm_reboot:
     conditions:
       - "topo_type in ['m0', 'mx', 't1', 't2']"
       - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-buildimage/issues/16502"
+      - "'f2' in topo_name"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:


### PR DESCRIPTION
Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/21469 into 202503

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip fast/warm reboot for t0-f2-d40u8 and t1-f2-d10u8 as it's not required.
Also remove duplicated `platform_tests/test_advanced_reboot.py::test_warm_reboot` entry in mark_condition_platform

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [] 202503

### Approach
#### What is the motivation for this PR?
Skip fast/warm reboot for t0-f2-d40u8 and t1-f2-d10u8 as it's not required.

#### How did you do it?
skip in mark conditions.

#### How did you verify/test it?
on local testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
