### PR TITLE
[202503] Fix tests/override_config_table/test_override_config_table.py to support LT2 / FT2

### DIFF
--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -85,21 +85,19 @@ def load_minigraph_with_golden_empty_input(duthost):
     reload_minigraph_with_golden_config(duthost, empty_input)
 
     current_config = get_running_config(duthost)
+    problem_tables = []
     for table in initial_config:
         if table in NON_USER_CONFIG_TABLES:
             continue
 
         if table == "ACL_TABLE":
-            pytest_assert(
-                compare_dicts_ignore_list_order(initial_config[table], current_config[table]),
-                "empty input ACL_TABLE compare fail!"
-            )
+            if not compare_dicts_ignore_list_order(initial_config[table], current_config[table]):
+                problem_tables.append(table)
         else:
-            pytest_assert(
-                initial_config[table] == current_config[table],
-                "empty input compare fail! {}".format(table)
-            )
+            if not initial_config[table] == current_config[table]:
+                problem_tables.append(table)
 
+    pytest_assert(not problem_tables, "empty input compare fail: {}".format(problem_tables))
 
 def load_minigraph_with_golden_partial_config(duthost):
     """Test Golden Config with partial config.

--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -8,6 +8,9 @@ from tests.common.utilities import backup_config, restore_config, get_running_co
     reload_minigraph_with_golden_config, file_exists_on_dut, compare_dicts_ignore_list_order, \
     NON_USER_CONFIG_TABLES
 
+# Tables known to be overriden in run-time config, which will appear different
+# if the golden config is overridden empty.
+GOLDEN_OVERRRIDDEN_TABLES = ["FEATURE", "PORT"]
 
 GOLDEN_CONFIG = "/etc/sonic/golden_config_db.json"
 GOLDEN_CONFIG_BACKUP = "/etc/sonic/golden_config_db.json_before_override"
@@ -87,7 +90,7 @@ def load_minigraph_with_golden_empty_input(duthost):
     current_config = get_running_config(duthost)
     problem_tables = []
     for table in initial_config:
-        if table in NON_USER_CONFIG_TABLES:
+        if table in NON_USER_CONFIG_TABLES or table in GOLDEN_OVERRRIDDEN_TABLES:
             continue
 
         if table == "ACL_TABLE":


### PR DESCRIPTION
This pull request makes a small enhancement in the test_override_config_table.py test
case, and change to get the test case to pass. Both changes are in the function load_minigraph_with_golden_empty_input function.

The enhancement is to gather the names of all tables for which a mismatch occur so that the assertion lists all of them, rather than just the first one.

The second is to add exceptions for the "FEATURE" and "PORT" tables. With this change, the rest of the test case passes.