### PR TITLE
Enhance PTF function at scale testbed

### DIFF
--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -11,6 +11,7 @@ import ptf.packet as scapy
 
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses  # noqa F401
 import ptf.testutils as testutils
+from tests.common.helpers.constants import PTF_TIMEOUT
 from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.utilities import get_upstream_neigh_type, get_neighbor_ptf_port_list, \
@@ -242,7 +243,7 @@ def send_and_verify_packet(ptfadapter, pkt, exp_pkt, tx_port, rx_port, expected_
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, pkt=pkt, port_id=tx_port)
     if expected_action == FORWARD:
-        testutils.verify_packet(ptfadapter, pkt=exp_pkt, port_id=rx_port, timeout=5)
+        testutils.verify_packet(ptfadapter, pkt=exp_pkt, port_id=rx_port, timeout=PTF_TIMEOUT)
     else:
         testutils.verify_no_packet(ptfadapter, pkt=exp_pkt, port_id=rx_port, timeout=5)
 

--- a/tests/arp/test_arp_extended.py
+++ b/tests/arp/test_arp_extended.py
@@ -6,6 +6,7 @@ import ptf.testutils as testutils
 import pytest
 
 from tests.arp.arp_utils import clear_dut_arp_cache
+from tests.common.helpers.constants import PTF_TIMEOUT
 from tests.common.utilities import increment_ipv4_addr
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 
@@ -101,4 +102,4 @@ def test_proxy_arp(rand_selected_dut, proxy_arp_enabled, ip_and_intf_info, ptfad
     if ip_version == 'v6':
         neigh_table = rand_selected_dut.shell('ip -6 neigh')['stdout']
         logger.debug(neigh_table)
-    testutils.verify_packet(ptfadapter, expected_packet, ptf_intf_index, timeout=10)
+    testutils.verify_packet(ptfadapter, expected_packet, ptf_intf_index, timeout=PTF_TIMEOUT)

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -8,6 +8,7 @@ ASICS_PRESENT = 'asics_present'
 RANDOM_SEED = 'random_seed'
 CUSTOM_MSG_PREFIX = "sonic_custom_msg"
 DUT_CHECK_NAMESPACE = "dut_check_result"
+PTF_TIMEOUT = 60
 
 # Describe upstream neighbor of dut in different topos
 UPSTREAM_NEIGHBOR_MAP = {

--- a/tests/span/span_helpers.py
+++ b/tests/span/span_helpers.py
@@ -3,6 +3,7 @@ Helper functions for span tests
 '''
 
 import ptf.testutils as testutils
+from tests.common.helpers.constants import PTF_TIMEOUT
 
 
 def send_and_verify_mirrored_packet(ptfadapter, src_port, monitor):
@@ -20,4 +21,4 @@ def send_and_verify_mirrored_packet(ptfadapter, src_port, monitor):
 
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, src_port, pkt)
-    testutils.verify_packet(ptfadapter, pkt, monitor)
+    testutils.verify_packet(ptfadapter, pkt, monitor, timeout=PTF_TIMEOUT)


### PR DESCRIPTION
On Scale testbed there are 2 main differences:
1. There are much more PTF ports(512)
2. There are much more OVS and interface configurations

Those lead to:
1. NIC would take more time to handle the receiving packets
2. PTF could take more time to process

As a result:
1. More time to spend in ptf function testutils.verify_packet, and with more timeouts, the function verify_packet would capture the packet.