### PR TITLE
Fallback 202412 to use legacy docker-sonic-mgmt

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -42,7 +42,7 @@ declare EXISTING_CONTAINER_NAME=""
 
 ENV_VARS=""
 CONTAINER_NAME=""
-IMAGE_ID=""
+IMAGE_ID="sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:master"
 LINK_DIR=""
 MOUNT_POINTS="-v \"/var/run/docker.sock:/var/run/docker.sock:rslave\""
 PUBLISH_PORTS=""


### PR DESCRIPTION
After the docker-sonic-mgmt is upgraded  to Ubuntu 24.04, the new ansible requires python version >= 3.8 on target machine. The 202412 branch by default uses docker-ptf:202411 according to this code: https://github.com/Azure/sonic-mgmt.msft/blob/202412/ansible/roles/vm_set/tasks/add_topo.yml#L10

The docker-ptf:202411 image is still Debian buster based. Its python version is still 3.7.

While the "add-topo" tries to run the ptf_portchannel module on PTF container to start portchannel in PTF container, this issue is hit.

The easiest workaround is to fallback to the legacy docker-sonic-mgmt for 202412 branch.

This fix updated the setup-container.sh tool for 202412 branch to use "sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:master" by default. This is the legacy docker-sonic-mgmt last known good for 202412 branch.