### PR TITLE
[202509] Update docker image tag for docker-ptf to 202505

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -7,7 +7,7 @@
 # By using this practice, we suggest to add different tags for different PTF image versions in docker registry.
 - name: Set default value for ptf_imagetag
   set_fact:
-    ptf_imagetag: "latest"
+    ptf_imagetag: "202505"
   when: ptf_imagetag is not defined
 
 - name: set "PTF" container type, by default

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -12,7 +12,7 @@
   block:
   - name: Set default value for ptf_imagetag
     set_fact:
-      ptf_imagetag: "latest"
+      ptf_imagetag: "202505"
     when: ptf_imagetag is not defined
 
   - name: Stop mux simulator


### PR DESCRIPTION
**What is the motivation for this PR?**
Release branches must use branch-based tag names for docker-ptf. Updating for 202509.