### PR TITLE
202412.multi vrf

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -6,6 +6,8 @@ import datetime
 import os
 import argparse
 
+from ceos_topo_converger import converge_testbed
+
 """"
 Testbed Processing
 
@@ -246,7 +248,7 @@ error handling: checks if attribute values are None type or string "None"
 
 
 def makeTestbed(data, outfile):
-    csv_columns = "# conf-name,group-name,topo,ptf_image_name,ptf,ptf_ip,ptf_ipv6,server,vm_base,dut,comment"
+    csv_columns = "#conf-name,group-name,topo,ptf_image_name,ptf,ptf_ip,ptf_ipv6,server,vm_base,dut,comment,use_converged_peers"
     topology = data
     csv_file = outfile
 
@@ -265,6 +267,7 @@ def makeTestbed(data, outfile):
                 dut = groupDetails.get("dut")
                 ptf = groupDetails.get("ptf")
                 comment = groupDetails.get("comment")
+                use_converged_peers = str(groupDetails.get("use_converged_peers", False)).lower()
 
                 # catch empty types
                 if not groupName:
@@ -295,7 +298,7 @@ def makeTestbed(data, outfile):
 
                 row = confName + "," + groupName + "," + topo + "," + ptf_image_name + "," + ptf + \
                     "," + ptf_ip + "," + ptf_ipv6 + "," + server + \
-                    "," + vm_base + "," + dut + "," + comment
+                    "," + vm_base + "," + dut + "," + comment + "," + use_converged_peers
                 f.write(row + "\n")
     except IOError:
         print("I/O error: issue creating testbed.yaml")
@@ -1046,6 +1049,19 @@ def main():
     print("\tCREATING TEST BED: " + args.basedir + testbed_file)
     # Generate testbed.yaml (TESTBED)
     makeTestbed(testbed, args.basedir + testbed_file)
+    # If specified the testbed, overwrite the topology file the testbed will use with
+    # one which uses the fewest number of ceoslab peers possible.
+    for data in testbed.values():
+        topo = data.get("topo", "")
+        if topo and data.get("use_converged_peers", False):
+            topofile = os.path.join("vars", "topo_{}.yml".format(topo))
+            if os.path.exists(os.path.join(args.basedir, topofile)):
+                print("\tCONVERGING PEER INSTANCES: {}".format(topofile))
+                copyfile(topofile,
+                         os.path.join("/tmp/", "topo_{}.yml.orig".format(topo)))
+                converge_testbed(topofile, topofile) # overwrites contents of topofile
+            else:
+                print("Error: could not locate original topo file at " + topofile)
     print("\tCREATING VM_HOST/CREDS: " + args.basedir + vmHostCreds_file)
     # Generate vm_host\creds.yml (CREDS)
     makeVMHostCreds(veos, args.basedir + vmHostCreds_file)

--- a/ansible/ceos_topo_converger.py
+++ b/ansible/ceos_topo_converger.py
@@ -6,13 +6,11 @@ in the topology
 
 from copy import deepcopy
 from ipaddress import ip_address
-from typing import Optional, Union
+from typing import Dict, List, Optional, Union
 import yaml
-
 
 CEOSLAB_INTF_LIMIT = 127 # 128, minus one for backplane interface
 BASE_VLAN_ID = 2000
-
 
 class ListIndentDumper(yaml.Dumper):
     def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:
@@ -22,7 +20,7 @@ class ListIndentDumper(yaml.Dumper):
 class SonicTopoConverger:
 
 
-    def __init__(self, topology: dict[str, Union[int, str]], file_out: str) -> None:
+    def __init__(self, topology: Dict[str, Union[int, str]], file_out: str) -> None:
         self.topo = topology
         self.converged_topo = {
                 "topology": {},
@@ -87,7 +85,7 @@ class SonicTopoConverger:
                     self.prime_device_mapping[prime].append(device)
 
 
-    def converge_vms(self) -> dict[str, Union[int, str]]:
+    def converge_vms(self) -> Dict[str, Union[int, str]]:
         '''
         Helper to converge the "VMs" section of the input topology, where vlans and
         offsets are defined, per cEOSLab instance.
@@ -119,8 +117,8 @@ class SonicTopoConverger:
 
 
     def converge_peers(self,
-                       if_index_mapping: dict[str, list[int]],
-                       offset_mapping: dict[str, int]) -> dict[str, Union[int, str]]:
+                       if_index_mapping: Dict[str, List[int]],
+                       offset_mapping: Dict[str, int]) -> Dict[str, Union[int, str]]:
         '''
         Helper to converge the section of the input topology where the actual cEOSLab
         instance configuration is laid out.  This is where interface and BGP
@@ -136,7 +134,7 @@ class SonicTopoConverger:
             new_peers[dev] = {"properties": properties,
                              "vrf": {},
                              "bgp": {"asn": asn},
-                             "intf_offset_mapping": {}}
+                             "intf_mapping": {}}
 
         # Backplane L3 addresses are laid out for clarity-- addresses with odd
         # least-signifcant octets or hextets are assigned to the interfaces of the
@@ -158,6 +156,7 @@ class SonicTopoConverger:
                 peer = peers[peer_name]
                 vrf_name = peer_name
                 peer_intfs = peer["interfaces"]
+                orig_intf_map = {}
 
                 intf_index = i + intf_counter_base
                 vrf = { f"Vlan{vlan_id}": {}}
@@ -165,14 +164,20 @@ class SonicTopoConverger:
                 for intf, config in peer_intfs.items():
                     if "Ethernet" not in intf:
                         continue
-                    vrf[f"Ethernet{eth_intf_index}"] = deepcopy(peer_intfs[intf])
+                    eth_intf = f"Ethernet{eth_intf_index}"
+                    vrf[eth_intf] = deepcopy(peer_intfs[intf])
+                    orig_intf_map[intf] = eth_intf
                     eth_intf_index += 1
 
                 if "Port-Channel1" in peer_intfs:
-                    vrf[f"Port-Channel{intf_index}"] = deepcopy(
+                    po_intf = f"Port-Channel{intf_index}"
+                    orig_intf_map["Port-Channel1"] = po_intf
+                    vrf[po_intf] = deepcopy(
                             peer_intfs["Port-Channel1"])
                 if "Loopback0" in peer_intfs:
-                    vrf[f"Loopback{intf_index}"] = deepcopy(peer_intfs["Loopback0"])
+                    lo_intf = f"Loopback{intf_index}"
+                    orig_intf_map["Loopback0"] = lo_intf
+                    vrf[lo_intf] = deepcopy(peer_intfs["Loopback0"])
 
                 new_peers[prime_dev]["vrf"][vrf_name] = vrf
 
@@ -191,11 +196,11 @@ class SonicTopoConverger:
                     bp_addr_data["vlan"] = vlan_id
                     bp_addrs[peer_name] = bp_addr_data
 
-                if not new_peers[prime_dev]["intf_offset_mapping"]:
+                if not new_peers[prime_dev]["intf_mapping"]:
                     # If we are filling in a prime_dev for the first time, reset the
                     # offset
                     offset = 0
-                new_peers[prime_dev]["intf_offset_mapping"][vrf_name] = offset
+                new_peers[prime_dev]["intf_mapping"][vrf_name] = {"offset": offset, "orig_intf_map": orig_intf_map}
                 offset += 1
                 peer_bp_addr_offset += 2
                 ptf_bp_addr_offset += 2
@@ -265,7 +270,7 @@ class SonicTopoConverger:
                       Dumper=ListIndentDumper, sort_keys=False)
 
 
-def converge_testbed(input_file:str, output_file: str) -> None:
+def converge_testbed(input_file: str, output_file: str) -> None:
     with open(input_file, "r", encoding="utf-8") as in_file:
         topo = yaml.safe_load(in_file)
     converger = SonicTopoConverger(topo, output_file)

--- a/ansible/ceos_topo_converger.py
+++ b/ansible/ceos_topo_converger.py
@@ -9,8 +9,10 @@ from ipaddress import ip_address
 from typing import Optional, Union
 import yaml
 
+
 CEOSLAB_INTF_LIMIT = 127 # 128, minus one for backplane interface
 BASE_VLAN_ID = 2000
+
 
 class ListIndentDumper(yaml.Dumper):
     def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:

--- a/ansible/ceos_topo_converger.py
+++ b/ansible/ceos_topo_converger.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+
+'''Converts SONiC topologies to use fewer cEOSLab peers, based on the roles required
+in the topology
+'''
+
+from copy import deepcopy
+from ipaddress import ip_address
+from typing import Optional, Union
+import yaml
+
+CEOSLAB_INTF_LIMIT = 127 # 128, minus one for backplane interface
+BASE_VLAN_ID = 2000
+
+class ListIndentDumper(yaml.Dumper):
+    def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:
+        return super().increase_indent(flow, False)
+
+
+class SonicTopoConverger:
+
+
+    def __init__(self, topology: dict[str, Union[int, str]], file_out: str) -> None:
+        self.topo = topology
+        self.converged_topo = {
+                "topology": {},
+                "configuration_properties": {},
+                "configuration": {}}
+        self.file_out = file_out
+        self.prime_device_mapping = {}
+        self.prime_devices = []
+
+
+    def parse_properties(self) -> None:
+        '''
+        The base configuration items of the topology must be parsed first, as they
+        inform how other sections will be translated.  Most important of these items
+        is the roles that each cEOSLab docker peer may fulfill.  At minimum we need
+        one instance per role.  These instances are referred to as "prime" instances,
+        and will contain the converged configuration of all other instances in the
+        input topology.
+        '''
+        labels = []
+        roles_by_label = {}
+        config_properties = self.topo["configuration_properties"]
+        for label in config_properties:
+            if "swrole" in config_properties[label]:
+                labels.append(label)
+                roles_by_label[label] = config_properties[label]["swrole"]
+
+        # Select a prime device for each role (defined above) and unique BGP ASN
+        # combination.  The entire peer topology will be reduced into these devices.
+        #
+        # cEOSLab peers only support 128 interfaces (with LLDP running).  Each
+        # pre-converged peer in the topology will become a single BGP instance
+        # running inside a VRF on a primary peer device.  Each VRF will require an
+        # downstream link to PTF/exabgp instance/other test infrastructure, and an
+        # upstream link the DUT.  This is achieved by creating a backplane interface
+        # on each primary peer that is a trunk interface, with each VRF
+        # containing a backplane SVI.  So, if the pre-converged peer topology
+        # requires more than 127 peers in a single BGP AS, we distribute them across
+        # multiple primary peers.
+        config = self.topo["configuration"]
+        cur_prime_devs = {}
+        dev_count = 0
+        for device in config:
+            create_new_prime = False
+            device_properties = config[device]["properties"]
+            bgp_asn = config[device]["bgp"]["asn"]
+
+            dev_count += 1
+
+            if dev_count == CEOSLAB_INTF_LIMIT:
+                create_new_prime = True
+                dev_count = 0
+
+            for label in device_properties:
+                if label in labels:
+                    if label not in cur_prime_devs or create_new_prime:
+                        cur_prime_devs[label] = device
+                        self.prime_devices.append(device)
+                    prime = cur_prime_devs[label]
+                    if prime not in self.prime_device_mapping:
+                        self.prime_device_mapping[prime] = []
+                    self.prime_device_mapping[prime].append(device)
+
+
+    def converge_vms(self) -> dict[str, Union[int, str]]:
+        '''
+        Helper to converge the "VMs" section of the input topology, where vlans and
+        offsets are defined, per cEOSLab instance.
+        '''
+        prime_rev_map = {}
+        for key, names in self.prime_device_mapping.items():
+            for name in names:
+                prime_rev_map[name] = key
+
+        old_vms = self.topo["topology"]["VMs"]
+        vms = {}
+        for i, dev in enumerate(self.prime_devices):
+            vms[dev] = {"vlans": [], "vm_offset": i}
+
+        for vm_name, vm in old_vms.items():
+            prime = prime_rev_map[vm_name]
+            for vlan in vm["vlans"]:
+                vms[prime]["vlans"].append(vlan)
+
+        return vms
+
+
+    def modify_l3_address(self, address: str, offset: int) -> str:
+        delim = ":" if ":" in address else "."
+        octets = address.split(delim)
+        addr = octets[:-1] + ["0"]
+        addr = ip_address(delim.join(addr))
+        return str(addr + offset)
+
+
+    def converge_peers(self,
+                       if_index_mapping: dict[str, list[int]],
+                       offset_mapping: dict[str, int]) -> dict[str, Union[int, str]]:
+        '''
+        Helper to converge the section of the input topology where the actual cEOSLab
+        instance configuration is laid out.  This is where interface and BGP
+        configuration is translated.
+        '''
+        peers = self.topo["configuration"]
+        convergence_data = {}
+        new_peers = {}
+        bp_addrs = {}
+        for dev in self.prime_devices:
+            properties = deepcopy(peers[dev]["properties"])
+            asn = peers[dev]["bgp"]["asn"]
+            new_peers[dev] = {"properties": properties,
+                             "vrf": {},
+                             "bgp": {"asn": asn},
+                             "intf_offset_mapping": {}}
+
+        # Backplane L3 addresses are laid out for clarity-- addresses with odd
+        # least-signifcant octets or hextets are assigned to the interfaces of the
+        # PTF container, and those with even least-signifcant octets or hextets are
+        # assigned to the cEOSLab containers.  The addresses alternate.  We start at
+        # 100 as the IPv4 addresses used for backplane connections in most of the
+        # testbed topology files used with this conversion script lie in that range.
+        # We use a similar range for IPv6 for simplicity.
+        peer_bp_addr_offset = 100
+        ptf_bp_addr_offset = 101
+        for prime_dev, peer_list in self.prime_device_mapping.items():
+            num_peers = len(peer_list)
+            intf_counter_base = 1
+            eth_intf_index = 1
+            offset = 0
+            for i, peer_name in enumerate(peer_list):
+                #  For simplicity, VRFs are just peer names.
+                vlan_id = BASE_VLAN_ID + offset_mapping[peer_name]
+                peer = peers[peer_name]
+                vrf_name = peer_name
+                peer_intfs = peer["interfaces"]
+
+                intf_index = i + intf_counter_base
+                vrf = { f"Vlan{vlan_id}": {}}
+
+                for intf, config in peer_intfs.items():
+                    if "Ethernet" not in intf:
+                        continue
+                    vrf[f"Ethernet{eth_intf_index}"] = deepcopy(peer_intfs[intf])
+                    eth_intf_index += 1
+
+                if "Port-Channel1" in peer_intfs:
+                    vrf[f"Port-Channel{intf_index}"] = deepcopy(
+                            peer_intfs["Port-Channel1"])
+                if "Loopback0" in peer_intfs:
+                    vrf[f"Loopback{intf_index}"] = deepcopy(peer_intfs["Loopback0"])
+
+                new_peers[prime_dev]["vrf"][vrf_name] = vrf
+
+                bp_addr_data = {}
+                v4Addr = peer["bp_interface"].get("ipv4", "10.10.246.0")
+                if "ipv4" in peer["bp_interface"]:
+                    base_addr = v4Addr.split("/")[0]
+                    bp_addr_data["ipv4"] = f"{self.modify_l3_address(base_addr, ptf_bp_addr_offset)}/31"
+                    vrf[f"Vlan{vlan_id}"]["ipv4"] = f"{self.modify_l3_address(base_addr, peer_bp_addr_offset)}/31"
+                if "ipv6" in peer["bp_interface"]:
+                    base_addr = peer["bp_interface"]["ipv6"].split("/")[0]
+                    bp_addr_data["ipv6"] = f"{self.modify_l3_address(base_addr, ptf_bp_addr_offset)}/127"
+                    bp_addr_data["router-id"] = f"{self.modify_l3_address(v4Addr, ptf_bp_addr_offset)}"
+                    vrf[f"Vlan{vlan_id}"]["ipv6"] = f"{self.modify_l3_address(base_addr, peer_bp_addr_offset)}/127"
+                if bp_addr_data:
+                    bp_addr_data["vlan"] = vlan_id
+                    bp_addrs[peer_name] = bp_addr_data
+
+                if not new_peers[prime_dev]["intf_offset_mapping"]:
+                    # If we are filling in a prime_dev for the first time, reset the
+                    # offset
+                    offset = 0
+                new_peers[prime_dev]["intf_offset_mapping"][vrf_name] = offset
+                offset += 1
+                peer_bp_addr_offset += 2
+                ptf_bp_addr_offset += 2
+
+        convergence_data["converged_peers"] = new_peers
+        convergence_data["convergence_mapping"] = deepcopy(self.prime_device_mapping)
+        convergence_data["interface_index_mapping"] = if_index_mapping
+        convergence_data["vm_offset_mapping"] = offset_mapping
+        if bp_addrs:
+            convergence_data["ptf_backplane_addrs"] = bp_addrs
+        return convergence_data
+
+
+    def converge_topo(self) -> None:
+        '''
+        Converge the read DUT/cEOSLab topology into the fewest cEOSLab docker
+        instances as possible.  The number of containers is based on the roles
+        required by the topology
+
+        i.e. a topology with the "tor" and "spine" roles defined with be converged to
+        use two cEOSLab docker instances, one per role.
+        '''
+        new_topo = self.converged_topo["topology"]
+        old_topo = self.topo["topology"]
+
+        self.converged_topo["topo_is_multi_vrf"] = True
+
+        # We don't need to change the host_interfaces portion of the passed topo, so
+        # copy
+        # it over as is.
+        key = "host_interfaces"
+        if key in old_topo:
+            new_topo[key] = old_topo[key].copy()
+
+        key = "VMs"
+        # Save off which vm had which interface index as we will need this later
+        interface_indexes = {}
+        offsets = {}
+        for vm, data in self.topo["topology"]["VMs"].items():
+            interface_indexes[vm] = data["vlans"]
+            offsets[vm] = data["vm_offset"]
+        vms = self.converge_vms()
+        new_topo[key] = vms
+
+        # The DUT configuration and general configuration properties should be
+        # unchanged as well.
+        key = "DUT"
+        if key in old_topo:
+            new_topo[key] = old_topo[key].copy()
+
+        new_topo = self.converged_topo
+        old_topo = self.topo
+        key = "configuration_properties"
+        new_topo[key] = old_topo[key].copy()
+
+        # convergence metadata
+        key = "configuration"
+        new_topo[key] = old_topo[key].copy()
+        new_topo["convergence_data"] = self.converge_peers(interface_indexes, offsets)
+
+
+    def run(self) -> None:
+        self.parse_properties()
+        self.converge_topo()
+        with open(self.file_out, "w", encoding="utf-8") as out_file:
+            yaml.dump(self.converged_topo, out_file,
+                      Dumper=ListIndentDumper, sort_keys=False)
+
+
+def converge_testbed(input_file:str, output_file: str) -> None:
+    with open(input_file, "r", encoding="utf-8") as in_file:
+        topo = yaml.safe_load(in_file)
+    converger = SonicTopoConverger(topo, output_file)
+    converger.run()

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -132,6 +132,16 @@ def wait_for_http(host_ip, http_port, timeout=10):
     return started
 
 
+def get_change_routes_ports(vm, topo):
+    offset = 0
+    vrf_data = topo.get("convergence_data", None)
+    if vrf_data:
+        offset = vrf_data["vm_offset_mapping"][vm]
+    else:
+        offset = topo["topology"]["VMs"][vm]["vm_offset"]
+    return (IPV4_BASE_PORT + offset, IPV6_BASE_PORT + offset)
+
+
 def get_topo_type(topo_name):
     pattern = re.compile(
         r'^(t0-mclag|t0|t1|ptf|fullmesh|dualtor|t2|mgmttor|m0|mc0|mx|dpu|smartswitch-t1)')
@@ -525,18 +535,24 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
     if upstream_neighbor_groups == 0:
         upstream_neighbor_groups = common_config.get("upstream_neighbor_groups", DEFAULT_NEIGHBOR_GROUPS)
 
+    multi_vrf = topo.get('topo_is_multi_vrf', False)
+    multi_vrf_data = topo.get('convergence_data', {})
+
     vms = topo['topology']['VMs']
+    if multi_vrf:
+        vms = {}
+        for prime_dev, vrfs in multi_vrf_data['convergence_mapping'].items():
+            for vrf in vrfs:
+                vms[vrf] = prime_dev
+
     vms_len = len(vms)
     current_routes_offset = 0
     last_suffix = 0
     for index, vm_name in enumerate(sorted(vms.keys())):
-        vm = vms[vm_name]
         router_type = "leaf"
         if 'tor' in topo['configuration'][vm_name]['properties']:
             router_type = 'tor'
-        vm_offset = vm['vm_offset']
-        port = IPV4_BASE_PORT + vm_offset
-        port6 = IPV6_BASE_PORT + vm_offset
+        port, port6 = get_change_routes_ports(vm_name, topo)
         aggregate_prefixes = topo['configuration'][vm_name].get("aggregate_routes", AGGREGATE_ROUTES_DEFAULT_VALUE)
         aggregate_routes = [(prefix, nhipv4 if "." in prefix else nhipv6, "") for prefix in aggregate_prefixes]
         aggregate_routes_v4 = get_ipv4_routes(aggregate_routes)
@@ -595,8 +611,16 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
     enable_ipv4_routes_generation = common_config.get("enable_ipv4_routes_generation",
                                                       ENABLE_IPV4_ROUTES_GENERATION_DEFAULT_VALUE)
 
+    multi_vrf = topo.get('topo_is_multi_vrf', False)
+    multi_vrf_data = topo.get('convergence_data', {})
+
     vms = topo['topology']['VMs']
     vms_config = topo['configuration']
+    if multi_vrf:
+        vms = {}
+        for prime_dev, vrfs in multi_vrf_data['convergence_mapping'].items():
+            for vrf in vrfs:
+                vms[vrf] = prime_dev
 
     dpus = None
     if 'DPUs' in topo['topology']:
@@ -620,9 +644,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
             v = downstream_vm_config[k]
             if dpus and k in dpus:
                 continue
-            vm_offset = vms[k]['vm_offset']
-            port = IPV4_BASE_PORT + vm_offset
-            port6 = IPV6_BASE_PORT + vm_offset
+            port, port6 = get_change_routes_ports(k, topo)
             routes_to_change[port] = []
             routes_to_change[port6] = []
             aggregate_prefixes = v.get("aggregate_routes", AGGREGATE_ROUTES_DEFAULT_VALUE)
@@ -665,10 +687,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
             curr_no_default_route = True
         if dpus and k in dpus:
             continue
-
-        vm_offset = vms[k]['vm_offset']
-        port = IPV4_BASE_PORT + vm_offset
-        port6 = IPV6_BASE_PORT + vm_offset
+        port, port6 = get_change_routes_ports(k, topo)
         # ports for T0 is already in routes_to_change, but ports for T1 is not, hence need setdefault
         routes_to_change.setdefault(port, [])
         routes_to_change.setdefault(port6, [])
@@ -836,9 +855,7 @@ def fib_m0(topo, ptf_ip, action="announce", topo_routes={}):
     m1_routes_v6 = None
     mx_index = -1
     for k, v in vms_config.items():
-        vm_offset = vms[k]['vm_offset']
-        port = IPV4_BASE_PORT + vm_offset
-        port6 = IPV6_BASE_PORT + vm_offset
+        port, port6 = get_change_routes_ports(k, topo)
 
         router_type = None
         # Upstream
@@ -1011,9 +1028,7 @@ def fib_mx(topo, ptf_ip, action="announce", topo_routes={}):
     m0_routes_v4 = None
     m0_routes_v6 = None
     for k, v in vms_config.items():
-        vm_offset = vms[k]['vm_offset']
-        port = IPV4_BASE_PORT + vm_offset
-        port6 = IPV6_BASE_PORT + vm_offset
+        port, port6 = get_change_routes_ports(k, topo)
 
         # Routes announced by different M0s are the same, can reuse generated routes
         if m0_routes_v4 is not None:
@@ -1128,9 +1143,7 @@ def fib_m1(topo, ptf_ip, action="announce", topo_routes={}):
     ipv6_base = ipaddress.IPv6Address(UNICODE_TYPE("20c0:a800::0"))
 
     for k, v in vms_config.items():
-        vm_offset = vms[k]['vm_offset']
-        port = IPV4_BASE_PORT + vm_offset
-        port6 = IPV6_BASE_PORT + vm_offset
+        port, port6 = get_change_routes_ports(k, topo)
 
         router_type = None
         if "ma" in v["properties"]:
@@ -1267,9 +1280,7 @@ def fib_ft2_routes(topo, ptf_ip, action="announce", topo_routes={}):
             if vm_index >= len(vms):
                 break
             vm_name = vms[vm_index]
-            vm_offset = topo['topology']['VMs'][vm_name]['vm_offset']
-            port = IPV4_BASE_PORT + vm_offset
-            port6 = IPV6_BASE_PORT + vm_offset
+            port, port6 = get_change_routes_ports(vm_name, topo)
             ipv4_routes = []
             for subnet in group_subnets_ipv4:
                 # Generate IPv4 routes
@@ -1329,9 +1340,7 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce", topo_routes
                 set_num = 0
             else:
                 set_num = 1
-            vm_offset = vms[a_vm]['vm_offset']
-            port = IPV4_BASE_PORT + vm_offset
-            port6 = IPV6_BASE_PORT + vm_offset
+            port, port6 = get_change_routes_ports(a_vm, topo)
             aggregate_prefixes = vms_config[a_vm].get("aggregate_routes", AGGREGATE_ROUTES_DEFAULT_VALUE)
             aggregate_routes = [(prefix, nhipv4 if "." in prefix else nhipv6, "") for prefix in aggregate_prefixes]
             aggregate_routes_v4 = get_ipv4_routes(aggregate_routes)
@@ -1410,9 +1419,7 @@ def fib_t0_mclag(topo, ptf_ip, action="announce", topo_routes={}):
             set_num = 0
         else:
             set_num = 1
-        vm_offset = vms[vm]['vm_offset']
-        port = IPV4_BASE_PORT + vm_offset
-        port6 = IPV6_BASE_PORT + vm_offset
+        port, port6 = get_change_routes_ports(vm, topo)
         aggregate_prefixes = topo['configuration'][vm].get("aggregate_routes", AGGREGATE_ROUTES_DEFAULT_VALUE)
         aggregate_routes = [(prefix, nhipv4 if "." in prefix else nhipv6, "") for prefix in aggregate_prefixes]
         aggregate_routes_v4 = get_ipv4_routes(aggregate_routes)
@@ -1487,7 +1494,7 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
             if group * T1_GROUP_SIZE + vm_index >= len(t1_vms):
                 break
             vm_name = t1_vms[group * T1_GROUP_SIZE + vm_index]
-            vm_offset = topo['topology']['VMs'][vm_name]['vm_offset']
+            port, port6 = get_change_routes_ports(vm_name, topo)
 
             ipv4_routes = []
             ipv6_routes = []
@@ -1502,8 +1509,8 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
             topo_routes[vm_name][IPV4] = ipv4_routes
             topo_routes[vm_name][IPV6] = ipv6_routes
             if action != GENERATE_WITHOUT_APPLY:
-                change_routes(action, ptf_ip, IPV4_BASE_PORT + vm_offset, ipv4_routes)
-                change_routes(action, ptf_ip, IPV6_BASE_PORT + vm_offset, ipv6_routes)
+                change_routes(action, ptf_ip, port, ipv4_routes)
+                change_routes(action, ptf_ip, port6, ipv6_routes)
 
     for device in range(len(ut2_vms)):
         ipv4_routes = [
@@ -1518,7 +1525,7 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
         as_path = "{} {}".format(leaf_asn_start + group, tor_asn_start + group)
 
         vm_name = ut2_vms[device]
-        vm_offset = topo['topology']['VMs'][vm_name]['vm_offset']
+        port, port6 = get_change_routes_ports(vm_name, topo)
 
         ipv4_routes.append((topo['configuration'][vm_name]['interfaces']['Loopback0']['ipv4'], nhipv4, as_path))
         ipv6_routes.append((topo['configuration'][vm_name]['interfaces']['Loopback0']['ipv6'], nhipv6, as_path))
@@ -1528,8 +1535,8 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
         topo_routes[vm_name][IPV4] = ipv4_routes
         topo_routes[vm_name][IPV6] = ipv6_routes
         if action != GENERATE_WITHOUT_APPLY:
-            change_routes(action, ptf_ip, IPV4_BASE_PORT + vm_offset, ipv4_routes)
-            change_routes(action, ptf_ip, IPV6_BASE_PORT + vm_offset, ipv6_routes)
+            change_routes(action, ptf_ip, port, ipv4_routes)
+            change_routes(action, ptf_ip, port6, ipv6_routes)
 
 
 def fib_dpu(topo, ptf_ip, action="announce", topo_routes={}):
@@ -1545,9 +1552,7 @@ def fib_dpu(topo, ptf_ip, action="announce", topo_routes={}):
     all_vms = sorted(vms.keys())
 
     for vm in all_vms:
-        vm_offset = vms[vm]['vm_offset']
-        port = IPV4_BASE_PORT + vm_offset
-        port6 = IPV6_BASE_PORT + vm_offset
+        port, port6 = get_change_routes_ports(vm, topo)
 
         topo_routes[vm] = {}
         topo_routes[vm][IPV4] = routes_v4
@@ -1560,12 +1565,17 @@ def fib_dpu(topo, ptf_ip, action="announce", topo_routes={}):
 def adhoc_routes(topo, ptf_ip, peers_routes_to_change, action):
     vms = topo['topology']['VMs']
 
+    vms = topo['topology']['VMs']
+    if topo.get('topo_is_multi_vrf', False):
+        multi_vrf_data = topo.get('convergence_data', {})
+        vms = []
+        for vrfs in multi_vrf_data['convergence_mapping'].values():
+            vms.extend(vrfs)
+
     for hostname, routes in peers_routes_to_change.items():
         if hostname not in vms:
             continue
-        vm_offset = vms[hostname]['vm_offset']
-        port = IPV4_BASE_PORT + vm_offset
-        port6 = IPV6_BASE_PORT + vm_offset
+        port, port6 = get_change_routes_ports(hostname, topo)
 
         ipv4_routes = [r for r in routes if '.' in r[0]]
         if ipv4_routes and action != GENERATE_WITHOUT_APPLY:

--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -197,7 +197,6 @@ startsecs=1
 numprocs=1
 '''
 
-
 def exec_command(module, cmd, ignore_error=False, msg="executing command"):
     rc, out, err = module.run_command(cmd)
     if not ignore_error and rc != 0:

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -6,6 +6,7 @@ import sys
 import yaml
 import re
 from ansible.module_utils.basic import AnsibleModule
+import itertools
 
 DOCUMENTATION = '''
 module: topo_facts.py
@@ -86,12 +87,26 @@ class ParseTestbedTopoinfo():
     def __init__(self):
         self.vm_topo_config = {}
         self.asic_topo_config = {}
+        self.topo_is_multi_vrf = False
+
+    def get_vm_list(self, topo_definition, neigh_type):
+        if neigh_type == 'VMs' and self.topo_is_multi_vrf:
+            mapping = topo_definition['convergence_data']['convergence_mapping']
+            return list(itertools.chain(*mapping.values()))
+        else:
+            return topo_definition['topology'][neigh_type]
+
+    def get_vlans(self, vm, topo_definition, neigh_type):
+        if neigh_type == 'VMs' and self.topo_is_multi_vrf:
+            return topo_definition['convergence_data']['interface_index_mapping'][vm]
+        else:
+            return topo_definition['topology'][neigh_type][vm]['vlans']
 
     def parse_topo_defintion(self, topo_definition, po_map, dut_num, neigh_type='VMs'):
         vmconfig = dict()
         if topo_definition['topology'][neigh_type] is None:
             return vmconfig
-        for vm in topo_definition['topology'][neigh_type]:
+        for vm in self.get_vm_list(topo_definition, neigh_type):
             vmconfig[vm] = dict()
             vmconfig[vm]['intfs'] = [[] for i in range(dut_num)]
             if 'properties' in vmconfig[vm]:
@@ -105,7 +120,7 @@ class ParseTestbedTopoinfo():
             if neigh_type == 'VMs':
                 vmconfig[vm]['interface_indexes'] = [[]
                                                      for i in range(dut_num)]
-                for vlan in topo_definition['topology'][neigh_type][vm]['vlans']:
+                for vlan in self.get_vlans(vm, topo_definition, neigh_type):
                     (dut_index, vlan_index, _) = parse_vm_vlan_port(vlan)
                     vmconfig[vm]['interface_indexes'][dut_index].append(
                         vlan_index)
@@ -284,6 +299,9 @@ class ParseTestbedTopoinfo():
         if 'dut_num' in topo_definition['topology']:
             dut_num = topo_definition['topology']['dut_num']
         vm_topo_config['dut_num'] = dut_num
+
+        self.topo_is_multi_vrf = topo_definition.get('topo_is_multi_vrf', False)
+        vm_topo_config['topo_is_multi_vrf'] = self.topo_is_multi_vrf
 
         if 'topo_type' in topo_definition['topology']:
             vm_topo_config['topo_type'] = topo_definition['topology']['topo_type']

--- a/ansible/roles/eos/tasks/ceos.yml
+++ b/ansible/roles/eos/tasks/ceos.yml
@@ -38,8 +38,8 @@
     capabilities:
       - net_admin
     privileged: yes
-    memory: 2G
-    memory_swap: 4G
+    memory: "{{ '10G' if use_converged_peers|bool else '2G' }}"
+    memory_swap: "{{ '20G' if use_converged_peers|bool else '4G' }}"
     env:
       CEOS=1
       container=docker

--- a/ansible/roles/eos/templates/t0-isolated-d2u254s1-tor.j2
+++ b/ansible/roles/eos/templates/t0-isolated-d2u254s1-tor.j2
@@ -1,4 +1,10 @@
+{% set converged = topo_is_multi_vrf|default(false) %}
 {% set host = configuration[hostname] %}
+{% if converged %}
+    {% set conv_config = convergence_data["converged_peers"][hostname] %}
+    {% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
+    {% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
+{% endif %}
 {% set mgmt_ip = ansible_host %}
 {% if vm_type is defined and vm_type == "ceos" %}
     {% set mgmt_if_index = 0 %}
@@ -19,8 +25,16 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+{% if converged %}
+vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
+!
+{% endif %}
+vrf instance MGMT
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+vrf instance {{vrf_name}}
+    {% endfor %}
+{% endif %}
 !
 spanning-tree mode mstp
 !
@@ -39,7 +53,17 @@ snmp-server vrf MGMT
 !
 ip routing
 ip routing vrf MGMT
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+ip routing vrf {{vrf_name}}
+    {% endfor %}
+{% endif %}
 ipv6 unicast-routing
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+ipv6 unicast-routing vrf {{vrf_name}}
+    {% endfor %}
+{% endif %}
 !
 {% if disable_ceos_mgmt_gateway is defined and disable_ceos_mgmt_gateway == 'yes'%}
 {% elif vm_mgmt_gw is defined %}
@@ -58,80 +82,188 @@ interface Management {{ mgmt_if_index }}
  ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
  no shutdown
 !
-{% for name, iface in host['interfaces'].items() %}
-interface {{ name }}
-{% if name.startswith('Loopback') %}
- description LOOPBACK
+{% if converged %}
+interface {{ bp_ifname }}
+!
+ description backplane
+ mtu 9214
+ switchport trunk allowed vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
+ switchport mode trunk
+ no shutdown
+!
+    {% for vrf in conv_mapping %}
+        {% for if_name, if_data in conv_config['vrf'][vrf].items() %}
+interface {{ if_name }}
+            {% if if_name.startswith('Vlan') %}
+ description {{ vrf }} backplane
+            {% endif %}
+            {% if if_name.startswith('Loopback') %}
+ description {{ vrf }} LOOPBACK
+            {% endif %}
+            {% if if_name.startswith('Port-Channel') %}
+ port-channel min-links 1
+ mtu 9214
+ no switchport
+            {% endif %}
+            {% if if_name.startswith('Ethernet') %}
+ mtu 9214
+ no switchport
+            {% endif %}
+ vrf {{ vrf }}
+            {% if if_data['lacp'] is defined %}
+ channel-group {{ if_data['lacp'] }} mode active
+ lacp rate normal
+            {% endif %}
+            {% if if_data['ipv4'] is defined %}
+ ip address {{ if_data['ipv4'] }}
+            {% endif %}
+            {% if if_data['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ if_data['ipv6'] }}
+ ipv6 nd ra suppress
+ ipv6 nd dad disabled
+            {% endif %}
+ no shutdown
+!
+        {% endfor %}
+    {% endfor %}
+!
 {% else %}
+    {% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+        {% if name.startswith('Loopback') %}
+ description LOOPBACK
+        {% else %}
  mtu 9214
  no switchport
  no shutdown
-{% endif %}
-{% if iface['ipv4'] is defined %}
+        {% endif %}
+        {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}
-{% endif %}
-{% if iface['ipv6'] is defined %}
+        {% endif %}
+        {% if iface['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ iface['ipv6'] }}
  ipv6 nd ra suppress
-{% endif %}
+        {% endif %}
  no shutdown
 !
-{% endfor %}
+    {% endfor %}
 !
 interface {{ bp_ifname }}
  description backplane
  no switchport
  no shutdown
-{% if host['bp_interface']['ipv4'] is defined %}
+    {% if host['bp_interface']['ipv4'] is defined %}
  ip address {{ host['bp_interface']['ipv4'] }}
-{% endif %}
-{% if host['bp_interface']['ipv6'] is defined %}
+    {% endif %}
+    {% if host['bp_interface']['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ host['bp_interface']['ipv6'] }}
  ipv6 nd ra suppress
-{% endif %}
+    {% endif %}
  no shutdown
 !
+{% endif %}
+{% if converged %}
+router bgp {{ conv_config['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
+    {% for vrf in conv_config['vrf'] %}
+ vrf {{ vrf }}
+        {% set vrf_bgp = configuration[vrf]['bgp'] %}
+        {% set vrf_intfs = conv_config['vrf'][vrf] %}
+        {% set lo_config = vrf_intfs|get_first_loopback %}
+        {% if vrf_bgp['router-id'] is defined %}
+  router-id {{ vrf_bgp['router-id'] }}
+        {% else %}
+            {% if lo_config['ipv4'] is defined %}
+  router-id {{ lo_config['ipv4']|ansible.utils.ipaddr('address') }}
+            {% endif %}
+        {% endif %}
+  graceful-restart restart-time {{ bgp_gr_timer }}
+  graceful-restart
+  local-as {{ vrf_bgp['asn'] }}
+        {% for asn, remote_ips in vrf_bgp['peers'].items() %}
+            {% for remote_ip in remote_ips %}
+  neighbor {{ remote_ip }} remote-as {{ asn }}
+  neighbor {{ remote_ip }} description {{ asn }}
+  neighbor {{ remote_ip }} next-hop-self
+                {% if remote_ip|ipv6 %}
+  address-family ipv6
+   neighbor {{ remote_ip }} activate
+  exit
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+        {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} description exabgp_v4
+        {% endif %}
+        {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} description exabgp_v6
+        {% endif %}
+  address-family ipv4
+        {% if lo_config['ipv4'] is defined %}
+   network {{ lo_config['ipv4'] }}
+        {% endif %}
+  exit
+  address-family ipv6
+   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} activate
+        {% if lo_config['ipv6'] is defined %}
+   network {{ lo_config['ipv6'] }}
+        {% endif %}
+  exit
+ exit
+    {% endfor %}
+{% else %}
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
  !
-{% for asn, remote_ips in host['bgp']['peers'].items() %}
-    {% for remote_ip in remote_ips %}
+    {% for asn, remote_ips in host['bgp']['peers'].items() %}
+        {% for remote_ip in remote_ips %}
  router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] |  ansible.utils.ipaddr('address') }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-        {% if remote_ip | ansible.utils.ipv6 %}
+            {% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit
-        {% endif %}
+            {% endif %}
+        {% endfor %}
     {% endfor %}
-{% endfor %}
-{% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+    {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
  neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv4 }} description exabgp_v4
-{% endif %}
-{% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+    {% endif %}
+    {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
  neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv6 }} description exabgp_v6
  address-family ipv6
   neighbor {{ props.nhipv6 }} activate
  exit
-{% endif %}
+    {% endif %}
  !
-{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
-    {% if iface['ipv4'] is defined %}
+    {% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+        {% if iface['ipv4'] is defined %}
  network {{ iface['ipv4'] }}
-    {% endif %}
-    {% if iface['ipv6'] is defined %}
+        {% endif %}
+        {% if iface['ipv6'] is defined %}
  network {{ iface['ipv6'] }}
-    {% endif %}
-{% endfor %}
+        {% endif %}
+    {% endfor %}
+{% endif %}
 !
 management api http-commands
  no protocol https

--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -1,4 +1,10 @@
+{% set converged = topo_is_multi_vrf|default(false) %}
 {% set host = configuration[hostname] %}
+{% if converged %}
+    {% set conv_config = convergence_data["converged_peers"][hostname] %}
+    {% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
+    {% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
+{% endif %}
 {% set mgmt_ip = ansible_host %}
 {% if vm_type is defined and vm_type == "ceos" %}
     {% set mgmt_if_index = 0 %}
@@ -19,8 +25,16 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+{% if converged %}
+vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
+!
+{% endif %}
+vrf instance MGMT
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+vrf instance {{vrf_name}}
+    {% endfor %}
+{% endif %}
 !
 spanning-tree mode mstp
 !
@@ -39,7 +53,17 @@ snmp-server vrf MGMT
 !
 ip routing
 ip routing vrf MGMT
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+ip routing vrf {{vrf_name}}
+    {% endfor %}
+{% endif %}
 ipv6 unicast-routing
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+ipv6 unicast-routing vrf {{vrf_name}}
+    {% endfor %}
+{% endif %}
 !
 {% if disable_ceos_mgmt_gateway is defined and disable_ceos_mgmt_gateway == 'yes'%}
 {% elif vm_mgmt_gw is defined %}
@@ -58,83 +82,189 @@ interface Management {{ mgmt_if_index }}
  ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
  no shutdown
 !
-{% for name, iface in host['interfaces'].items() %}
+{% if converged %}
+interface {{ bp_ifname }}
+!
+ description backplane
+ mtu 9214
+ switchport trunk allowed vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
+ switchport mode trunk
+ no shutdown
+!
+    {% for vrf in conv_mapping %}
+        {% for if_name, if_data in conv_config['vrf'][vrf].items() %}
+interface {{ if_name }}
+            {% if if_name.startswith('Vlan') %}
+ description {{ vrf }} backplane
+            {% endif %}
+            {% if if_name.startswith('Loopback') %}
+ description {{ vrf }} LOOPBACK
+            {% endif %}
+            {% if if_name.startswith('Port-Channel') %}
+ port-channel min-links 1
+ mtu 9214
+ no switchport
+            {% endif %}
+            {% if if_name.startswith('Ethernet') %}
+ mtu 9214
+ no switchport
+            {% endif %}
+ vrf {{ vrf }}
+            {% if if_data['lacp'] is defined %}
+ channel-group {{ if_data['lacp'] }} mode active
+ lacp rate normal
+            {% endif %}
+            {% if if_data['ipv4'] is defined %}
+ ip address {{ if_data['ipv4'] }}
+            {% endif %}
+            {% if if_data['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ if_data['ipv6'] }}
+ ipv6 nd ra suppress
+ ipv6 nd dad disabled
+            {% endif %}
+ no shutdown
+!
+        {% endfor %}
+    {% endfor %}
+!
+{% else %}
+    {% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
-    {% if name.startswith('Loopback') %}
+        {% if name.startswith('Loopback') %}
  description LOOPBACK
-    {% else %}
+        {% else %}
  mtu 9214
  no switchport
  no shutdown
-    {% endif %}
-    {% if name.startswith('Port-Channel') %}
+        {% endif %}
+        {% if name.startswith('Port-Channel') %}
  port-channel min-links 1
-    {% endif %}
-    {% if iface['lacp'] is defined %}
+        {% endif %}
+        {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
  lacp rate normal
-    {% endif %}
-    {% if iface['ipv4'] is defined %}
+        {% endif %}
+        {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}
-    {% endif %}
-    {% if iface['ipv6'] is defined %}
+        {% endif %}
+        {% if iface['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ iface['ipv6'] }}
  ipv6 nd ra suppress
-    {% endif %}
+        {% endif %}
  no shutdown
 !
-{% endfor %}
+    {% endfor %}
 !
 interface {{ bp_ifname }}
  description backplane
  no switchport
  no shutdown
-{% if host['bp_interface']['ipv4'] is defined %}
+    {% if host['bp_interface']['ipv4'] is defined %}
  ip address {{ host['bp_interface']['ipv4'] }}
-{% endif %}
-{% if host['bp_interface']['ipv6'] is defined %}
+    {% endif %}
+    {% if host['bp_interface']['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ host['bp_interface']['ipv6'] }}
  ipv6 nd ra suppress
-{% endif %}
+    {% endif %}
  no shutdown
 !
+{% endif %}
+{% if converged %}
+router bgp {{ conv_config['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
+    {% for vrf in conv_config['vrf'] %}
+ vrf {{ vrf }}
+        {% set vrf_bgp = configuration[vrf]['bgp'] %}
+        {% set vrf_intfs = conv_config['vrf'][vrf] %}
+        {% set lo_config = vrf_intfs|get_first_loopback %}
+        {% if vrf_bgp['router-id'] is defined %}
+  router-id {{ vrf_bgp['router-id'] }}
+        {% else %}
+            {% if lo_config['ipv4'] is defined %}
+  router-id {{ lo_config['ipv4']|ansible.utils.ipaddr('address') }}
+            {% endif %}
+        {% endif %}
+  local-as {{ vrf_bgp['asn'] }}
+        {% for asn, remote_ips in vrf_bgp['peers'].items() %}
+            {% for remote_ip in remote_ips %}
+  neighbor {{ remote_ip }} remote-as {{ asn }}
+  neighbor {{ remote_ip }} description {{ asn }}
+  neighbor {{ remote_ip }} next-hop-self
+                {% if remote_ip|ipv6 %}
+  address-family ipv6
+   neighbor {{ remote_ip }} activate
+  exit
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+        {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} description exabgp_v4
+        {% endif %}
+        {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} description exabgp_v6
+        {% endif %}
+  address-family ipv4
+        {% if lo_config['ipv4'] is defined %}
+   network {{ lo_config['ipv4'] }}
+        {% endif %}
+  exit
+  address-family ipv6
+   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} activate
+        {% if lo_config['ipv6'] is defined %}
+   network {{ lo_config['ipv6'] }}
+        {% endif %}
+  exit
+ exit
+    {% endfor %}
+{% else %}
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
-{% for asn, remote_ips in host['bgp']['peers'].items() %}
-    {% for remote_ip in remote_ips %}
+    {% for asn, remote_ips in host['bgp']['peers'].items() %}
+        {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-        {% if remote_ip | ansible.utils.ipv6 %}
+            {% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit
-        {% endif %}
+            {% endif %}
+        {% endfor %}
     {% endfor %}
-{% endfor %}
-{% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+    {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
  neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv4 }} description exabgp_v4
-{% endif %}
-{% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+    {% endif %}
+    {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
  neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv6 }} description exabgp_v6
  address-family ipv6
   neighbor {{ props.nhipv6 }} activate
  exit
-{% endif %}
+    {% endif %}
  !
-{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
-    {% if iface['ipv4'] is defined %}
+    {% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+        {% if iface['ipv4'] is defined %}
  network {{ iface['ipv4'] }}
-    {% endif %}
-    {% if iface['ipv6'] is defined %}
+        {% endif %}
+        {% if iface['ipv6'] is defined %}
  network {{ iface['ipv6'] }}
-    {% endif %}
-{% endfor %}
+        {% endif %}
+    {% endfor %}
+{% endif %}
 !
 management api http-commands
  no protocol https

--- a/ansible/roles/eos/templates/t0-v6-leaf.j2
+++ b/ansible/roles/eos/templates/t0-v6-leaf.j2
@@ -1,4 +1,10 @@
+{% set converged = topo_is_multi_vrf|default(false) %}
 {% set host = configuration[hostname] %}
+{% if converged %}
+    {% set conv_config = convergence_data["converged_peers"][hostname] %}
+    {% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
+    {% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
+{% endif %}
 {% set mgmt_ip = ansible_host %}
 {% if vm_type is defined and vm_type == "ceos" %}
     {% set mgmt_if_index = 0 %}
@@ -19,8 +25,16 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+{% if converged %}
+vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
+!
+{% endif %}
+vrf instance MGMT
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+vrf instance {{vrf_name}}
+    {% endfor %}
+{% endif %}
 !
 spanning-tree mode mstp
 !
@@ -39,7 +53,17 @@ snmp-server vrf MGMT
 !
 ip routing
 ip routing vrf MGMT
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+ip routing vrf {{vrf_name}}
+    {% endfor %}
+{% endif %}
 ipv6 unicast-routing
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+ipv6 unicast-routing vrf {{vrf_name}}
+    {% endfor %}
+{% endif %}
 !
 {% if disable_ceos_mgmt_gateway is defined and disable_ceos_mgmt_gateway == 'yes'%}
 {% elif vm_mgmt_gw is defined %}
@@ -58,81 +82,187 @@ interface Management {{ mgmt_if_index }}
  ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
  no shutdown
 !
-{% for name, iface in host['interfaces'].items() %}
+{% if converged %}
+interface {{ bp_ifname }}
+!
+ description backplane
+ mtu 9214
+ switchport trunk allowed vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
+ switchport mode trunk
+ no shutdown
+!
+    {% for vrf in conv_mapping %}
+        {% for if_name, if_data in conv_config['vrf'][vrf].items() %}
+interface {{ if_name }}
+            {% if if_name.startswith('Vlan') %}
+ description {{ vrf }} backplane
+            {% endif %}
+            {% if if_name.startswith('Loopback') %}
+ description {{ vrf }} LOOPBACK
+            {% endif %}
+            {% if if_name.startswith('Port-Channel') %}
+ port-channel min-links 1
+ mtu 9214
+ no switchport
+            {% endif %}
+            {% if if_name.startswith('Ethernet') %}
+ mtu 9214
+ no switchport
+            {% endif %}
+ vrf {{ vrf }}
+            {% if if_data['lacp'] is defined %}
+ channel-group {{ if_data['lacp'] }} mode active
+ lacp rate normal
+            {% endif %}
+            {% if if_data['ipv4'] is defined %}
+ ip address {{ if_data['ipv4'] }}
+            {% endif %}
+            {% if if_data['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ if_data['ipv6'] }}
+ ipv6 nd ra suppress
+ ipv6 nd dad disabled
+            {% endif %}
+ no shutdown
+!
+        {% endfor %}
+    {% endfor %}
+!
+{% else %}
+    {% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
-    {% if name.startswith('Loopback') %}
+        {% if name.startswith('Loopback') %}
  description LOOPBACK
-    {% else %}
+        {% else %}
  mtu 9214
  no switchport
  no shutdown
-    {% endif %}
-    {% if name.startswith('Port-Channel') %}
+        {% endif %}
+        {% if name.startswith('Port-Channel') %}
  port-channel min-links 1
-    {% endif %}
-    {% if iface['lacp'] is defined %}
+        {% endif %}
+        {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
  lacp rate normal
-    {% endif %}
-    {% if iface['ipv4'] is defined %}
+        {% endif %}
+        {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}
-    {% endif %}
-    {% if iface['ipv6'] is defined %}
+        {% endif %}
+        {% if iface['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ iface['ipv6'] }}
  ipv6 nd ra suppress
-    {% endif %}
+        {% endif %}
  no shutdown
 !
-{% endfor %}
+    {% endfor %}
 !
 interface {{ bp_ifname }}
  description backplane
  no switchport
  no shutdown
-{% if host['bp_interface']['ipv4'] is defined %}
+    {% if host['bp_interface']['ipv4'] is defined %}
  ip address {{ host['bp_interface']['ipv4'] }}
-{% endif %}
-{% if host['bp_interface']['ipv6'] is defined %}
+    {% endif %}
+    {% if host['bp_interface']['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ host['bp_interface']['ipv6'] }}
  ipv6 nd ra suppress
-{% endif %}
+    {% endif %}
  no shutdown
 !
+{% endif %}
+{% if converged %}
+router bgp {{ conv_config['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
+    {% for vrf in conv_config['vrf'] %}
+ vrf {{ vrf }}
+        {% set vrf_bgp = configuration[vrf]['bgp'] %}
+        {% set vrf_intfs = conv_config['vrf'][vrf] %}
+        {% set lo_config = vrf_intfs|get_first_loopback %}
+        {% if vrf_bgp['router-id'] is defined %}
+  router-id {{ vrf_bgp['router-id'] }}
+        {% else %}
+            {% if lo_config['ipv4'] is defined %}
+  router-id {{ lo_config['ipv4']|ansible.utils.ipaddr('address') }}
+            {% endif %}
+        {% endif %}
+  local-as {{ vrf_bgp['asn'] }}
+        {% for asn, remote_ips in vrf_bgp['peers'].items() %}
+            {% for remote_ip in remote_ips %}
+  neighbor {{ remote_ip }} remote-as {{ asn }}
+  neighbor {{ remote_ip }} description {{ asn }}
+  neighbor {{ remote_ip }} next-hop-self
+                {% if remote_ip|ipv6 %}
+  address-family ipv6
+   neighbor {{ remote_ip }} activate
+  exit
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+        {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} description exabgp_v4
+        {% endif %}
+        {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} description exabgp_v6
+        {% endif %}
+  address-family ipv4
+        {% if lo_config['ipv4'] is defined %}
+   network {{ lo_config['ipv4'] }}
+        {% endif %}
+  exit
+  address-family ipv6
+   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} activate
+        {% if lo_config['ipv6'] is defined %}
+   network {{ lo_config['ipv6'] }}
+        {% endif %}
+  exit
+ exit
+    {% endfor %}
+{% else %}
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['bgp']['router-id'] | ansible.utils.ipaddr('address') }}
  !
-{% for asn, remote_ips in host['bgp']['peers'].items() %}
-    {% for remote_ip in remote_ips %}
+    {% for asn, remote_ips in host['bgp']['peers'].items() %}
+        {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-        {% if remote_ip | ansible.utils.ipv6 %}
+            {% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit
-        {% endif %}
+            {% endif %}
+        {% endfor %}
     {% endfor %}
-{% endfor %}
-{% if props.nhipv4 is defined %}
+    {% if props.nhipv4 is defined %}
  neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv4 }} description exabgp_v4
-{% endif %}
+    {% endif %}
  neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv6 }} description exabgp_v6
  address-family ipv6
   neighbor {{ props.nhipv6 }} activate
  exit
  !
-{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
-    {% if iface['ipv4'] is defined %}
+    {% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+        {% if iface['ipv4'] is defined %}
  network {{ iface['ipv4'] }}
-    {% endif %}
-    {% if iface['ipv6'] is defined %}
+        {% endif %}
+        {% if iface['ipv6'] is defined %}
  network {{ iface['ipv6'] }}
-    {% endif %}
-{% endfor %}
+        {% endif %}
+    {% endfor %}
+{% endif %}
 !
 management api http-commands
  no protocol https

--- a/ansible/roles/eos/templates/t1-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-lag-spine.j2
@@ -1,4 +1,10 @@
 {% set host = configuration[hostname] %}
+{% set converged = topo_is_multi_vrf|default(false) %}
+{% if converged %}
+    {% set conv_config = convergence_data["converged_peers"][hostname] %}
+    {% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
+    {% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
+{% endif %}
 {% set mgmt_ip = ansible_host %}
 {% if vm_type is defined and vm_type == "ceos" %}
     {% set mgmt_if_index = 0 %}
@@ -19,9 +25,17 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+{% if converged %}
+vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
 !
+{% endif %}
+vrf instance MGMT
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+vrf instance {{vrf_name}}
+    {% endfor %}
+!
+{% endif %}
 spanning-tree mode mstp
 !
 aaa root secret 0 123456
@@ -39,7 +53,17 @@ snmp-server vrf MGMT
 !
 ip routing
 ip routing vrf MGMT
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+ip routing vrf {{vrf_name}}
+    {% endfor %}
+{% endif %}
 ipv6 unicast-routing
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+ipv6 unicast-routing vrf {{vrf_name}}
+    {% endfor %}
+{% endif %}
 !
 {% if disable_ceos_mgmt_gateway is defined and disable_ceos_mgmt_gateway == 'yes'%}
 {% elif vm_mgmt_gw is defined %}
@@ -58,83 +82,189 @@ interface Management {{ mgmt_if_index }}
  ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
  no shutdown
 !
-{% for name, iface in host['interfaces'].items() %}
+{% if converged %}
+interface {{ bp_ifname }}
+!
+ description backplane
+ mtu 9214
+ switchport trunk allowed vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
+ switchport mode trunk
+ no shutdown
+!
+    {% for vrf in conv_mapping %}
+        {% for if_name, if_data in conv_config['vrf'][vrf].items() %}
+interface {{ if_name }}
+            {% if if_name.startswith('Vlan') %}
+ description {{ vrf }} backplane
+            {% endif %}
+            {% if if_name.startswith('Loopback') %}
+ description {{ vrf }} LOOPBACK
+            {% endif %}
+            {% if if_name.startswith('Port-Channel') %}
+ port-channel min-links 1
+ mtu 9214
+ no switchport
+            {% endif %}
+            {% if if_name.startswith('Ethernet') %}
+ mtu 9214
+ no switchport
+            {% endif %}
+ vrf {{ vrf }}
+            {% if if_data['lacp'] is defined %}
+ channel-group {{ if_data['lacp'] }} mode active
+ lacp rate normal
+            {% endif %}
+            {% if if_data['ipv4'] is defined %}
+ ip address {{ if_data['ipv4'] }}
+            {% endif %}
+            {% if if_data['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ if_data['ipv6'] }}
+ ipv6 nd ra suppress
+ ipv6 nd dad disabled
+            {% endif %}
+ no shutdown
+!
+        {% endfor %}
+    {% endfor %}
+!
+{% else %}
+    {% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
-    {% if name.startswith('Loopback') %}
+        {% if name.startswith('Loopback') %}
  description LOOPBACK
-    {% else %}
+        {% else %}
  mtu 9214
  no switchport
  no shutdown
-    {% endif %}
-    {% if name.startswith('Port-Channel') %}
+        {% endif %}
+        {% if name.startswith('Port-Channel') %}
  port-channel min-links 2
-    {% endif %}
-    {% if iface['lacp'] is defined %}
+        {% endif %}
+        {% if iface['lacp'] is defined %}
  channel-group {{ iface['lacp'] }} mode active
  lacp rate normal
-    {% endif %}
-    {% if iface['ipv4'] is defined %}
+        {% endif %}
+        {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}
-    {% endif %}
-    {% if iface['ipv6'] is defined %}
+        {% endif %}
+        {% if iface['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ iface['ipv6'] }}
  ipv6 nd ra suppress
-    {% endif %}
+        {% endif %}
  no shutdown
 !
-{% endfor %}
+    {% endfor %}
 !
 interface {{ bp_ifname }}
  description backplane
  no switchport
  no shutdown
-{% if host['bp_interface']['ipv4'] is defined %}
+    {% if host['bp_interface']['ipv4'] is defined %}
  ip address {{ host['bp_interface']['ipv4'] }}
-{% endif %}
-{% if host['bp_interface']['ipv6'] is defined %}
+    {% endif %}
+    {% if host['bp_interface']['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ host['bp_interface']['ipv6'] }}
  ipv6 nd ra suppress
-{% endif %}
+    {% endif %}
  no shutdown
 !
+{% endif %}
+{% if converged %}
+router bgp {{ conv_config['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
+    {% for vrf in conv_config['vrf'] %}
+ vrf {{ vrf }}
+        {% set vrf_bgp = configuration[vrf]['bgp'] %}
+        {% set vrf_intfs = conv_config['vrf'][vrf] %}
+        {% set lo_config = vrf_intfs|get_first_loopback %}
+        {% if vrf_bgp['router-id'] is defined %}
+  router-id {{ vrf_bgp['router-id'] }}
+        {% else %}
+            {% if lo_config['ipv4'] is defined %}
+  router-id {{ lo_config['ipv4']|ansible.utils.ipaddr('address') }}
+            {% endif %}
+        {% endif %}
+  local-as {{ vrf_bgp['asn'] }}
+        {% for asn, remote_ips in vrf_bgp['peers'].items() %}
+            {% for remote_ip in remote_ips %}
+  neighbor {{ remote_ip }} remote-as {{ asn }}
+  neighbor {{ remote_ip }} description {{ asn }}
+  neighbor {{ remote_ip }} next-hop-self
+                {% if remote_ip|ipv6 %}
+  address-family ipv6
+   neighbor {{ remote_ip }} activate
+  exit
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+        {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} description exabgp_v4
+        {% endif %}
+        {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} description exabgp_v6
+        {% endif %}
+  address-family ipv4
+        {% if lo_config['ipv4'] is defined %}
+   network {{ lo_config['ipv4'] }}
+        {% endif %}
+  exit
+  address-family ipv6
+   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} activate
+        {% if lo_config['ipv6'] is defined %}
+   network {{ lo_config['ipv6'] }}
+        {% endif %}
+  exit
+ exit
+    {% endfor %}
+{% else %}
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
-{% for asn, remote_ips in host['bgp']['peers'].items() %}
-    {% for remote_ip in remote_ips %}
+    {% for asn, remote_ips in host['bgp']['peers'].items() %}
+        {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-        {% if remote_ip | ansible.utils.ipv6 %}
+            {% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit
-        {% endif %}
+            {% endif %}
+        {% endfor %}
     {% endfor %}
-{% endfor %}
-{% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+    {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
  neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv4 }} description exabgp_v4
-{% endif %}
-{% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+    {% endif %}
+    {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
  neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv6 }} description exabgp_v6
  address-family ipv6
   neighbor {{ props.nhipv6 }} activate
  exit
-{% endif %}
+    {% endif %}
  !
-{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
-    {% if iface['ipv4'] is defined %}
+    {% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+        {% if iface['ipv4'] is defined %}
  network {{ iface['ipv4'] }}
-    {% endif %}
-    {% if iface['ipv6'] is defined %}
+        {% endif %}
+        {% if iface['ipv6'] is defined %}
  network {{ iface['ipv6'] }}
-    {% endif %}
-{% endfor %}
+        {% endif %}
+    {% endfor %}
+{% endif %}
 !
 management api http-commands
  no protocol https

--- a/ansible/roles/eos/templates/t1-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-lag-tor.j2
@@ -1,4 +1,10 @@
 {% set host = configuration[hostname] %}
+{% set converged = topo_is_multi_vrf|default(false) %}
+{% if converged %}
+    {% set conv_config = convergence_data["converged_peers"][hostname] %}
+    {% set conv_mapping = convergence_data["convergence_mapping"][hostname] %}
+    {% set ptf_bp_addrs = convergence_data["ptf_backplane_addrs"] %}
+{% endif %}
 {% set mgmt_ip = ansible_host %}
 {% if vm_type is defined and vm_type == "ceos" %}
     {% set mgmt_if_index = 0 %}
@@ -19,9 +25,17 @@ agent Bfd shutdown
 !
 hostname {{ hostname }}
 !
-vrf definition MGMT
- rd 1:1
+{% if converged %}
+vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
 !
+{% endif %}
+vrf instance MGMT
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+vrf instance {{vrf_name}}
+    {% endfor %}
+!
+{% endif %}
 spanning-tree mode mstp
 !
 aaa root secret 0 123456
@@ -39,7 +53,17 @@ snmp-server vrf MGMT
 !
 ip routing
 ip routing vrf MGMT
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+ip routing vrf {{vrf_name}}
+    {% endfor %}
+{% endif %}
 ipv6 unicast-routing
+{% if converged %}
+    {% for vrf_name in conv_config['vrf'] %}
+ipv6 unicast-routing vrf {{vrf_name}}
+    {% endfor %}
+{% endif %}
 !
 {% if disable_ceos_mgmt_gateway is defined and disable_ceos_mgmt_gateway == 'yes'%}
 {% elif vm_mgmt_gw is defined %}
@@ -58,80 +82,179 @@ interface Management {{ mgmt_if_index }}
  ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
  no shutdown
 !
-{% for name, iface in host['interfaces'].items() %}
+{% if converged %}
+interface {{ bp_ifname }}
+!
+ description backplane
+ mtu 9214
+ switchport trunk allowed vlan {{ ptf_bp_addrs|allowed_vlans_range_str(conv_mapping) }}
+ switchport mode trunk
+ no shutdown
+!
+    {% for vrf in conv_mapping %}
+        {% for if_name, if_data in conv_config['vrf'][vrf].items() %}
+interface {{ if_name }}
+            {% if if_name.startswith('Vlan') %}
+ description {{ vrf }} backplane
+            {% endif %}
+            {% if if_name.startswith('Loopback') %}
+ description {{ vrf }} LOOPBACK
+            {% endif %}
+            {% if if_name.startswith('Ethernet') %}
+ mtu 9214
+ no switchport
+            {% endif %}
+ vrf {{ vrf }}
+            {% if if_data['ipv4'] is defined %}
+ ip address {{ if_data['ipv4'] }}
+            {% endif %}
+            {% if if_data['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ if_data['ipv6'] }}
+ ipv6 nd ra suppress
+ ipv6 nd dad disabled
+            {% endif %}
+ no shutdown
+!
+        {% endfor %}
+    {% endfor %}
+!
+{% else %}
+    {% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
-    {% if name.startswith('Loopback') %}
+        {% if name.startswith('Loopback') %}
  description LOOPBACK
-    {% else %}
+        {% else %}
  mtu 9214
  no switchport
  no shutdown
-    {% endif %}
-    {% if iface['ipv4'] is defined %}
+        {% endif %}
+        {% if iface['ipv4'] is defined %}
  ip address {{ iface['ipv4'] }}
-    {% endif %}
-    {% if iface['ipv6'] is defined %}
+        {% endif %}
+        {% if iface['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ iface['ipv6'] }}
  ipv6 nd ra suppress
-    {% endif %}
+        {% endif %}
  no shutdown
 !
-{% endfor %}
+    {% endfor %}
 !
 interface {{ bp_ifname }}
  description backplane
  no switchport
  no shutdown
-{% if host['bp_interface']['ipv4'] is defined %}
+    {% if host['bp_interface']['ipv4'] is defined %}
  ip address {{ host['bp_interface']['ipv4'] }}
-{% endif %}
-{% if host['bp_interface']['ipv6'] is defined %}
+    {% endif %}
+    {% if host['bp_interface']['ipv6'] is defined %}
  ipv6 enable
  ipv6 address {{ host['bp_interface']['ipv6'] }}
  ipv6 nd ra suppress
-{% endif %}
+    {% endif %}
  no shutdown
+{% endif %}
 !
+{% if converged %}
+router bgp {{ conv_config['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
+    {% for vrf in conv_config['vrf'] %}
+ vrf {{ vrf }}
+        {% set vrf_bgp = configuration[vrf]['bgp'] %}
+        {% set vrf_intfs = conv_config['vrf'][vrf] %}
+        {% set lo_config = vrf_intfs|get_first_loopback %}
+  graceful-restart restart-time {{ bgp_gr_timer }}
+  graceful-restart
+        {% if vrf_bgp['router-id'] is defined %}
+  router-id {{ vrf_bgp['router-id'] }}
+        {% else %}
+            {% if lo_config['ipv4'] is defined %}
+  router-id {{ lo_config['ipv4']|ansible.utils.ipaddr('address') }}
+            {% endif %}
+        {% endif %}
+  local-as {{ vrf_bgp['asn'] }}
+        {% for asn, remote_ips in vrf_bgp['peers'].items() %}
+            {% for remote_ip in remote_ips %}
+  neighbor {{ remote_ip }} remote-as {{ asn }}
+  neighbor {{ remote_ip }} description {{ asn }}
+  neighbor {{ remote_ip }} next-hop-self
+                {% if remote_ip|ipv6 %}
+  address-family ipv6
+   neighbor {{ remote_ip }} activate
+  exit
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+        {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv4'] | ansible.utils.ipaddr('address') }} description exabgp_v4
+        {% endif %}
+        {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} remote-as {{ vrf_bgp['asn'] }}
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} next-hop-peer
+  neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} description exabgp_v6
+        {% endif %}
+  address-family ipv4
+        {% if lo_config['ipv4'] is defined %}
+   network {{ lo_config['ipv4'] }}
+        {% endif %}
+  exit
+  address-family ipv6
+   neighbor {{ ptf_bp_addrs[vrf]['ipv6'] | ansible.utils.ipaddr('address') }} activate
+        {% if lo_config['ipv6'] is defined %}
+   network {{ lo_config['ipv6'] }}
+        {% endif %}
+  exit
+ exit
+    {% endfor %}
+{% else %}
 router bgp {{ host['bgp']['asn'] }}
+ vrf MGMT
+  rd 1:1
+ exit
  router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
  !
  graceful-restart restart-time {{ bgp_gr_timer }}
  graceful-restart
  !
-{% for asn, remote_ips in host['bgp']['peers'].items() %}
-    {% for remote_ip in remote_ips %}
+    {% for asn, remote_ips in host['bgp']['peers'].items() %}
+        {% for remote_ip in remote_ips %}
  router-id {{ host['bgp']['router-id'] if host['bgp']['router-id'] is defined else host['interfaces']['Loopback0']['ipv4'] |  ansible.utils.ipaddr('address') }}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
  neighbor {{ remote_ip }} next-hop-self
-        {% if remote_ip | ansible.utils.ipv6 %}
+            {% if remote_ip | ansible.utils.ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate
  exit
-        {% endif %}
+            {% endif %}
+        {% endfor %}
     {% endfor %}
-{% endfor %}
-{% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
+    {% if props.enable_ipv4_routes_generation is not defined or props.enable_ipv4_routes_generation %}
  neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv4 }} description exabgp_v4
-{% endif %}
-{% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
+    {% endif %}
+    {% if props.enable_ipv6_routes_generation is not defined or props.enable_ipv6_routes_generation %}
  neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv6 }} description exabgp_v6
  address-family ipv6
   neighbor {{ props.nhipv6 }} activate
  exit
-{% endif %}
+    {% endif %}
  !
-{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
-    {% if iface['ipv4'] is defined %}
+    {% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+        {% if iface['ipv4'] is defined %}
  network {{ iface['ipv4'] }}
-    {% endif %}
-    {% if iface['ipv6'] is defined %}
+        {% endif %}
+        {% if iface['ipv6'] is defined %}
  network {{ iface['ipv6'] }}
-    {% endif %}
-{% endfor %}
+        {% endif %}
+    {% endfor %}
+{% endif %}
 !
 management api http-commands
  no protocol https

--- a/ansible/roles/vm_set/library/ceos_network.py
+++ b/ansible/roles/vm_set/library/ceos_network.py
@@ -369,6 +369,7 @@ def main():
             fp_mtu=dict(required=False, type='int', default=DEFAULT_MTU),
             max_fp_num=dict(required=False, type='int',
                             default=NUM_FP_VLANS_PER_FP),
+            vm_server_ip=dict(required=False, type='str'),
         ),
         supports_check_mode=False)
 

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -570,6 +570,37 @@ class VMTopology(object):
         self.add_ip_to_docker_if(BP_PORT_NAME, mgmt_ip, mgmt_ipv6)
         VMTopology.iface_disable_txoff(BP_PORT_NAME, self.pid)
 
+    def add_bp_port_with_vlans_to_docker(self, vlan_data, vrf_map, multi_vrf_config):
+        rev_vrf_map = {}
+        for peer, vrfs in vrf_map.items():
+            for vrf in vrfs:
+                rev_vrf_map[vrf] = peer
+
+        self.add_br_if_to_docker(
+            self.bp_bridge, PTF_BP_IF_TEMPLATE % self.vm_set_name, BP_PORT_NAME)
+
+        for vrf, data in vlan_data.items():
+            vlan_id = data.get("vlan")
+            addr = data.get("ipv4")
+            addr6 = data.get("ipv6")
+
+            if vlan_id:
+                peer = rev_vrf_map[vrf]
+                vlan_intf_name = "%s.%d" % (BP_PORT_NAME, vlan_id)
+                config = multi_vrf_config[peer]["vrf"][vrf]["Vlan{}".format(vlan_id)]
+                VMTopology.cmd("nsenter -t %s -n ip link add link %s name %s type vlan id %d" %
+                               (self.pid, BP_PORT_NAME, vlan_intf_name, vlan_id))
+                if addr:
+                    VMTopology.cmd(
+                        "nsenter -t %s -n ip address add %s dev %s" % (self.pid, addr, vlan_intf_name))
+                if addr6:
+                    VMTopology.cmd(
+                        "nsenter -t %s -n ip -6 address add %s dev %s" % (self.pid, addr6, vlan_intf_name))
+
+                VMTopology.iface_up(vlan_intf_name, pid=self.pid)
+
+        VMTopology.iface_disable_txoff(BP_PORT_NAME, self.pid)
+
     def add_br_if_to_docker(self, bridge, ext_if, int_if):
         # add unique suffix to int_if to support multiple tasks run concurrently
         tmp_int_if = int_if + \
@@ -2219,6 +2250,9 @@ def main():
                                      default=max(MIN_THREAD_WORKER_COUNT,
                                                  multiprocessing.cpu_count() // 8)),
             batch_mode=dict(required=False, type='bool', default=False)
+            multi_vrf=dict(required=False, type='bool', default=False),
+            multi_vrf_data=dict(required=False, type='dict', default={}),
+            topo_config=dict(required=False, type='dict', default={}),
         ),
         supports_check_mode=False)
 
@@ -2262,7 +2296,10 @@ def main():
                                   'ptf_bp_ip_addr',
                                   'ptf_bp_ipv6_addr',
                                   'mgmt_bridge',
-                                  'duts_fp_ports'], cmd)
+                                  'duts_fp_ports',
+                                  'multi_vrf',
+                                  'multi_vrf_data',
+                                  'topo_config'], cmd)
 
             vm_set_name = module.params['vm_set_name']
             duts_fp_ports = module.params['duts_fp_ports']
@@ -2292,6 +2329,9 @@ def main():
             ptf_extra_mgmt_ip_addr = module.params['ptf_extra_mgmt_ip_addr']
             mgmt_bridge = module.params['mgmt_bridge']
             netns_mgmt_ip_addr = module.params['netns_mgmt_ip_addr']
+            is_multi_vrf = module.params['multi_vrf']
+            multi_vrf_data = module.params['multi_vrf_data']
+            config = module.params['topo_config']
 
             # Add management port to PTF docker and configure IP
             net.add_mgmt_port_to_docker(mgmt_bridge, ptf_mgmt_ip_addr, ptf_mgmt_ip_gw,
@@ -2311,7 +2351,13 @@ def main():
                 net.add_injected_VM_ports_to_docker()
                 net.bind_fp_ports(batch_mode=batch_mode)
                 net.bind_vm_backplane()
-                net.add_bp_port_to_docker(ptf_bp_ip_addr, ptf_bp_ipv6_addr)
+                if is_multi_vrf:
+                    vlan_data = multi_vrf_data.get("ptf_backplane_addrs", {})
+                    vrf_map = multi_vrf_data.get("convergence_mapping", {})
+                    multi_vrf_config = multi_vrf_data.get("converged_peers", {})
+                    net.add_bp_port_with_vlans_to_docker(vlan_data, vrf_map, multi_vrf_config)
+                else:
+                    net.add_bp_port_to_docker(ptf_bp_ip_addr, ptf_bp_ipv6_addr)
 
             if net.netns:
                 net.add_network_namespace()

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -2249,7 +2249,7 @@ def main():
             thread_worker_count=dict(required=False, type='int',
                                      default=max(MIN_THREAD_WORKER_COUNT,
                                                  multiprocessing.cpu_count() // 8)),
-            batch_mode=dict(required=False, type='bool', default=False)
+            batch_mode=dict(required=False, type='bool', default=False),
             multi_vrf=dict(required=False, type='bool', default=False),
             multi_vrf_data=dict(required=False, type='dict', default={}),
             topo_config=dict(required=False, type='dict', default={}),
@@ -2406,6 +2406,9 @@ def main():
             duts_fp_ports = module.params['duts_fp_ports']
             duts_name = module.params['duts_name']
             is_multi_duts = True if len(duts_name) > 1 else False
+            is_multi_vrf = module.params['multi_vrf']
+            multi_vrf_data = module.params['multi_vrf_data']
+            config = module.params['topo_config']
 
             if len(vm_set_name) > VM_SET_NAME_MAX_LEN:
                 raise Exception("vm_set_name can't be longer than %d characters: %s (%d)" % (

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -240,6 +240,9 @@
       max_fp_num: "{{ max_fp_num }}"
       netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
       dut_interfaces: "{{ dut_interfaces | default('') }}"
+      multi_vrf: "{{ topo_is_multi_vrf }}"
+      multi_vrf_data: "{{ convergence_data|default({}) }}"
+      topo_config: "{{ configuration }}"
       batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
     become: yes
     when: not enable_async

--- a/ansible/roles/vm_set/tasks/announce_routes.yml
+++ b/ansible/roles/vm_set/tasks/announce_routes.yml
@@ -18,6 +18,16 @@
 - name: Get VMs information
   set_fact:
     topo_vms: "{{ topology['VMs'] | get_vms_by_dut_interfaces(dut_interfaces | default('')) }}"
+  when: convergence_data is not defined
+
+- name: Get VMs (multi-vrf) information
+  set_fact:
+    topo_vms: "{{ configuration }}"
+  when: convergence_data is defined
+
+- name: Save multi-vrf vm offset mapping, if they exist
+  set_fact:
+    vm_offsets: "{{ convergence_data['vm_offset_mapping']|default({}) }}"
 
 - block:
   - name: Configure and start exabpg process for IPV4
@@ -31,12 +41,12 @@
       exabgp:
         name: "{{ vm_item.key }}"
         state: "configure"
-        router_id: "{{ ptf_local_ipv4 }}"
-        local_ip: "{{ ptf_local_ipv4 }}"
-        peer_ip: "{{ configuration[vm_item.key].bp_interface.ipv4.split('/')[0] }}"
+        router_id: "{{ vm_item.key|get_exabgp_router_id(convergence_data|default({}))|default(ptf_local_ipv4, true) }}"
+        local_ip: "{{ vm_item.key|get_exabgp_local_ip_v4(convergence_data|default({}))|default(ptf_local_ipv4, true) }}"
+        peer_ip: "{{ vm_item.key|get_exabgp_peer_v4(convergence_data|default({}))|default(configuration[vm_item.key].bp_interface.ipv4.split('/')[0], true) }}"
         local_asn: "{{ configuration[vm_item.key].bgp.asn }}"
         peer_asn: "{{ configuration[vm_item.key].bgp.asn }}"
-        port: "{{ 5000 + vm_item.value.vm_offset|int }}"
+        port: "{{ vm_item.key|get_exabgp_v4_port(topology, vm_offsets|default({}))|int }}"
       loop: "{{ topo_vms|dict2items }}"
       loop_control:
         loop_var: vm_item
@@ -63,7 +73,7 @@
     - name: Verify that exabgp processes for IPv4 are started
       wait_for:
         host: "{{ ptf_host_ip }}"
-        port: "{{ 5000 + topo_vms[vm_item.key].vm_offset|int }}"
+        port: "{{ vm_item.key|get_exabgp_v4_port(topology, vm_offsets|default({}))|int }}"
         state: "started"
         timeout: 180
       loop: "{{ topo_vms|dict2items }}"
@@ -78,16 +88,19 @@
     - set_fact:
         ptf_local_ipv6: "{{ configuration_properties.common.nhipv6|default('fc0a::ff') }}"
 
+    - set_fact:
+        ptf_router_id: "{{ configuration_properties.common.nhipv4|default('10.10.246.254') }}"
+
     - name: configure exabgp processes for IPv6 on PTF
       exabgp:
         name: "{{ vm_item.key }}-v6"
         state: "configure"
-        router_id: "{{ configuration_properties.common.nhipv4|default('10.10.246.254') }}"
-        local_ip: "{{ ptf_local_ipv6 }}"
-        peer_ip: "{{ configuration[vm_item.key].bp_interface.ipv6.split('/')[0] }}"
+        router_id: "{{ vm_item.key|get_exabgp_router_id(convergence_data|default({}))|default(ptf_router_id, true) }}"
+        local_ip: "{{ vm_item.key|get_exabgp_local_ip_v6(convergence_data|default({}))|default(ptf_local_ipv6, true) }}"
+        peer_ip: "{{ vm_item.key | get_exabgp_peer_v6(convergence_data|default({})) | default(configuration[vm_item.key].bp_interface.ipv6.split('/')[0], true) }}"
         local_asn: "{{ configuration[vm_item.key].bgp.asn }}"
         peer_asn: "{{ configuration[vm_item.key].bgp.asn }}"
-        port: "{{ 6000 + vm_item.value.vm_offset|int }}"
+        port: "{{ vm_item.key|get_exabgp_v6_port(topology, vm_offsets|default({}))|int }}"
       loop: "{{ topo_vms|dict2items }}"
       loop_control:
         loop_var: vm_item
@@ -114,7 +127,7 @@
     - name: Verify that exabgp processes for IPv6 are started
       wait_for:
         host: "{{ ptf_host_ip }}"
-        port: "{{ 6000 + vm_item.value.vm_offset|int }}"
+        port: "{{ vm_item.key|get_exabgp_v6_port(topology, vm_offsets|default({}))|int }}"
         state: "started"
         timeout: 180
       loop: "{{ topo_vms|dict2items }}"

--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -363,6 +363,11 @@
     vm_type: "ceos"
   when: vm_type is not defined
 
+- name: Set default value for topo_is_multi_vrf
+  set_fact:
+    topo_is_multi_vrf: False
+  when: topo_is_multi_vrf is not defined
+
 - name: Check VM type
   fail:
     msg: "Cannot support this VM type {{ vm_type }}"

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -142,7 +142,7 @@ function read_yaml
 
   tb_line=${tb_lines[0]}
   line_arr=($1)
-  for attr in group-name topo ptf_image_name ptf ptf_ip ptf_ipv6 ptf_extra_mgmt_ip netns_mgmt_ip server vm_base dut inv_name auto_recover comment servers upstream_neighbor_groups downstream_neighbor_groups;
+  for attr in group-name topo ptf_image_name ptf ptf_ip ptf_ipv6 ptf_extra_mgmt_ip netns_mgmt_ip server vm_base dut inv_name auto_recover comment servers upstream_neighbor_groups downstream_neighbor_groups use_converged_peers;
   do
     value=$(python -c "from __future__ import print_function; tb=eval(\"$tb_line\"); print(tb.get('$attr', None))")
     [ "$value" == "None" ] && value=
@@ -168,6 +168,7 @@ function read_yaml
   servers=${line_arr[15]}
   upstream_neighbor_groups=${line_arr[16]}
   downstream_neighbor_groups=${line_arr[17]}
+  use_converged_peers=${line_arr[18]}
   # Remove the dpu duts by the keyword 'dpu' in the dut name
   duts=$(echo $duts | sed "s/,[^,]*dpu[^,]*//g")
 }
@@ -322,6 +323,7 @@ function add_topo
           -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" \
           -e ptf_extra_mgmt_ip="$ptf_extra_mgmt_ip" -e netns_mgmt_ip="$netns_mgmt_ip" \
           -e upstream_neighbor_groups="$upstream_neighbor_groups" -e downstream_neighbor_groups="$downstream_neighbor_groups" \
+          -e use_converged_peers="$use_converged_peers" \
           $ansible_options $@
 
     if [ $i -eq 0 ]; then

--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -144,6 +144,10 @@
         - name: Load topo variables
           include_vars: "vars/topo_{{ topo }}.yml"
 
+        - name: Set default value for topo_is_multi_vrf
+          set_fact: topo_is_multi_vrf=False
+          when: topo_is_multi_vrf is not defined
+
         - name: Find current server group
           set_fact: current_server={{ group_names | extract_by_prefix('server_') }}
 

--- a/ansible/testbed_announce_routes.yml
+++ b/ansible/testbed_announce_routes.yml
@@ -39,5 +39,9 @@
   - name: Load topo variables
     include_vars: "vars/topo_{{ topo }}.yml"
 
+  - name: Set default value for topo_is_multi_vrf
+    set_fact: topo_is_multi_vrf=False
+    when: topo_is_multi_vrf is not defined
+
   tasks:
   - include_tasks: roles/vm_set/tasks/announce_routes.yml

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -382,8 +382,9 @@ def check_routes_on_from_neighbor(setup_info, nbrhosts):
     downstream = setup_info['downstream']
     for prefixes in list(PREFIX_LISTS.values()):
         for prefix in prefixes:
-            downstream_route = nbrhosts[downstream]['host'].get_route(prefix)
-            route_entries = downstream_route['vrfs']['default']['bgpRouteEntries']
+            vrf = downstream if nbrhosts[downstream].get('is_multi_vrf_peer', False) else 'default'
+            downstream_route = nbrhosts[downstream]['host'].get_route(prefix, vrf=vrf)
+            route_entries = downstream_route['vrfs'][vrf]['bgpRouteEntries']
             pytest_assert(prefix in route_entries, 'Announced route {} not found on {}'.format(prefix, downstream))
 
 
@@ -411,7 +412,8 @@ def check_routes_on_neighbors_empty_allow_list(nbrhosts, setup, permit=True):
         for list_name, prefixes in list(PREFIX_LISTS.items()):
             for prefix in prefixes:
                 prefix_result = {'failed': False, 'prefix': prefix, 'reasons': []}
-                neigh_route = nbrhosts[node]['host'].get_route(prefix)['vrfs']['default']['bgpRouteEntries']
+                vrf = node if nbrhosts[node].get('is_multi_vrf_peer', False) else 'default'
+                neigh_route = nbrhosts[node]['host'].get_route(prefix, vrf=vrf)['vrfs'][vrf]['bgpRouteEntries']
 
                 if permit:
                     # All routes should be forwarded
@@ -464,7 +466,8 @@ def check_routes_on_neighbors(nbrhosts, setup, permit=True):
         for list_name, prefixes in list(PREFIX_LISTS.items()):
             for prefix in prefixes:
                 prefix_result = {'failed': False, 'prefix': prefix, 'reasons': []}
-                neigh_route = nbrhosts[node]['host'].get_route(prefix)['vrfs']['default']['bgpRouteEntries']
+                vrf = node if nbrhosts[node].get('is_multi_vrf_peer', False) else 'default'
+                neigh_route = nbrhosts[node]['host'].get_route(prefix, vrf=vrf)['vrfs'][vrf]['bgpRouteEntries']
 
                 if permit:
                     # All routes should be forwarded
@@ -555,11 +558,26 @@ def restart_bgp_session(duthost):
     duthost.shell('vtysh -c "clear bgp *"')
 
 
-def get_ptf_recv_port(duthost, vm_name, tbinfo):
+def get_ptf_recv_port(duthost, vm_name, tbinfo, multi_vrf_topo=False):
     """
     Get ptf receive port
     """
-    port = duthost.shell("show lldp table | grep -w {} | awk '{{print $1}}'".format(vm_name))['stdout']
+    if multi_vrf_topo:
+        # When using multi-vrf topologies, the vm_name alone is not unique enough to be used as an
+        # index into the lldp table.  In this scenario, only the host container is listed by name,
+        # with multiple interfaces. So, in order to get the right dut interface, we need to figure
+        # out which host and interface are being used for the passed peer.  The POSIX string for
+        # whitespace is used to avoid python escaping backslashes in the pattern.
+        vrf_data = tbinfo["topo"]["properties"]["convergence_data"]
+        host_map = { vrf: host for host, vrfs in vrf_data["convergence_mapping"].items() for vrf in vrfs }
+        host = host_map[vm_name]
+        peer_config = vrf_data["converged_peers"][host]["vrf"][vm_name]
+        host_if = [k for k in peer_config.keys() if "Ethernet" in k][0]
+        pattern = "{}[[:space:]]*{}".format(host, host_if)
+    else:
+        pattern = vm_name
+
+    port = duthost.shell("show lldp table | grep -w {} | awk '{{print $1}}'".format(pattern))['stdout']
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     return mg_facts['minigraph_ptf_indices'][port]
 
@@ -578,14 +596,18 @@ def get_vm_offset(duthost, nbrhosts, tbinfo, is_random=True):
     """
     Get ports offset of exabgp and ptf receive port
     """
+    multi_vrf_topo = tbinfo["topo"]["properties"].get("topo_is_multi_vrf", False)
     port_offset_ptf_recv_port_list = []
     vm_name_list = [vm_name for vm_name in nbrhosts.keys() if vm_name.endswith('T0')]
     logging.info("get_vm_offset ---------")
     if is_random:
         vm_name_list = [random.choice(vm_name_list)]
     for vm_name in vm_name_list:
-        port_offset = tbinfo['topo']['properties']['topology']['VMs'][vm_name]['vm_offset']
-        ptf_recv_port = get_ptf_recv_port(duthost, vm_name, tbinfo)
+        if multi_vrf_topo:
+            port_offset = tbinfo['topo']['properties']['convergence_data']['vm_offset_mapping'][vm_name]
+        else:
+            port_offset = tbinfo['topo']['properties']['topology']['VMs'][vm_name]['vm_offset']
+        ptf_recv_port = get_ptf_recv_port(duthost, vm_name, tbinfo, multi_vrf_topo=multi_vrf_topo)
         logging.info("vm_offset of {} is: {}".format(vm_name, port_offset))
         port_offset_ptf_recv_port_list.append((port_offset, ptf_recv_port))
     return port_offset_ptf_recv_port_list
@@ -605,7 +627,11 @@ def get_vm_name_list(tbinfo, vm_level='T2'):
     Get vm name, default return value would be T2 VM name
     """
     vm_name_list = []
-    for vm in tbinfo['topo']['properties']['topology']['VMs'].keys():
+    if tbinfo.get('use_converged_peers', False):
+        vms = list(tbinfo['topo']['properties']['configuration'].keys())
+    else:
+        vms = list(tbinfo['topo']['properties']['topology']['VMs'].keys())
+    for vm in vms:
         if vm[-2:] == vm_level:
             vm_name_list.append(vm)
     return vm_name_list
@@ -712,16 +738,20 @@ def check_route_install_status(duthost, route, vrf=DEFAULT, ip_ver=IP_VER, check
                           "Vrf:{} - route:{} is installed into FIB".format(vrf, route))
 
 
-def check_propagate_route(vmhost, route_list, bgp_neighbor, ip_ver=IP_VER, action=ACTION_IN):
+def check_propagate_route(vmhost, route_list, bgp_neighbor, ip_ver=IP_VER, action=ACTION_IN, vrf=DEFAULT):
     """
     Check whether ipv4 or ipv6 route is advertised to T2 VM
     """
+    vrf = DEFAULT
+    if vmhost.get('is_multi_vrf_peer', False):
+        vrf = vmhost['multi_vrf_data']['vrf']
+
     if ip_ver == IP_VER:
-        logging.info('Execute EOS command - "show ip bgp neighbors {} routes"'.format(bgp_neighbor))
-        out = vmhost['host'].eos_command(commands=['show ip bgp neighbors {} routes'.format(bgp_neighbor)])['stdout'][0]
+        logging.info('Execute EOS command - "show ip bgp neighbors {} routes vrf {}"'.format(bgp_neighbor, vrf))
+        out = vmhost['host'].eos_command(commands=['show ip bgp neighbors {} routes vrf {}'.format(bgp_neighbor, vrf)])['stdout'][0]
     else:
-        logging.info('Execute EOS command - "show ipv6 bgp peers {} routes"'.format(bgp_neighbor))
-        out = vmhost['host'].eos_command(commands=['show ipv6 bgp peers {} routes'.format(bgp_neighbor)])['stdout'][0]
+        logging.info('Execute EOS command - "show ipv6 bgp peers {} routes vrf {}"'.format(bgp_neighbor, vrf))
+        out = vmhost['host'].eos_command(commands=['show ipv6 bgp peers {} routes vrf {}'.format(bgp_neighbor, vrf)])['stdout'][0]
     logging.debug('Command output:\n {}'.format(out))
 
     if action == ACTION_IN:

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -71,21 +71,40 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo
         logger.info('enable graceful restart on neighbor host {}'.format(node['host'].hostname))
         logger.info('bgp asn {}'.format(asn))
         if isinstance(node['host'], EosHost):
-            node_results.append(node['host'].config(
-                    lines=['graceful-restart restart-time 300'],
-                    parents=['router bgp {}'.format(asn)],
-                    module_ignore_errors=True)
-                )
-            node_results.append(node['host'].config(
-                    lines=['graceful-restart'],
-                    parents=['router bgp {}'.format(asn), 'address-family ipv4'],
-                    module_ignore_errors=True)
-                )
-            node_results.append(node['host'].config(
-                    lines=['graceful-restart'],
-                    parents=['router bgp {}'.format(asn), 'address-family ipv6'],
-                    module_ignore_errors=True)
-                )
+            if node.get('is_multi_vrf_peer', False):
+                vrf = node['multi_vrf_data']['vrf']
+                asn = node['multi_vrf_data']['primary_host_asn']
+                node_results.append(node['host'].config(
+                        lines=['graceful-restart restart-time 300'],
+                        parents=['router bgp {}'.format(asn), 'vrf {}'.format(vrf)],
+                        module_ignore_errors=True)
+                    )
+                node_results.append(node['host'].config(
+                        lines=['graceful-restart'],
+                        parents=['router bgp {}'.format(asn), 'vrf {}'.format(vrf), 'address-family ipv4'],
+                        module_ignore_errors=True)
+                    )
+                node_results.append(node['host'].config(
+                        lines=['graceful-restart'],
+                        parents=['router bgp {}'.format(asn), 'vrf {}'.format(vrf), 'address-family ipv6'],
+                        module_ignore_errors=True)
+                    )
+            else:
+                node_results.append(node['host'].config(
+                        lines=['graceful-restart restart-time 300'],
+                        parents=['router bgp {}'.format(asn)],
+                        module_ignore_errors=True)
+                    )
+                node_results.append(node['host'].config(
+                        lines=['graceful-restart'],
+                        parents=['router bgp {}'.format(asn), 'address-family ipv4'],
+                        module_ignore_errors=True)
+                    )
+                node_results.append(node['host'].config(
+                        lines=['graceful-restart'],
+                        parents=['router bgp {}'.format(asn), 'address-family ipv6'],
+                        module_ignore_errors=True)
+                    )
         elif isinstance(node['host'], SonicHost):
             node_results.append(node['host'].config(
                 lines=['bgp graceful-restart', 'bgp graceful-restart restart-time 300'],
@@ -135,16 +154,30 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo
         logger.info('disable graceful restart on neighbor {}'.format(node))
         asn = (node['conf']['bgp']['asn'])
         if isinstance(node['host'], EosHost):
-            node_results.append(node['host'].config(
-                    lines=['no graceful-restart'],
-                    parents=['router bgp {}'.format(asn), 'address-family ipv4'],
-                    module_ignore_errors=True)
-                )
-            node_results.append(node['host'].config(
-                    lines=['no graceful-restart'],
-                    parents=['router bgp {}'.format(asn), 'address-family ipv6'],
-                    module_ignore_errors=True)
-                )
+            if node.get('is_multi_vrf_peer', False):
+                vrf = node['multi_vrf_data']['vrf']
+                asn = node['multi_vrf_data']['primary_host_asn']
+                node_results.append(node['host'].config(
+                        lines=['no graceful-restart'],
+                        parents=['router bgp {}'.format(asn), 'vrf {}'.format(vrf), 'address-family ipv4'],
+                        module_ignore_errors=True)
+                    )
+                node_results.append(node['host'].config(
+                        lines=['no graceful-restart'],
+                        parents=['router bgp {}'.format(asn), 'vrf {}'.format(vrf), 'address-family ipv6'],
+                        module_ignore_errors=True)
+                    )
+            else:
+                node_results.append(node['host'].config(
+                        lines=['no graceful-restart'],
+                        parents=['router bgp {}'.format(asn), 'address-family ipv4'],
+                        module_ignore_errors=True)
+                    )
+                node_results.append(node['host'].config(
+                        lines=['no graceful-restart'],
+                        parents=['router bgp {}'.format(asn), 'address-family ipv6'],
+                        module_ignore_errors=True)
+                    )
         elif isinstance(node['host'], SonicHost):
             node_results.append(node['host'].config(
                 lines=['no bgp graceful-restart', 'no bgp graceful-restart restart-time 300'],
@@ -173,6 +206,10 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo
         results[node['host'].hostname] = node_results
 
     # enable graceful restart on neighbors
+    if tbinfo['topo']['properties'].get('topo_is_multi_vrf', False):
+        # cEOSLab only supports running 5 concurrent in-progress config sessions.
+        # We run this task sequentially to avoid races
+        cct = 1
     results = parallel_run(configure_nbr_gr, (), {}, list(nbrhosts.values()), timeout=120, concurrent_tasks=cct)
 
     check_results(results)

--- a/tests/bgp/test_bgp_gr_helper.py
+++ b/tests/bgp/test_bgp_gr_helper.py
@@ -110,6 +110,7 @@ def test_bgp_gr_helper_routes_perserved(duthosts, rand_one_dut_hostname, nbrhost
     configurations = tbinfo['topo']['properties']['configuration_properties']
     exabgp_ips = [configurations['common']['nhipv4'], configurations['common']['nhipv6']]
     exabgp_sessions = ['exabgp_v4', 'exabgp_v6']
+    vrf = "default"
 
     # select neighbor to test
     if duthost.check_bgp_default_route():
@@ -140,7 +141,14 @@ def test_bgp_gr_helper_routes_perserved(duthosts, rand_one_dut_hostname, nbrhost
         nbr_ports.append(dev_nbrs[test_interface]['port'])
         test_neighbor_name = dev_nbrs[test_interface]['name']
 
-    test_neighbor_host = nbrhosts[test_neighbor_name]['host']
+    nbrhost = nbrhosts[test_neighbor_name]
+    if nbrhost['is_multi_vrf_peer']:
+        vrf = test_neighbor_name
+        exabgp_ips = [nbrhost['multi_vrf_data']['ptf_bp_config'].get("ipv4"),
+                      nbrhost['multi_vrf_data']['ptf_bp_config'].get("ipv6")]
+        exabgp_ips = list(filter(None, exabgp_ips))
+        exabgp_ips = [ip.split("/")[0] for ip in exabgp_ips]
+    test_neighbor_host = nbrhost['host']
 
     # get neighbor BGP peers
     test_bgp_neighbors = _find_test_bgp_neighbors(test_neighbor_name, bgp_neighbors)
@@ -155,7 +163,7 @@ def test_bgp_gr_helper_routes_perserved(duthosts, rand_one_dut_hostname, nbrhost
 
     # verify exabgp sessions to the neighbor are up before GR process
     pytest_assert(
-        test_neighbor_host.check_bgp_session_state(exabgp_ips, exabgp_sessions),
+        test_neighbor_host.check_bgp_session_state(exabgp_ips, exabgp_sessions, vrf=vrf),
         "exabgp sessions {} are not up before graceful restart".format(exabgp_sessions)
     )
 
@@ -194,7 +202,7 @@ def test_bgp_gr_helper_routes_perserved(duthosts, rand_one_dut_hostname, nbrhost
 
         # wait for exabgp sessions to establish
         pytest_assert(
-            wait_until(300, 10, 0, test_neighbor_host.check_bgp_session_state, exabgp_ips, exabgp_sessions),
+            wait_until(300, 10, 0, test_neighbor_host.check_bgp_session_state, exabgp_ips, exabgp_sessions, vrf=vrf),
             "exabgp sessions {} are not coming back".format(exabgp_sessions)
         )
 

--- a/tests/bgp/test_bgp_route_neigh_learning.py
+++ b/tests/bgp/test_bgp_route_neigh_learning.py
@@ -15,6 +15,50 @@ Logger = logging.getLogger(__name__)
 V4_PREFIX = "77.88.99.1"
 V4_MASK = "32"
 
+def add_route_to_nbr(data, name):
+    loopback = 1
+    vrf = "default"
+    if data["nbr"][name].get("is_multi_vrf_peer", False):
+        vrf = name
+        loopback += data["nbr"][name]["multi_vrf_data"]["intf_offset_mapping"]
+
+    bgp_as_num = data['bgp'][name]
+    # add a route in the neighbor T1 eos device
+    cmds = ["configure",
+            "interface loopback {}".format(loopback),
+            "vrf {}".format(vrf),
+            "ip address {}/{}".format(V4_PREFIX, V4_MASK),
+            "exit",
+            "router bgp {}".format(bgp_as_num),
+            "vrf {}".format(vrf),
+            "address-family ipv4",
+            "network {}/{}".format(V4_PREFIX, V4_MASK),
+            "exit",
+            ]
+    data['nbr'][name]['host'].run_command_list(cmds)
+    Logger.info("Route %s added to vrf %s on %s", V4_PREFIX, vrf, name)
+
+
+def rm_route_from_nbr(data, name):
+    loopback = 1
+    vrf = "default"
+    if data["nbr"][name].get("is_multi_vrf_peer", False):
+        vrf = name
+        loopback += data["nbr"][name]["multi_vrf_data"]["intf_offset_mapping"]
+
+    bgp_as_num = data['bgp'][name]
+    # remove the route in the neighbor T1 eos device
+    cmds = ["configure",
+            "router bgp {}".format(bgp_as_num),
+            "vrf {}".format(vrf),
+            "address-family ipv4",
+            "no network {}/{}".format(V4_PREFIX, V4_MASK),
+            "no interface loopback {}".format(loopback),
+            "exit",
+            ]
+    data['nbr'][name]['host'].run_command_list(cmds)
+    Logger.info("Route, IP and Loopback %d removed from %s on %s", loopback, vrf, name)
+
 
 @pytest.fixture(name="setUp", scope="module")
 def fixture_setUp(nbrhosts, duthosts, enum_frontend_dut_hostname):
@@ -54,15 +98,7 @@ def fixture_setUp(nbrhosts, duthosts, enum_frontend_dut_hostname):
         bgp_as_num = data['bgp'][name]
         # remove the route in the neighbor T1 eos device
         if isinstance(nbrhost, EosHost):
-            cmds = ["configure",
-                    "router bgp {}".format(bgp_as_num),
-                    "address-family ipv4",
-                    "no network {}/{}".format(V4_PREFIX, V4_MASK),
-                    "no interface loopback 1",
-                    "exit"
-                    ]
-            Logger.info("Route, IP and Loopback 1 removed from %s", name)
-            nbrhost.run_command_list(cmds)
+            rm_route_from_nbr(data, name)
         elif isinstance(nbrhost, SonicHost):
             cmd = "sudo vtysh -c 'configure terminal' " \
                   f"-c 'router bgp {bgp_as_num}' " \
@@ -94,22 +130,14 @@ def run_bgp_neighbor_route_learning(duthosts, enum_frontend_dut_hostname, data):
     """ Route added on All neighbor should be learned by the DUT"""
     Logger.info("Adding routes on neighbors")
 
+    exp_len = 0
     for name in data['T1']:
         bgp_as_num = data['bgp'][name]
         nbrhost = data['nbr'][name]['host']
         cmds = []
         # add a route in the neighbor T1 eos device
         if isinstance(nbrhost, EosHost):
-            cmds = ["configure",
-                    "interface loopback 1",
-                    "ip address {}/{}".format(V4_PREFIX, V4_MASK),
-                    "exit",
-                    "router bgp {}".format(bgp_as_num),
-                    "address-family ipv4",
-                    "network {}/{}".format(V4_PREFIX, V4_MASK),
-                    "exit"
-                    ]
-            nbrhost.run_command_list(cmds)
+            add_route_to_nbr(data, name)
         elif isinstance(nbrhost, SonicHost):
             # Create and configure loopback interface
             cmd = f"sudo config interface ip add Loopback1 {V4_PREFIX}/{V4_MASK}"

--- a/tests/bgp/test_bgp_route_neigh_learning.py
+++ b/tests/bgp/test_bgp_route_neigh_learning.py
@@ -20,7 +20,7 @@ def add_route_to_nbr(data, name):
     vrf = "default"
     if data["nbr"][name].get("is_multi_vrf_peer", False):
         vrf = name
-        loopback += data["nbr"][name]["multi_vrf_data"]["intf_offset_mapping"]
+        loopback += data["nbr"][name]["multi_vrf_data"]["intf_offset"]
 
     bgp_as_num = data['bgp'][name]
     # add a route in the neighbor T1 eos device
@@ -44,7 +44,7 @@ def rm_route_from_nbr(data, name):
     vrf = "default"
     if data["nbr"][name].get("is_multi_vrf_peer", False):
         vrf = name
-        loopback += data["nbr"][name]["multi_vrf_data"]["intf_offset_mapping"]
+        loopback += data["nbr"][name]["multi_vrf_data"]["intf_offset"]
 
     bgp_as_num = data['bgp'][name]
     # remove the route in the neighbor T1 eos device

--- a/tests/bgp/test_bgp_router_id.py
+++ b/tests/bgp/test_bgp_router_id.py
@@ -17,6 +17,26 @@ logger = logging.getLogger(__name__)
 CUSTOMIZED_BGP_ROUTER_ID = "8.8.8.8"
 
 
+def verify_bgp_peer(neighbor_type, nbrhost, localip, expected_bgp_router_id, is_v6_topo, vrf="default"):
+    if neighbor_type == "sonic":
+        if is_v6_topo:
+            cmd = "show ipv6 bgp neighbors {}".format(localip)
+        else:
+            cmd = "show ip bgp neighbors {}".format(localip)
+    elif neighbor_type == "eos":
+        if is_v6_topo:
+            cmd = "/usr/bin/Cli -c \"show ipv6 bgp peers {} vrf {}\"".format(localip, vrf)
+        else:
+            cmd = "/usr/bin/Cli -c \"show ip bgp neighbors {} vrf {}\"".format(localip, vrf)
+    output = nbrhost["host"].shell(cmd, module_ignore_errors=True)["stdout"]
+    pattern = r"BGP version 4, remote router ID (\d+\.\d+\.\d+\.\d+)"
+    match = re.search(pattern, output)
+    pytest_assert(match, "Cannot get remote BGP router id from [{}]".format(output))
+    pytest_assert(match.group(1) == expected_bgp_router_id,
+                  "BGP router id is unexpected, local: {}, fetch from remote:{}".format(
+                      expected_bgp_router_id, match.group(1)))
+
+
 def verify_bgp(enum_asic_index, duthost, expected_bgp_router_id, neighbor_type, nbrhosts):
     output = duthost.shell("show ip bgp summary", module_ignore_errors=True)["stdout"]
 
@@ -41,17 +61,9 @@ def verify_bgp(enum_asic_index, duthost, expected_bgp_router_id, neighbor_type, 
 
     for neighbor_name, nbrhost in nbrhosts.items():
         pytest_assert(neighbor_name in local_ip_map, "Cannot find local ip for {}".format(neighbor_name))
-        if neighbor_type == "sonic":
-            cmd = "show ip neighbors {}".format(local_ip_map[neighbor_name])
-        elif neighbor_type == "eos":
-            cmd = "/usr/bin/Cli -c \"show ip bgp neighbors {}\"".format(local_ip_map[neighbor_name])
-        output = nbrhost["host"].shell(cmd, module_ignore_errors=True)['stdout']
-        pattern = r"BGP version 4, remote router ID (\d+\.\d+\.\d+\.\d+)"
-        match = re.search(pattern, output)
-        pytest_assert(match, "Cannot get remote BGP router id from [{}]".format(output))
-        pytest_assert(match.group(1) == expected_bgp_router_id,
-                      "BGP router id is unexpected, local: {}, fetch from remote: {}"
-                      .format(expected_bgp_router_id, match.group(1)))
+        localip = local_ip_map[neighbor_name]
+        vrf = neighbor_name if nbrhost["is_multi_vrf_peer"] else "default"
+        verify_bgp_peer(neighbor_type, nbrhost, localip, expected_bgp_router_id, is_v6_topo, vrf=vrf)
 
 
 @pytest.fixture()

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -218,7 +218,7 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
             neighbor_port = setup['neighhosts'][neighbor]['interface'][port]['port']
             nbr_data = nbrhosts[neighbor_name]
             if nbr_data.get('is_multi_vrf_peer', False):
-                offset = nbr_data['multi_vrf_data']['intf_offset_mapping']
+                offset = nbr_data['multi_vrf_data']['intf_offset']
                 intf_prefix, intf_num = re.findall(r"(\D+)(\d+)", neighbor_port)[0]
                 neighbor_port = intf_prefix + str(int(intf_num) + offset)
 
@@ -257,7 +257,7 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
             neighbor_port = setup['neighhosts'][neighbor]['interface'][port]['port']
             nbr_data = nbrhosts[neighbor_name]
             if nbr_data.get('is_multi_vrf_peer', False):
-                offset = nbr_data['multi_vrf_data']['intf_offset_mapping']
+                offset = nbr_data['multi_vrf_data']['intf_offset']
                 intf_prefix, intf_num = re.findall(r"(\D+)(\d+)", neighbor_port)[0]
                 neighbor_port = intf_prefix + str(int(intf_num) + offset)
 

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import re
 import time
 from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.utilities import wait_until
@@ -213,7 +214,14 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
 
     elif failure_type == "neighbor":
         for port in local_interfaces:
+            peer_name = neighbor_name
             neighbor_port = setup['neighhosts'][neighbor]['interface'][port]['port']
+            nbr_data = nbrhosts[neighbor_name]
+            if nbr_data.get('is_multi_vrf_peer', False):
+                offset = nbr_data['multi_vrf_data']['intf_offset_mapping']
+                intf_prefix, intf_num = re.findall(r"(\D+)(\d+)", neighbor_port)[0]
+                neighbor_port = intf_prefix + str(int(intf_num) + offset)
+
             logger.info("shutdown interface neighbor {} port {}".format(neighbor_name, neighbor_port))
             nbrhosts[neighbor_name]['host'].shutdown(neighbor_port)
             time.sleep(1)
@@ -245,7 +253,14 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
 
     elif failure_type == "neighbor":
         for port in local_interfaces:
+            peer_name = neighbor_name
             neighbor_port = setup['neighhosts'][neighbor]['interface'][port]['port']
+            nbr_data = nbrhosts[neighbor_name]
+            if nbr_data.get('is_multi_vrf_peer', False):
+                offset = nbr_data['multi_vrf_data']['intf_offset_mapping']
+                intf_prefix, intf_num = re.findall(r"(\D+)(\d+)", neighbor_port)[0]
+                neighbor_port = intf_prefix + str(int(intf_num) + offset)
+
             logger.info("no shutdown interface neighbor {} port {}".format(neighbor_name, neighbor_port))
             nbrhosts[neighbor_name]['host'].no_shutdown(neighbor_port)
             time.sleep(1)

--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -112,7 +112,7 @@ def bgp_peers_info(tbinfo, duthost):
         if topo_is_multi_vrf:
             topo = tbinfo['topo']['properties']['topology']
             primary = multi_vrf_map[hostname]
-            intf_offset = multi_vrf_data['converged_peers'][primary]['intf_offset_mapping'][hostname]
+            intf_offset = multi_vrf_data['converged_peers'][primary]['intf_mapping'][hostname]['offset']
             ptf_port = topo['VMs'][primary]['vlans'][intf_offset]
         else:
             ptf_port = tbinfo['topo']['properties']['topology']['VMs'][hostname]['vlans'][0]

--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -83,6 +83,14 @@ def bgp_peers_info(tbinfo, duthost):
     bgp_info = {}
     topo_name = tbinfo['topo']['name']
 
+    topo_is_multi_vrf = tbinfo['topo']['properties'].get('topo_is_multi_vrf', False)
+    multi_vrf_data = {}
+    multi_vrf_map = {}
+    if topo_is_multi_vrf:
+        multi_vrf_data = tbinfo['topo']['properties']['convergence_data']
+        for primary, vrfs in multi_vrf_data['convergence_mapping'].items():
+           for vrf in vrfs:
+              multi_vrf_map[vrf] = primary
     logger.info("Waiting for BGP sessions are established")
     while True:
         down_neighbors = get_down_bgp_sessions_neighbors(duthost)
@@ -100,8 +108,16 @@ def bgp_peers_info(tbinfo, duthost):
             or ('t1' in topo_name and 'T0' not in hostname) \
                 or (hostname in down_neighbors):
             continue
+
+        if topo_is_multi_vrf:
+            topo = tbinfo['topo']['properties']['topology']
+            primary = multi_vrf_map[hostname]
+            intf_offset = multi_vrf_data['converged_peers'][primary]['intf_offset_mapping'][hostname]
+            ptf_port = topo['VMs'][primary]['vlans'][intf_offset]
+        else:
+            ptf_port = tbinfo['topo']['properties']['topology']['VMs'][hostname]['vlans'][0]
+
         bgp_info[hostname] = {}
-        ptf_port = tbinfo['topo']['properties']['topology']['VMs'][hostname]['vlans'][0]
         bgp_info[hostname][PTF_PORT] = ptf_port
         bgp_info[hostname][DUT_PORT] = alias[ptf_port]['name']
 

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -245,7 +245,8 @@ class EosHost(AnsibleHostBase):
         logging.info('No shut BGP neighbors: {}'.format(json.dumps(neighbors)))
         return out
 
-    def check_bgp_session_state(self, neigh_ips, neigh_desc, state="established"):
+    def check_bgp_session_state(self, neigh_ips, neigh_desc,
+                                state="established", vrf="default"):
         """
         @summary: check if current bgp session equals to the target state
 
@@ -259,11 +260,11 @@ class EosHost(AnsibleHostBase):
         neigh_desc_available = False
 
         out_v4 = self.eos_command(
-            commands=['show ip bgp summary | json'])
+            commands=['show ip bgp summary vrf {} | json'.format(vrf)])
         logging.info("ip bgp summary: {}".format(out_v4))
 
         out_v6 = self.eos_command(
-            commands=['show ipv6 bgp summary | json'])
+            commands=['show ipv6 bgp summary vrf {} | json'.format(vrf)])
         logging.info("ipv6 bgp summary: {}".format(out_v6))
 
         # when bgpd is inactive, the bgp summary output: [{u'vrfs': {}, u'warnings': [u'BGP inactive']}]
@@ -272,7 +273,7 @@ class EosHost(AnsibleHostBase):
             return False
 
         try:
-            for k, v in list(out_v4['stdout'][0]['vrfs']['default']['peers'].items()):
+            for k, v in list(out_v4['stdout'][0]['vrfs'][vrf]['peers'].items()):
                 if v['peerState'].lower() == state.lower():
                     if k in neigh_ips:
                         neigh_ips_ok.append(k)
@@ -281,7 +282,7 @@ class EosHost(AnsibleHostBase):
                         if v['description'] in neigh_desc:
                             neigh_desc_ok.append(v['description'])
 
-            for k, v in list(out_v6['stdout'][0]['vrfs']['default']['peers'].items()):
+            for k, v in list(out_v6['stdout'][0]['vrfs'][vrf]['peers'].items()):
                 if v['peerState'].lower() == state.lower():
                     if k.lower() in neigh_ips:
                         neigh_ips_ok.append(k)
@@ -314,10 +315,13 @@ class EosHost(AnsibleHostBase):
         if res["localhost"]["rc"] != 0:
             raise Exception("Unable to execute template\n{}".format(res["localhost"]["stdout"]))
 
-    def get_route(self, prefix):
+    def get_route(self, prefix, vrf=None):
         cmd = 'show ip bgp' if ipaddress.ip_network(prefix.encode().decode()).version == 4 else 'show ipv6 bgp'
+        cmd = '{} {}'.format(cmd, prefix)
+        if vrf:
+            cmd = '{} vrf {}'.format(cmd, vrf)
         return self.eos_command(commands=[{
-            'command': '{} {}'.format(cmd, prefix),
+            'command': cmd,
             'output': 'json'
         }])['stdout'][0]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -676,9 +676,21 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
         logger.info("No VMs exist for this topology: {}".format(tbinfo['topo']['properties']['topology']))
         return devices
 
-    def initial_neighbor(neighbor_name, vm_name):
+    def initial_neighbor(neighbor_name, vm_name, multi_vrf_peer=False, multi_vrf_primary_host=None):
         logger.info(f"nbrhosts started: {neighbor_name}_{vm_name}")
         if neighbor_type == "eos":
+            if multi_vrf_peer:
+                data = tbinfo['topo']['properties']['convergence_data']
+                primary_data = data['converged_peers'][multi_vrf_primary_host]
+                primary_asn = tbinfo['topo']['properties']['configuration'][multi_vrf_primary_host]['bgp']['asn']
+                multi_vrf_data = {'vrf': neighbor_name,
+                                  'intf_config': copy.deepcopy(primary_data['vrf'][neighbor_name]),
+                                  'intf_offset_mapping': primary_data['intf_offset_mapping'][neighbor_name],
+                                  'primary_host': multi_vrf_primary_host,
+                                  'primary_host_asn': primary_asn,
+                                  'intf_index_mapping': copy.deepcopy(data['interface_index_mapping'][neighbor_name]),
+                                  'vm_offset_mapping': data['vm_offset_mapping'][neighbor_name],
+                                  'ptf_bp_config': copy.deepcopy(data['ptf_backplane_addrs'][neighbor_name])}
             device = NeighborDevice(
                 {
                     'host': EosHost(
@@ -689,7 +701,9 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
                         shell_user=creds['eos_root_user'] if 'eos_root_user' in creds else None,
                         shell_passwd=creds['eos_root_password'] if 'eos_root_password' in creds else None
                     ),
-                    'conf': tbinfo['topo']['properties']['configuration'][neighbor_name]
+                    'conf': tbinfo['topo']['properties']['configuration'][neighbor_name],
+                    'is_multi_vrf_peer': multi_vrf_peer,
+                    'multi_vrf_data': multi_vrf_data if multi_vrf_peer else None,
                 }
             )
         elif neighbor_type == "sonic":
@@ -737,9 +751,17 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
                 tbinfo['topo']['properties']['topology']['VMs'],
                 server['dut_interfaces']
             ) if 'dut_interfaces' in server else tbinfo['topo']['properties']['topology']['VMs']
+        topo_is_multi_vrf = tbinfo['topo']['properties'].get('topo_is_multi_vrf', False)
         for neighbor_name, neighbor in vms.items():
             vm_name = vm_name_fmt % (vm_base + neighbor['vm_offset'])
-            futures.append(executor.submit(initial_neighbor, neighbor_name, vm_name))
+            if topo_is_multi_vrf:
+                convergence_info = tbinfo['topo']['properties']['convergence_data']
+                for vrf_name in convergence_info['convergence_mapping'][neighbor_name]:
+                    futures.append(executor.submit(initial_neighbor, vrf_name,
+                                                   vm_name, multi_vrf_peer=True,
+                                                   multi_vrf_primary_host=neighbor_name))
+            else:
+                futures.append(executor.submit(initial_neighbor, neighbor_name, vm_name))
 
     for future in as_completed(futures):
         # if exception caught in the sub-thread, .result() will raise it in the main thread

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -685,7 +685,8 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
                 primary_asn = tbinfo['topo']['properties']['configuration'][multi_vrf_primary_host]['bgp']['asn']
                 multi_vrf_data = {'vrf': neighbor_name,
                                   'intf_config': copy.deepcopy(primary_data['vrf'][neighbor_name]),
-                                  'intf_offset_mapping': primary_data['intf_offset_mapping'][neighbor_name],
+                                  'intf_offset': primary_data['intf_mapping'][neighbor_name]["offset"],
+                                  'orig_intf_map': primary_data['intf_mapping'][neighbor_name]["orig_intf_map"],
                                   'primary_host': multi_vrf_primary_host,
                                   'primary_host_asn': primary_asn,
                                   'intf_index_mapping': copy.deepcopy(data['interface_index_mapping'][neighbor_name]),

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import re
 import ipaddress
+from copy import deepcopy
 
 from tests.common.devices.base import AnsibleHostBase
 from tests.common.utilities import wait, wait_until
@@ -81,6 +82,11 @@ def setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
     portchannel_members = [member for portchannel in list(minigraph_portchannels.values())
                            for member in portchannel['members']]
     physical_interfaces = [item for item in up_ports if item not in portchannel_members]
+
+    multi_vrf_info = None
+    if tbinfo.get('use_converged_peers', False):
+        multi_vrf_info = deepcopy(tbinfo['topo']['properties']['convergence_data'])
+
     setup_info = {
          'default_interfaces': default_interfaces,
          'minigraph_facts': minigraph_facts,
@@ -90,7 +96,8 @@ def setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
          'port_alias_map': port_alias_map,
          'port_speed': port_speed,
          'up_ports': up_ports,
-         'upport_alias_list': upport_alias_list
+         'upport_alias_list': upport_alias_list,
+         'multi_vrf_info': multi_vrf_info,
     }
 
     yield setup_info
@@ -265,15 +272,26 @@ class TestShowLLDP():
         lldp_table = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show lldp table'.format(ifmode))['stdout']
         logger.info('lldp_table:\n{}'.format(lldp_table))
 
+        vrf_map = {}
+        multi_vrf = False
+        if setup.get('multi_vrf_info'):
+            multi_vrf = True
+            for host, vrfs in setup['multi_vrf_info']['convergence_mapping'].items():
+                for vrf in vrfs:
+                    vrf_map[vrf] = host
+
         if mode == 'alias':
             for alias in lldp_interfaces['alias']:
-                assert re.search(r'{}.*\s+{}'
-                                 .format(alias, minigraph_neighbors[setup['port_alias_map'][alias]]['name']),
-                                 lldp_table) is not None
+                peer = minigraph_neighbors[setup['port_alias_map'][alias]]['name']
+                if multi_vrf:
+                    peer = vrf_map[peer]
+                assert re.search(r'{}.*\s+{}'.format(alias, peer), lldp_table) is not None
         elif mode == 'default':
             for intf in lldp_interfaces['interface']:
-                assert re.search(r'{}.*\s+{}'.format(intf, minigraph_neighbors[intf]['name']),
-                                 lldp_table) is not None
+                peer= minigraph_neighbors[intf]['name']
+                if multi_vrf:
+                    peer = vrf_map[peer]
+                assert re.search(r'{}.*\s+{}'.format(intf, peer), lldp_table) is not None
 
     def test_show_lldp_neighbor(self, setup, setup_config_mode, lldp_interfaces):
         """

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -288,7 +288,7 @@ class TestShowLLDP():
                 assert re.search(r'{}.*\s+{}'.format(alias, peer), lldp_table) is not None
         elif mode == 'default':
             for intf in lldp_interfaces['interface']:
-                peer= minigraph_neighbors[intf]['name']
+                peer = minigraph_neighbors[intf]['name']
                 if multi_vrf:
                     peer = vrf_map[peer]
                 assert re.search(r'{}.*\s+{}'.format(intf, peer), lldp_table) is not None

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -91,10 +91,9 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
             exp_intf = config_facts['DEVICE_NEIGHBOR'][k]['port']
             vrf = config_facts['DEVICE_NEIGHBOR'][k]['name']
             primary = rev_vrf_map[vrf]
-            if_offset = convergence_info['converged_peers'][primary]['intf_offset_mapping'][vrf]
-            if_name, if_id = re.match(r'([A-Za-z]+)(\d+)', exp_intf).groups()
+            new_intf = convergence_info['converged_peers'][primary]['intf_mapping'][vrf]['orig_intf_map'][exp_intf]
             assert v['chassis']['name'] == primary
-            assert v['port']['ifname'] == "{}{}".format(if_name, int(if_id) + if_offset)
+            assert v['port']['ifname'] == new_intf
         else:
             # Compare the LLDP neighbor name with minigraph neigbhor name (exclude the management port)
             assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name']

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import re
 from tests.common.platform.interface_utils import get_dpu_npu_ports_from_hwsku
 from tests.common.utilities import wait_until
 
@@ -66,6 +67,15 @@ def get_num_lldpctl_facts(duthost, enum_frontend_asic_index):
 def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
               collect_techsupport_all_duts, enum_frontend_asic_index, request):
     """ verify the LLDP message on DUT """
+    converged = duthosts.tbinfo['topo']['properties'].get('topo_is_multi_vrf', False)
+    convergence_info = None
+    rev_vrf_map = {}
+    if converged:
+        convergence_info = duthosts.tbinfo['topo']['properties']['convergence_data']
+        for primary, vrflist in convergence_info['convergence_mapping'].items():
+            for vrf in vrflist:
+                rev_vrf_map[vrf] = primary
+
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     config_facts = duthost.asic_instance(
@@ -77,14 +87,23 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
     if not list(lldpctl_facts['lldpctl'].items()):
         pytest.fail("No LLDP neighbors received (lldpctl_facts are empty)")
     for k, v in list(lldpctl_facts['lldpctl'].items()):
-        # Compare the LLDP neighbor name with minigraph neigbhor name (exclude the management port)
-        assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name']
-        # Compare the LLDP neighbor interface with minigraph neigbhor interface (exclude the management port)
-        if request.config.getoption("--neighbor_type") == 'eos':
-            assert v['port']['ifname'] == config_facts['DEVICE_NEIGHBOR'][k]['port']
+        if converged:
+            exp_intf = config_facts['DEVICE_NEIGHBOR'][k]['port']
+            vrf = config_facts['DEVICE_NEIGHBOR'][k]['name']
+            primary = rev_vrf_map[vrf]
+            if_offset = convergence_info['converged_peers'][primary]['intf_offset_mapping'][vrf]
+            if_name, if_id = re.match(r'([A-Za-z]+)(\d+)', exp_intf).groups()
+            assert v['chassis']['name'] == primary
+            assert v['port']['ifname'] == "{}{}".format(if_name, int(if_id) + if_offset)
         else:
-            # Dealing with KVM that advertises port description
-            assert v['port']['descr'] == config_facts['DEVICE_NEIGHBOR'][k]['port']
+            # Compare the LLDP neighbor name with minigraph neigbhor name (exclude the management port)
+            assert v['chassis']['name'] == config_facts['DEVICE_NEIGHBOR'][k]['name']
+            # Compare the LLDP neighbor interface with minigraph neigbhor interface (exclude the management port)
+            if request.config.getoption("--neighbor_type") == 'eos':
+                assert v['port']['ifname'] == config_facts['DEVICE_NEIGHBOR'][k]['port']
+            else:
+                # Dealing with KVM that advertises port description
+                assert v['port']['descr'] == config_facts['DEVICE_NEIGHBOR'][k]['port']
 
 
 def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_duts,


### PR DESCRIPTION
### Description of PR
Converge cEOSLab peer containers via the use of VRFs and VLANs

### Type of change

- [ ]  Bug fix
- [x]  Testbed and Framework(new/improvement)
- [ ]  New Test case
- [ ]  Skipped for non-supported platforms
- [ ]  Test case improvement

### Approach
Converging the total number of peer switches into the fewest possible
number of cEOSLab containers reduces the overall resource constraints
required to run large numbers of peers. The basic premises behind
convergence are as follows:

cEOSLab peers in docker containers may be converged into a smaller
number of host peers.
The SONiC-facing configuration of each BGP peer may be separated in
routing and bridging via the use of VRFs.
The PTF-facing configuration of each BGP peer may be separated within
each VRF via VLAN tagging, enabling the use of a single backplane
interface on each host cEOSLab container.
Each VRF includes a number of interfaces either facing the SONiC DUT
or the backplane.
Changes should be as transparent to the SONiC DUT as possible.
At the time of testbed setup, the ansible topology file for the testbed
is modified to include new metadata specific to multi-vrf configuration,
and the VMs list is trimmed to only include those containers which will
host multiple BGP peerings, separated by VRF. The new metadata includes
mappings between host containers and VRFs, backplane VLAN mappings, and
BGP session parameters.

VLAN tag 2000 is used as the starting value for all VLANs between the
test infrastructure PTF container interfaces and cEOSLab device
interfaces.

The IP and IPv6 addresses used to connect the cEOSLab peer and
infrastructure PTF container are generated in order to
make the backplane connections clearer, more unique, and easier to
implement. In general, backplane L3 addresses used by the CEOSLab peer
end in even numbers, and those used by the PTF container end in odd
numbers. All addresses generated for use in backplane connections start
with the value 100 (0x64) in the least-significant octet or hextet
(depending on the family of the address). The address changes are
mapped and stored in the new multi-vrf metadata in the ansible topology
file.

Multiple BGP features, such as local-as and next-hop-peer, are used in
order to aid in the resolution of routes. This is necessary to keep the
SONiC DUT multi-vrf-agnostic as possible.

Known limitations:
- cEOSLab instances do not allow for the creation of interfaces with
interface-IDs greater than 127, when interfaces are layed out unidimensionally.
- The use of multiple VRFs has not been tested in conjunction with
asynchronous ansible tasks.