### PR TITLE
[manual] [PR:19258] Fix shebang to /usr/bin/python in ansible modules for compatibility

### DIFF
--- a/ansible/library/acl_facts.py
+++ b/ansible/library/acl_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # This ansible module is for gathering ACL related facts from SONiC device.
 #
 # The "sonic-cfggen" tool is used to output all the running config data from db in JSON format. ACL table information

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 import math
 import os

--- a/ansible/library/config_facts.py
+++ b/ansible/library/config_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 import json
 import traceback

--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 import csv
 
 from ansible.module_utils.basic import AnsibleModule

--- a/ansible/library/counter_facts.py
+++ b/ansible/library/counter_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
 import re

--- a/ansible/library/dut_basic_facts.py
+++ b/ansible/library/dut_basic_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # This ansible module is for gathering basic facts from DUT of specified testbed.
 #
 # Example output:

--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
 import jinja2

--- a/ansible/library/fabric_info.py
+++ b/ansible/library/fabric_info.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
 import ipaddress

--- a/ansible/library/feature_facts.py
+++ b/ansible/library/feature_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 # This ansible module is for gathering feature facts from SONiC device.
 #

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 # This ansible module is for generate golden_config_db.json
 # Currently, only enable dhcp_server feature and generated related configuration in MX device

--- a/ansible/library/image_facts.py
+++ b/ansible/library/image_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # This ansible module is for gathering image facts from SONiC device.
 #
 # The "sonic_installer list" command can list the images on SONiC device, including:

--- a/ansible/library/interface_up_down_data_struct_facts.py
+++ b/ansible/library/interface_up_down_data_struct_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 
 from ansible.module_utils.basic import AnsibleModule

--- a/ansible/library/lldp_facts.py
+++ b/ansible/library/lldp_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 import json
 from collections import defaultdict

--- a/ansible/library/lldpctl_facts.py
+++ b/ansible/library/lldpctl_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # This ansible module is for gathering lldp facts from SONiC device.
 # It takes two argument
 # asic_instance_id :- Used to specify LLDP Instance in Multi-asic platforms

--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from __future__ import print_function
 from ansible.module_utils.basic import AnsibleModule
 import calendar

--- a/ansible/library/mux_cable_facts.py
+++ b/ansible/library/mux_cable_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 import os.path
 import sys
 import traceback

--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
 import re

--- a/ansible/library/ptf_portchannel.py
+++ b/ansible/library/ptf_portchannel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
 import jinja2

--- a/ansible/library/shell_cmds.py
+++ b/ansible/library/shell_cmds.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # This ansible module is for running multiple commands by /bin/sh on remote device.
 #
 # The ansible builtin module "command" and "shell" can run a single command on the remote device and get its output.

--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 import sys
 import traceback

--- a/ansible/library/topo_facts.py
+++ b/ansible/library/topo_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 import os
 import traceback
 import ipaddress

--- a/ansible/library/vlan_config.py
+++ b/ansible/library/vlan_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
 import traceback

--- a/ansible/library/vlan_facts.py
+++ b/ansible/library/vlan_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # This ansible module is for gathering VLAN related facts from SONiC device.
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We encountered the following issue when trying to upgrade ansible:
 `/bin/sh: 1: /usr/bin/env python3: not found`
This error occurred when attempting to invoke certain Ansible modules.

According to the [Module format and documentation](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#python-shebang-utf-8-coding),

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/c91a0372-5622-44d7-81e1-d2bd63100d54" />
the recommended shebang is: `#!/usr/bin/python`

From the logs, we can observe the following behavior:
+ When the shebang is /usr/bin/env python, Ansible translates it into:
```
   203 1751357337.89274: _low_level_execute_command(): starting
   203 1751357337.89277: _low_level_execute_command(): executing: /bin/sh -c ''"'"'/usr/bin/env python'"'"' && sleep 0'
```

+ In contrast, when using /usr/bin/python, Ansible attempts a full interpreter discovery:
```
   171 1751357179.48738: _low_level_execute_command(): starting
   171 1751357179.48741: _low_level_execute_command(): executing: /bin/sh -c 'echo PLATFORM; uname; echo FOUND; command -v '"'"'python3.13'"'"'; command -v '"'"'python3.12'"'"'; command -v '"'"'python3.11'"'"'; command -v '"'"'python3.10'"'"'; command -v '"'"'python3.9'"'"'; command -v '"'"'python3.8'"'"'; command -v '"'"'/usr/bin/python3'"'"'; command -v '"'"'python3'"'"'; echo ENDFOUND && sleep 0'
```

This indicates that Ansible treats `/usr/bin/env python` literally and does not invoke its interpreter auto-discovery logic, leading to failures on systems without the python symlink.

To satisfy the requirements of the latest ansible, we update the shebang lines in all affected modules in advance.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
We encountered the following issue when trying to upgrade ansible:
 `/bin/sh: 1: /usr/bin/env python3: not found`
This error occurred when attempting to invoke certain Ansible modules.

According to the [Module format and documentation](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#python-shebang-utf-8-coding),

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/c91a0372-5622-44d7-81e1-d2bd63100d54" />
the recommended shebang is: `#!/usr/bin/python`

From the logs, we can observe the following behavior:
+ When the shebang is /usr/bin/env python, Ansible translates it into:
```
   203 1751357337.89274: _low_level_execute_command(): starting
   203 1751357337.89277: _low_level_execute_command(): executing: /bin/sh -c ''"'"'/usr/bin/env python'"'"' && sleep 0'
```

+ In contrast, when using /usr/bin/python, Ansible attempts a full interpreter discovery:
```
   171 1751357179.48738: _low_level_execute_command(): starting
   171 1751357179.48741: _low_level_execute_command(): executing: /bin/sh -c 'echo PLATFORM; uname; echo FOUND; command -v '"'"'python3.13'"'"'; command -v '"'"'python3.12'"'"'; command -v '"'"'python3.11'"'"'; command -v '"'"'python3.10'"'"'; command -v '"'"'python3.9'"'"'; command -v '"'"'python3.8'"'"'; command -v '"'"'/usr/bin/python3'"'"'; command -v '"'"'python3'"'"'; echo ENDFOUND && sleep 0'
```

This indicates that Ansible treats `/usr/bin/env python` literally and does not invoke its interpreter auto-discovery logic, leading to failures on systems without the python symlink.

To satisfy the requirements of the latest ansible, we update the shebang lines in all affected modules in advance.

#### How did you do it?
To satisfy the requirements of the latest ansible, this PR updates the shebang lines in all affected modules to #!/usr/bin/python.

#### How did you verify/test it?
We need to make sure that this change won't affect current test firstly -- test by pipeline itself. And then, we need to make sure that this change works in the new version -- test locally.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
