### PR TITLE
fix: Add capability check and skip unsupported cases

### DIFF
--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -12,6 +12,7 @@ import random
 # Module-level fixtures
 from .everflow_test_utilities import setup_info      # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor      # noqa F401
+from tests.common.macsec.macsec_helper import MACSEC_INFO
 
 pytestmark = [
     pytest.mark.topology("t0", "t1", "t2", "m0")
@@ -182,6 +183,14 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
     @pytest.fixture(scope='class',  autouse=True)
     def setup_acl_table(self, setup_info, setup_mirror_session, config_method, setup_mirror_session_dest_ip_route):         # noqa F811
+
+        # Capability check; skips when unsupported
+        if not setup_info[self.acl_stage()][self.mirror_type()]:
+            pytest.skip("{} ACL w/ {} Mirroring not supported, skipping"
+                        .format(self.acl_stage(), self.mirror_type()))
+        if MACSEC_INFO and self.mirror_type() == "egress":
+            pytest.skip("With MACSEC {} ACL w/ {} Mirroring not supported, skipping"
+                        .format(self.acl_stage(), self.mirror_type()))
 
         if setup_info['topo'] in ['t0', 'm0_vlan']:
             everflow_dut = setup_info[UP_STREAM]['everflow_dut']


### PR DESCRIPTION
These changes are to add capability checks and skip unsupported cases. It is merged in the main branch but adding the same changes here as the cherrypick didn't work. Ref: https://github.com/sonic-net/sonic-mgmt/pull/21735

To add capability check and skip the test when unsupported
Before:
<img width="2455" height="566" alt="image" src="https://github.com/user-attachments/assets/02c183cb-f954-49b2-94d1-7c5d7e6bfa8a" />



After the changes:
<img width="2495" height="501" alt="image" src="https://github.com/user-attachments/assets/08d11258-dab3-4c84-b5a7-c4110d6cbedf" />



