### PR TITLE
fix: Remove macsec from 202412 branch

### DIFF
--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -12,7 +12,6 @@ import random
 # Module-level fixtures
 from .everflow_test_utilities import setup_info      # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor      # noqa F401
-from tests.common.macsec.macsec_helper import MACSEC_INFO
 
 pytestmark = [
     pytest.mark.topology("t0", "t1", "t2", "m0")
@@ -187,9 +186,6 @@ class EverflowIPv6Tests(BaseEverflowTest):
         # Capability check; skips when unsupported
         if not setup_info[self.acl_stage()][self.mirror_type()]:
             pytest.skip("{} ACL w/ {} Mirroring not supported, skipping"
-                        .format(self.acl_stage(), self.mirror_type()))
-        if MACSEC_INFO and self.mirror_type() == "egress":
-            pytest.skip("With MACSEC {} ACL w/ {} Mirroring not supported, skipping"
                         .format(self.acl_stage(), self.mirror_type()))
 
         if setup_info['topo'] in ['t0', 'm0_vlan']:


### PR DESCRIPTION
As MACSEC_INFO is only for T2, removing it from this branch

test summary info ================================================================
SKIPPED [2] everflow/test_everflow_ipv6_2.py:343: egress ACL w/ egress Mirroring not supported, skipping
====================================================== 2 skipped, 1 warning in 1286.20s (0:21:26) =======================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_l4_dst_port_range_mirroring[erspan_ipv6-cli-default]>
DEBUG:tests.conftest:append custom_msg: {'dut_check_result': {'pre_sanity_check_failed': True, 'pre_sanity_recovery_failed': False}}
INFO:root:Can not get Allure report URL. Please check logs