### PR TITLE
[Everflow] Add Support for Egress V6 Testing 

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -30,10 +30,12 @@ EVERFLOW_RULE_CREATE_TEMPLATE = "acl-erspan.json.j2"
 FILE_DIR = "everflow/files"
 EVERFLOW_V4_RULES = "ipv4_test_rules.yaml"
 EVERFLOW_DSCP_RULES = "dscp_test_rules.yaml"
+IP_TYPE_RULE_V6 = "test_rules_ip_type_v6.json"
 
 DUT_RUN_DIR = "/tmp/everflow"
 EVERFLOW_RULE_CREATE_FILE = "acl-erspan.json"
 EVERFLOW_RULE_DELETE_FILE = "acl-remove.json"
+EVERFLOW_NOT_OPENCONFIG_CREATE_FILE = 'acl_config.json'
 
 STABILITY_BUFFER = 0.05     # 50msec
 
@@ -761,6 +763,60 @@ class BaseEverflowTest(object):
         """
         pass
 
+    def check_rule_counters(self, duthost):
+        """
+        Check if Acl rule counters initialized
+        Args:
+            duthost: DUT host object
+        Returns:
+            Bool value
+        """
+        res = duthost.shell("aclshow -a")['stdout_lines']
+        if len(res) <= 2 or [line for line in res if 'N/A' in line]:
+            return False
+        else:
+            return True
+
+    def apply_non_openconfig_acl_rle(self, duthost, extra_vars, rule_file):
+        """
+        Not all ACL match groups are valid in openconfig-acl format used in rest of these
+        tests. Instead we must load these uing SONiC-style acl jsons.
+        Args:
+            duthost: Device under test
+            extra_vars: Variables needed to fill template in `rule_file`
+            rule_file: File with rule template to stage on `duthost`
+        """
+        dest_path = os.path.join(DUT_RUN_DIR, EVERFLOW_NOT_OPENCONFIG_CREATE_FILE)
+        duthost.host.options['variable_manager'].extra_vars.update(extra_vars)
+        duthost.file(path=dest_path, state='absent')
+        duthost.template(src=os.path.join(FILE_DIR, rule_file), dest=dest_path)
+        duthost.shell("config load -y {}".format(dest_path))
+
+        if duthost.facts['asic_type'] != 'vs':
+            pytest_assert(wait_until(60, 2, 0, self.check_rule_counters, duthost), "Acl rule counters are not ready")
+
+    def apply_ip_type_rule(self, duthost, ip_version):
+        """
+        Applies rule to match SAI-defined IP_TYPE. This has to be done separately as the openconfig-acl
+        definition does not cover ip_type. Requires also matching on another attribute as otherwise
+        unwanted traffic is also mirrored.
+        Args:
+            duthost: Device under test
+            table_name: Which Everflow table to add this rule to
+            ip_version: 4 for ipv4 and 6 for ipv6
+        """
+        if ip_version == 4:
+            pytest.skip("IP_TYPE Matching test has not been written for IPv4")
+        else:
+            rule_file = IP_TYPE_RULE_V6
+        table_name = "EVERFLOWV6" if self.acl_stage() == "ingress" else "EVERFLOW_EGRESSV6"
+        action = "MIRROR_INGRESS_ACTION" if self.acl_stage() == "ingress" else "MIRROR_EGRESS_ACTION"
+        extra_vars = {
+            'table_name': table_name,
+            'action': action
+        }
+        self.apply_non_openconfig_acl_rle(duthost, extra_vars, rule_file)
+
     def send_and_check_mirror_packets(self,
                                       setup,
                                       mirror_session,
@@ -852,7 +908,14 @@ class BaseEverflowTest(object):
                 # but DMAC and checksum are trickier. For now, update the TTL and SMAC, and
                 # mask off the DMAC and IP Checksum to verify the packet contents.
                 if self.mirror_type() == "egress":
-                    mirror_packet_sent[packet.IP].ttl -= 1
+                    inner_packet.set_do_not_care_scapy(packet.Ether, "dst")
+
+                    if self.acl_ip_version() == 4:
+                        mirror_packet_sent[packet.IP].ttl -= 1
+                        inner_packet.set_do_not_care_scapy(packet.IP, "chksum")
+                    else:
+                        mirror_packet_sent[packet.IPv6].hlim -= 1
+
                     if 't2' in setup['topo']:
                         if duthost.facts['switch_type'] == "voq":
                             mirror_packet_sent[packet.Ether].src = setup[direction]["ingress_router_mac"]
@@ -861,9 +924,6 @@ class BaseEverflowTest(object):
                         mirror_packet_sent[packet.Ether].src = setup[direction]["vlan_mac"]
                     else:
                         mirror_packet_sent[packet.Ether].src = setup[direction]["egress_router_mac"]
-
-                    inner_packet.set_do_not_care_scapy(packet.Ether, "dst")
-                    inner_packet.set_do_not_care_scapy(packet.IP, "chksum")
 
                 logging.info("Expected inner packet: %s", mirror_packet_sent.summary())
                 pytest_assert(inner_packet.pkt_match(mirror_packet_sent),

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -16,7 +16,7 @@ import ptf.packet as packet
 from abc import abstractmethod
 from ptf.mask import Mask
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until, check_msg_in_syslog, find_duthost_on_role
+from tests.common.utilities import wait_until, find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 import json
 

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -16,7 +16,7 @@ import ptf.packet as packet
 from abc import abstractmethod
 from ptf.mask import Mask
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import find_duthost_on_role
+from tests.common.utilities import wait_until, check_msg_in_syslog, find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 import json
 

--- a/tests/everflow/files/ipv6_test_rules.yaml
+++ b/tests/everflow/files/ipv6_test_rules.yaml
@@ -179,3 +179,12 @@
     transport:
       source-port: "12002"
       destination-port: "12003"
+
+- qualifiers:
+    icmp:
+      type: 2
+
+- qualifiers:
+    icmp:
+      type: 3
+      code: 1

--- a/tests/everflow/files/test_rules_ip_type_v6.json
+++ b/tests/everflow/files/test_rules_ip_type_v6.json
@@ -1,0 +1,22 @@
+{
+    "ACL_RULE": {
+        "{{ table_name }}|rule_999": {
+            "PRIORITY": "999",
+            "IP_TYPE": "ANY",
+            "{{ action }}": "test_session_1",
+            "DST_IPV6": "2002:0225:7c6b:a982:d48b:230e:f271:0011"
+        },
+        "{{ table_name }}|rule_998": {
+            "PRIORITY": "998",
+            "IP_TYPE": "IP",
+            "{{ action }}": "test_session_1",
+            "DST_IPV6": "2002:0225:7c6b:a982:d48b:230e:f271:0012"
+        },
+        "{{ table_name }}|rule_997": {
+            "PRIORITY": "997",
+            "IP_TYPE": "IPV6ANY",
+            "{{ action }}": "test_session_1",
+            "DST_IPV6": "2002:0225:7c6b:a982:d48b:230e:f271:0013"
+        }
+    }
+}

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -934,6 +934,7 @@ class TestIngressEverflowIPv6(EverflowIPv6Tests):
     def mirror_type(self):
         return "ingress"
 
+
 class TestEgressEverflowIPv6(EverflowIPv6Tests):
     """Parameters for Egress Everflow IPv6 testing. (Egress ACLs/Egress Mirror)"""
     def acl_stage(self):
@@ -941,4 +942,3 @@ class TestEgressEverflowIPv6(EverflowIPv6Tests):
 
     def mirror_type(self):
         return "egress"
-

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -33,29 +33,29 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     DEFAULT_SRC_IP = "2002:0225:7c6b:a982:d48b:230e:f271:0000"
     DEFAULT_DST_IP = "2002:0225:7c6b:a982:d48b:230e:f271:0001"
+    RULE_DST_IP = "2002:0225:7c6b::"
     rx_port_ptf_id = None
     tx_port_ids = []
 
+    @pytest.fixture(scope='class')
+    def dest_port_type(self, setup_info):     # noqa F811
+        if setup_info['topo'] in ['t0', 'm0_vlan']:
+            return UP_STREAM
+        return DOWN_STREAM
+
     @pytest.fixture(scope='class',  autouse=True)
-    def setup_mirror_session_dest_ip_route(self, tbinfo, setup_info, setup_mirror_session, erspan_ip_ver):     # noqa F811
+    def setup_mirror_session_dest_ip_route(self, tbinfo, setup_info, setup_mirror_session, erspan_ip_ver, dest_port_type):     # noqa F811
         """
         Setup the route for mirror session destination ip and update monitor port list.
         Remove the route as part of cleanup.
         """
         ip = "ipv4" if erspan_ip_ver == 4 else "ipv6"
-        if setup_info['topo'] in ['t0', 'm0_vlan']:
-            # On T0 testbed, the collector IP is routed to T1
-            namespace = setup_info[UP_STREAM]['remote_namespace']
-            tx_port = setup_info[UP_STREAM]["dest_port"][0]
-            dest_port_ptf_id_list = [setup_info[UP_STREAM]["dest_port_ptf_id"][0]]
-            remote_dut = setup_info[UP_STREAM]['remote_dut']
-            rx_port_id = setup_info[UP_STREAM]["src_port_ptf_id"]
-        else:
-            namespace = setup_info[DOWN_STREAM]['remote_namespace']
-            tx_port = setup_info[DOWN_STREAM]["dest_port"][0]
-            dest_port_ptf_id_list = [setup_info[DOWN_STREAM]["dest_port_ptf_id"][0]]
-            remote_dut = setup_info[DOWN_STREAM]['remote_dut']
-            rx_port_id = setup_info[DOWN_STREAM]["src_port_ptf_id"]
+        # On T0 testbed, the collector IP is routed to T1
+        namespace = setup_info[dest_port_type]['remote_namespace']
+        tx_port = setup_info[dest_port_type]["dest_port"][0]
+        dest_port_ptf_id_list = [setup_info[dest_port_type]["dest_port_ptf_id"][0]]
+        remote_dut = setup_info[dest_port_type]['remote_dut']
+        rx_port_id = setup_info[dest_port_type]["src_port_ptf_id"]
         remote_dut.shell(remote_dut.get_vtysh_cmd_for_namespace(
             f"vtysh -c \"config\" -c \"router bgp\" -c \"address-family {ip}\" -c \"redistribute static\"", namespace))
         peer_ip = everflow_utils.get_neighbor_info(remote_dut, tx_port, tbinfo, ip_version=erspan_ip_ver)
@@ -72,6 +72,29 @@ class EverflowIPv6Tests(BaseEverflowTest):
         remote_dut.shell(remote_dut.get_vtysh_cmd_for_namespace(
             f"vtysh -c \"config\" -c \"router bgp\" -c \"address-family {ip}\" -c \"no redistribute static\"",
             namespace))
+
+    @pytest.fixture(scope='class', autouse=True)
+    def add_dest_routes(self, setup_info, tbinfo, dest_port_type):      # noqa F811
+        if self.acl_stage() != 'egress':
+            yield
+            return
+
+        default_traffic_port_type = DOWN_STREAM if dest_port_type == UP_STREAM else UP_STREAM
+
+        duthost = setup_info[default_traffic_port_type]['remote_dut']
+        rx_port = setup_info[default_traffic_port_type]["dest_port"][0]
+        nexthop_ip = everflow_utils.get_neighbor_info(duthost, rx_port, tbinfo, ip_version=6)
+
+        ns = setup_info[default_traffic_port_type]["remote_namespace"]
+        networks_to_add = [f"{self.DEFAULT_DST_IP}/128", f"{self.RULE_DST_IP}/48"]
+
+        for network in networks_to_add:
+            everflow_utils.add_route(duthost, network, nexthop_ip, ns)
+
+        yield
+
+        for network in networks_to_add:
+            everflow_utils.remove_route(duthost, network, nexthop_ip, ns)
 
     @pytest.fixture(scope='class')
     def everflow_dut(self, setup_info):             # noqa F811
@@ -156,6 +179,60 @@ class EverflowIPv6Tests(BaseEverflowTest):
             # Wait for the background thread to finish
             background_thread.join()
             background_traffic(run_count=1)
+
+    @pytest.fixture(scope='class',  autouse=True)
+    def setup_acl_table(self, setup_info, setup_mirror_session, config_method, setup_mirror_session_dest_ip_route):         # noqa F811
+
+        if setup_info['topo'] in ['t0', 'm0_vlan']:
+            everflow_dut = setup_info[UP_STREAM]['everflow_dut']
+            remote_dut = setup_info[UP_STREAM]['remote_dut']
+        else:
+            everflow_dut = setup_info[DOWN_STREAM]['everflow_dut']
+            remote_dut = setup_info[DOWN_STREAM]['remote_dut']
+
+        table_name = self._get_table_name(everflow_dut)
+        temporary_table = False
+
+        duthost_set = set()
+        duthost_set.add(everflow_dut)
+        duthost_set.add(remote_dut)
+
+        if not table_name:
+            table_name = "EVERFLOWV6" if self.acl_stage() == "ingress" else "EVERFLOW_EGRESSV6"
+            temporary_table = True
+
+        for duthost in duthost_set:
+            if temporary_table:
+                self.apply_acl_table_config(duthost, table_name, "MIRRORV6", config_method)
+
+            self.apply_acl_rule_config(duthost, table_name, setup_mirror_session["session_name"],
+                                       config_method, rules=EVERFLOW_V6_RULES)
+            self.apply_ip_type_rule(duthost, 6)
+
+        yield
+
+        for duthost in duthost_set:
+            self.remove_acl_rule_config(duthost, table_name, config_method)
+
+            if temporary_table:
+                self.remove_acl_table_config(duthost, table_name, config_method)
+
+    # TODO: This can probably be refactored into a common utility method later.
+    def _get_table_name(self, duthost):
+        show_output = duthost.command("show acl table")
+
+        table_name = None
+        for line in show_output["stdout_lines"]:
+            if "MIRRORV6" in line:
+                # NOTE: Once we branch out the sonic-mgmt repo we can skip the version check.
+                if "201811" in duthost.os_version or self.acl_stage() in line:
+                    table_name = line.split()[0]
+                    break
+
+        return table_name
+
+    def acl_ip_version(self):
+        return 6
 
     def test_src_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
                                 setup_standby_ports_on_rand_unselected_tor_unconditionally,             # noqa F811
@@ -670,6 +747,130 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids,
                                            erspan_ip_ver=erspan_ip_ver)
 
+    def test_icmpv6_type(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
+                         setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+                         everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
+                         erspan_ip_ver):                                                          # noqa F811
+        """Verify that we can match packets with icmp type field"""
+        test_packet = self._base_icmpv6_packet(
+            everflow_direction,
+            ptfadapter,
+            setup_info,
+            icmp_type=2
+        )
+
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           everflow_dut,
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
+                                           erspan_ip_ver=erspan_ip_ver)
+
+    def test_icmpv6_code(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
+                         setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+                         everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
+                         erspan_ip_ver):                                                          # noqa F811
+        """Verify that we can match packets with icmp code field"""
+        test_packet = self._base_icmpv6_packet(
+            everflow_direction,
+            ptfadapter,
+            setup_info,
+            icmp_type=3,
+            icmp_code=1
+        )
+
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           everflow_dut,
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
+                                           erspan_ip_ver=erspan_ip_ver)
+
+    def test_ip_type_any(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
+                         setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+                         everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
+                         erspan_ip_ver):                                                          # noqa F811
+        test_packet = self._base_tcpv6_packet(
+            everflow_direction,
+            ptfadapter,
+            setup_info,
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:0011"
+        )
+
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           everflow_dut,
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
+                                           erspan_ip_ver=erspan_ip_ver)
+
+    def test_ip_type_ip(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
+                        setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+                        everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
+                        erspan_ip_ver):                                                          # noqa F811
+        test_packet = self._base_tcpv6_packet(
+            everflow_direction,
+            ptfadapter,
+            setup_info,
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:0012"
+        )
+
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           everflow_dut,
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
+                                           erspan_ip_ver=erspan_ip_ver)
+
+    def test_ip_type_ipv6any(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
+                             setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+                             everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
+                             erspan_ip_ver):                                                          # noqa F811
+        test_packet = self._base_tcpv6_packet(
+            everflow_direction,
+            ptfadapter,
+            setup_info,
+            dst_ip="2002:0225:7c6b:a982:d48b:230e:f271:0013"
+        )
+
+        self.send_and_check_mirror_packets(setup_info,
+                                           setup_mirror_session,
+                                           ptfadapter,
+                                           everflow_dut,
+                                           test_packet, everflow_direction, src_port=EverflowIPv6Tests.rx_port_ptf_id,
+                                           dest_ports=EverflowIPv6Tests.tx_port_ids,
+                                           erspan_ip_ver=erspan_ip_ver)
+
+    def _base_icmpv6_packet(self,
+                            direction,
+                            ptfadapter,
+                            setup,
+                            src_ip=DEFAULT_SRC_IP,
+                            dst_ip=DEFAULT_DST_IP,
+                            next_header=None,
+                            dscp=None,
+                            icmp_type=8,
+                            icmp_code=0):
+        pkt = testutils.simple_icmpv6_packet(
+            eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
+            eth_dst=setup[direction]["ingress_router_mac"],
+            ipv6_src=src_ip,
+            ipv6_dst=dst_ip,
+            ipv6_dscp=dscp,
+            ipv6_hlim=64,
+            icmp_type=icmp_type,
+            icmp_code=icmp_code
+        )
+
+        if next_header:
+            pkt["IPv6"].nh = next_header
+
+        return pkt
+
     def _base_tcpv6_packet(self,
                            direction,
                            ptfadapter,
@@ -733,52 +934,11 @@ class TestIngressEverflowIPv6(EverflowIPv6Tests):
     def mirror_type(self):
         return "ingress"
 
-    @pytest.fixture(scope='class',  autouse=True)
-    def setup_acl_table(self, setup_info, setup_mirror_session, config_method):         # noqa F811
+class TestEgressEverflowIPv6(EverflowIPv6Tests):
+    """Parameters for Egress Everflow IPv6 testing. (Egress ACLs/Egress Mirror)"""
+    def acl_stage(self):
+        return "egress"
 
-        if setup_info['topo'] in ['t0', 'm0_vlan']:
-            everflow_dut = setup_info[UP_STREAM]['everflow_dut']
-            remote_dut = setup_info[UP_STREAM]['remote_dut']
-        else:
-            everflow_dut = setup_info[DOWN_STREAM]['everflow_dut']
-            remote_dut = setup_info[DOWN_STREAM]['remote_dut']
+    def mirror_type(self):
+        return "egress"
 
-        table_name = self._get_table_name(everflow_dut)
-        temporary_table = False
-
-        duthost_set = set()
-        duthost_set.add(everflow_dut)
-        duthost_set.add(remote_dut)
-
-        if not table_name:
-            table_name = "EVERFLOWV6"
-            temporary_table = True
-
-        for duthost in duthost_set:
-            if temporary_table:
-                self.apply_acl_table_config(duthost, table_name, "MIRRORV6", config_method)
-
-            self.apply_acl_rule_config(duthost, table_name, setup_mirror_session["session_name"],
-                                       config_method, rules=EVERFLOW_V6_RULES)
-
-        yield
-
-        for duthost in duthost_set:
-            self.remove_acl_rule_config(duthost, table_name, config_method)
-
-            if temporary_table:
-                self.remove_acl_table_config(duthost, table_name, config_method)
-
-    # TODO: This can probably be refactored into a common utility method later.
-    def _get_table_name(self, duthost):
-        show_output = duthost.command("show acl table")
-
-        table_name = None
-        for line in show_output["stdout_lines"]:
-            if "MIRRORV6" in line:
-                # NOTE: Once we branch out the sonic-mgmt repo we can skip the version check.
-                if "201811" in duthost.os_version or "ingress" in line:
-                    table_name = line.split()[0]
-                    break
-
-        return table_name

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -911,6 +911,9 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
         return pkt
 
+    def acl_ip_version(self):
+        return 4
+
 
 class TestEverflowV4IngressAclIngressMirror(EverflowIPv4Tests):
     def acl_stage(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #20571 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Approach
#### What is the motivation for this PR?

Adding support for Egress ERSPAN for IPv6. OUTER_VLAN matching was skipped as there is no current production need. Gap may be closed in future PR.

#### How did you do it?

Leveraged existing infrastructure using same tests and only adding support for egress v6 tables and packet validation.

#### How did you verify/test it?

Ran against SN4600 and SN4700 T0/T1 testbeds. Sample output below:

[Egress_everflow_v6.txt](https://github.com/user-attachments/files/23666093/Egress_everflow_v6.txt)

#### Any platform specific information?
Tested against SN4600/SN4700.

#### Supported testbed topology if it's a new test case?
Only support for T0/T1 was verified as skus supporting this feature are limited, but test should work on all topologies implemented for ingress v6.

### Documentation
Existing ERSPAN documentation appears to be severely out of date. Will update these in batch in a future PR.