### PR TITLE
[202412] Fix test_acl.py [ipv6-ingress-uplink->downlink-*] cases for v6 topo

### DIFF
--- a/tests/acl/templates/acltb_v6_test_rules.j2
+++ b/tests/acl/templates/acltb_v6_test_rules.j2
@@ -582,6 +582,36 @@
                                         "destination-ip-address": "fc02:1000:0:1::7/128"
                                     }
                                 }
+                            },
+                            "38": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 38
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "2064:100:0::C0A8:0000:1/128"
+                                    }
+                                }
+                            },
+                            "39": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 39
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "2064:100:0::C0A8:0000:9/128"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/templates/acltb_v6_test_rules_part_2.j2
+++ b/tests/acl/templates/acltb_v6_test_rules_part_2.j2
@@ -540,6 +540,36 @@
                                         "destination-ip-address": "fc02:1000:0:1::7/128"
                                     }
                                 }
+                            },
+                            "38": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 38
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "2064:100:0::C0A8:0000:1/128"
+                                    }
+                                }
+                            },
+                            "39": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 39
+                                },
+                                "ip": {
+                                    "config": {
+                                        "destination-ip-address": "2064:100:0::C0A8:0000:9/128"
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -923,7 +923,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
             return True
 
         logger.info('Wait all rule counters are ready')
-        return wait_until(60, 2, 0, self.check_rule_counters_internal, duthost)
+        return wait_until(120, 2, 0, self.check_rule_counters_internal, duthost)
 
     def check_rule_counters_internal(self, duthost):
         for asic_id in duthost.get_frontend_asic_ids():

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -29,6 +29,7 @@ from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.platform.interface_utils import check_all_interface_information
 from tests.common.utilities import get_iface_ip
 from tests.common.utilities import is_ipv4_address
+from tests.common.utilities import is_ipv6_only_topology
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +78,21 @@ DOWNSTREAM_IP_TO_ALLOW = {
 DOWNSTREAM_IP_TO_BLOCK = {
     "ipv4": "192.168.0.251",
     "ipv6": "20c0:a800::9"
+}
+
+# Below T1 V6 topo IPs are announced to DUT by annouce_route.py
+# IPv4 addrs are placeholders only
+DOWNSTREAM_DST_IP_V6_TOPO = {
+    "ipv4": "192.168.0.253",
+    "ipv6": "2064:100:0::C0A8:0000:14"
+}
+DOWNSTREAM_IP_TO_ALLOW_V6_TOPO = {
+    "ipv4": "192.168.0.252",
+    "ipv6": "2064:100:0::C0A8:0000:1"
+}
+DOWNSTREAM_IP_TO_BLOCK_V6_TOPO = {
+    "ipv4": "192.168.0.251",
+    "ipv6": "2064:100:0::C0A8:0000:9"
 }
 
 # Below M0_L3 IPs are announced to DUT by annouce_route.py, it point to neighbor mx
@@ -309,6 +325,15 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
         DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_M0_L3
         DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_M0_L3
         DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_M0_L3
+    elif is_ipv6_only_topology(tbinfo):
+        if tbinfo['topo']['type'] in ['t0']:
+            DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_VLAN
+            DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_VLAN
+            DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_VLAN
+        else:
+            DOWNSTREAM_DST_IP = DOWNSTREAM_DST_IP_V6_TOPO
+            DOWNSTREAM_IP_TO_ALLOW = DOWNSTREAM_IP_TO_ALLOW_V6_TOPO
+            DOWNSTREAM_IP_TO_BLOCK = DOWNSTREAM_IP_TO_BLOCK_V6_TOPO
     elif tbinfo['topo']['type'] in ['t0']:
         try:
             vlan_config = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']['default_vlan_config']
@@ -1100,6 +1125,11 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                     rule_id = 33 if vlan_name == "Vlan1000" else 2
                 logging.info("topo: {} vlan_config: {} vlan_name: {} rule_id: {} ".format(
                     setup["topo"], setup["vlan_config"], vlan_name, rule_id))
+            elif "-v6-" in setup["topo_name"]:
+                if setup["topo"] in ['t0']:
+                    rule_id = 34
+                else:
+                    rule_id = 38
             else:
                 rule_id = 2
         else:
@@ -1128,6 +1158,11 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                     rule_id = 32 if vlan_name == "Vlan1000" else 15
                 logging.info("topo: {} vlan_config: {} vlan_name: {} rule_id: {} ".format(
                     setup["topo"], setup["vlan_config"], vlan_name, rule_id))
+            elif "-v6-" in setup["topo_name"]:
+                if setup["topo"] in ['t0']:
+                    rule_id = 35
+                else:
+                    rule_id = 39
             else:
                 rule_id = 15
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
t0-isolated-v6-*:
Downstream neighbors are servers connected to VLAN interface. Use DOWNSTREAM_DST_IP_VLAN as dest ips. IPv6 cases have been skipped for t0 since beginning, only fix it for v6 topos now.

t1-isolated-v6-*:
V6 topo files set ipv6_address_pattern: 2064:100:0::%02X%02X:%02X%02X:0/120.
announce_routes.py uses the pattern to generate routes for PTF and pass them to VMs. If it is not set, default pattern 20%02X:%02X%02X:0:%02X::/64 is used.
acl tests use hardcoded dest ip 20c0:a800::1 that is not covered by v6 topo pattern, so packets are forwarded with the default route to upstream VM.
Fix it by changing dest ip for v6 topos, also add acl rules for these dest ips.

With extra ACL rules for v6 topos, also increase timeout for check_rule_counters.

Manual cherry pick of https://github.com/sonic-net/sonic-mgmt/pull/21760

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
test_acl.py [ipv6-ingress-uplink->downlink-*] cases failed on v6 topo

#### How did you do it?
Correct DOWNSTREAM_DST_IP for t0/t1-isolated-v6-*. topos, and add corresponding acl rules

#### How did you verify/test it?
Test passed on t0/t1-isolated-v6-*. topos

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
