### PR TITLE
fix: enhance routeCheck toggle logic (#21614)

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -91,12 +91,31 @@ def backup_and_restore_config_db_session(duthosts):
         yield func
 
 
-def stop_route_checker_on_duthost(duthost):
+def _is_route_checker_in_status(duthost, expected_status_substrings):
+    """
+    Check if routeCheck service status contains any expected substring.
+    """
+    route_checker_status = duthost.get_monit_services_status().get("routeCheck", {})
+    status = route_checker_status.get("service_status", "").lower()
+    return any(status_fragment in status for status_fragment in expected_status_substrings)
+
+
+def stop_route_checker_on_duthost(duthost, wait_for_status=False):
     duthost.command("sudo monit stop routeCheck", module_ignore_errors=True)
+    if wait_for_status:
+        pytest_assert(
+            wait_until(600, 15, 0, _is_route_checker_in_status, duthost, ("not monitored",)),
+            "routeCheck service did not stop on {}".format(duthost.hostname),
+        )
 
 
-def start_route_checker_on_duthost(duthost):
+def start_route_checker_on_duthost(duthost, wait_for_status=False):
     duthost.command("sudo monit start routeCheck", module_ignore_errors=True)
+    if wait_for_status:
+        pytest_assert(
+            wait_until(900, 20, 0, _is_route_checker_in_status, duthost, ("status ok",)),
+            "routeCheck service did not start on {}".format(duthost.hostname),
+        )
 
 
 def _disable_route_checker(duthost):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2740,8 +2740,10 @@ def temporarily_disable_route_check(request, tbinfo, duthosts):
             check_flag = True
             break
 
-    if 't2' not in tbinfo['topo']['name']:
-        logger.info("Topology is not T2, skipping temporarily_disable_route_check fixture")
+    allowed_topologies = {"t2", "ut2", "lt2"}
+    topo_name = tbinfo['topo']['name']
+    if check_flag and topo_name not in allowed_topologies:
+        logger.info("Topology {} is not allowed for temporarily_disable_route_check fixture".format(topo_name))
         check_flag = False
 
     def wait_for_route_check_to_pass(dut):
@@ -2766,7 +2768,7 @@ def temporarily_disable_route_check(request, tbinfo, duthosts):
 
             with SafeThreadPoolExecutor(max_workers=8) as executor:
                 for duthost in duthosts.frontend_nodes:
-                    executor.submit(stop_route_checker_on_duthost, duthost)
+                    executor.submit(stop_route_checker_on_duthost, duthost, wait_for_status=True)
 
             yield
 
@@ -2776,7 +2778,7 @@ def temporarily_disable_route_check(request, tbinfo, duthosts):
         finally:
             with SafeThreadPoolExecutor(max_workers=8) as executor:
                 for duthost in duthosts.frontend_nodes:
-                    executor.submit(start_route_checker_on_duthost, duthost)
+                    executor.submit(start_route_checker_on_duthost, duthost, wait_for_status=True)
     else:
         logger.info("Skipping temporarily_disable_route_check fixture")
         yield


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Further enhance the routeCheck monitor disable-and-enable logic:
- Users can choose which topologies apply the disable-and-enable routeCheck behavior
- Use `wait_until()` timeout to verify the routeCheck status is as expected before proceeding to the next step

Summary:
Fixes # (issue) Microsoft ADO 36101536

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
This is a follow-up PR of https://github.com/sonic-net/sonic-mgmt/pull/21582. Not all platforms need the "temporarily disable roureCheck monitor" feature, and the routeCheck monitor will take some time to startup after running `sudo monit start routeCheck` on some platforms. Therefore, we want to allow the users to choose which topologies they want to apply the disable-and-enable routeCheck behavior (Now only T2, LT2 & UT2 are allowed). Besides, we added a `wait_until()` timeout to verify the routeCheck status is as expected before proceeding to the next step.

#### How did you do it?

#### How did you verify/test it?
I verified it on a T0 platform and I can confirm this logic will be skipped:  https://elastictest.org/scheduler/testplan/69389f2d392767e9bf67ef1a

<img width="1606" height="209" alt="image" src="https://github.com/user-attachments/assets/81f5c39b-23b6-4b8c-a2b6-734522702107" />

<img width="1830" height="218" alt="image" src="https://github.com/user-attachments/assets/73357408-f497-40be-ae16-93104246f77e" />


I also verified on a T2 platform and I can confirm this logic is applied there: https://elastictest.org/scheduler/testplan/69389e7794f9e10e4c224c66

<img width="1835" height="356" alt="image" src="https://github.com/user-attachments/assets/2647bd40-b44f-48af-aa68-2bda0397ea2d" />
<img width="1893" height="662" alt="image" src="https://github.com/user-attachments/assets/10391c32-0e27-4186-876f-64f7ae137569" />

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
