### PR TITLE
Fix test_voq_chassis_app_db_consistency config_reload_with_config_save

### DIFF
--- a/tests/common/helpers/voq_lag.py
+++ b/tests/common/helpers/voq_lag.py
@@ -31,7 +31,7 @@ def get_lag_ids_from_chassis_db(duthosts):
     return lag_ids
 
 
-def get_lag_id_from_chassis_db(duthosts):
+def get_lag_id_from_chassis_db(duthosts, portchannel=TMP_PC):
     """
     Get LAG id for a lag form CHASSIS_DB
     Args:
@@ -50,9 +50,9 @@ def get_lag_id_from_chassis_db(duthosts):
         voqdb = VoqDbCli(node)
         lag_list = voqdb.get_lag_list()
         for lag in lag_list:
-            if TMP_PC in lag:
+            if portchannel in lag:
                 lag_id = voqdb.hget_key_value(lag, "lag_id")
-                logging.info("LAG id for lag {} is {}".format(TMP_PC, lag_id))
+                logging.info("LAG id for lag {} is {}".format(portchannel, lag_id))
                 return lag_id
 
         pytest.fail("LAG id for lag {} is not preset in CHASSIS_DB".format(TMP_PC))
@@ -321,7 +321,7 @@ def verify_lag_member_in_remote_asic_db(remote_dut, lag_id, pc_members, deleted=
         verify_lag_member_in_asic_db(dut.asics, lag_id, pc_members, deleted)
 
 
-def verify_lag_member_in_chassis_db(duthosts, members, deleted=False):
+def verify_lag_member_in_chassis_db(duthosts, members, portchannel=TMP_PC, deleted=False):
     """
     verifies lag members for a lag exist in chassis db
     cmd = 'sonic-db-cli CHASSIS_APP_DB KEYS "*SYSTEM_LAG_MEMBER_TABLE*|PortChannel0051*|Ethernet*"'
@@ -332,7 +332,7 @@ def verify_lag_member_in_chassis_db(duthosts, members, deleted=False):
         if deleted:
             for member in members:
                 exist = False
-                pattern = "{}.*{}".format(TMP_PC, member)
+                pattern = "{}.*{}".format(portchannel, member)
                 for lag_member in lag_member_list:
                     if re.search(pattern, lag_member):
                         exist = True
@@ -347,7 +347,7 @@ def verify_lag_member_in_chassis_db(duthosts, members, deleted=False):
         else:
             for member in members:
                 exist = False
-                pattern = "{}.*{}".format(TMP_PC, member)
+                pattern = "{}.*{}".format(portchannel, member)
                 for lag_member in lag_member_list:
                     if re.search(pattern, lag_member):
                         exist = True

--- a/tests/voq/test_voq_chassis_app_db_consistency.py
+++ b/tests/voq/test_voq_chassis_app_db_consistency.py
@@ -51,6 +51,50 @@ def verify_data_in_db(tmp_pc, pc_members, duthosts, pc_nbr_ip, duthost, pc_nbr_i
     return True
 
 
+def verify_data_not_in_db(pc, pc_members, duthosts, pc_nbr_ip, duthost, pc_nbr_ipv6):
+    '''
+    Verification of portchannel data in chassis_app_db tables removed
+    '''
+    # Verification on SYSTEM_LAG_MEMBER_TABLE
+    voq_lag.verify_lag_member_in_chassis_db(duthosts, pc_members, pc, deleted=True)
+    # Verification on SYSTEM_NEIGH for pc_nbr_ip
+    if len(duthosts) == 1:
+        voqdb = VoqDbCli(duthosts.frontend_nodes[0])
+    else:
+        voqdb = VoqDbCli(duthosts.supervisor_nodes[0])
+    neigh_key = voqdb.get_neighbor_key_by_ip(pc_nbr_ip)
+    if pc in neigh_key:
+        logging.error(
+            "{} Portchannel Neigh ip {} is still allocated to portchannel {}"
+            .format(neigh_key, pc_nbr_ip, pc))
+        return False
+
+    # Verification on SYSTEM_NEIGH for pc_nbr_ipv6
+    neigh_key = voqdb.get_neighbor_key_by_ip(pc_nbr_ipv6)
+    if pc in neigh_key:
+        logging.error(
+            "{} Portchannel Neigh ip {} is still allocated to portchannel {}"
+            .format(neigh_key, pc_nbr_ipv6, pc))
+        return False
+
+    # Verification on SYSTEM_INTERFACE
+    # usage of redis_get_keys as voqdb.get_keys will log an ERROR if stdout is empty
+    key = "SYSTEM_INTERFACE|{}*{}".format(duthost.sonichost.hostname, pc)
+    if len(duthosts) == 1:
+        chassis_app_db_result = redis_get_keys(duthosts.frontend_nodes[0],
+                                               "CHASSIS_APP_DB", key)
+    else:
+        chassis_app_db_result = redis_get_keys(duthosts.supervisor_nodes[0],
+                                               "CHASSIS_APP_DB", key)
+
+    if chassis_app_db_result:
+        logging.error(
+            "{} SYSTEM_INTERFACE in Chasiss_APP_DB is still present for portchannel {}"
+            .format(key, pc))
+        return False
+
+    return True
+
 @pytest.mark.parametrize("test_case", ["dut_reboot", "config_reload_with_config_save", "config_reload_no_config_save"])
 def test_voq_chassis_app_db_consistency(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_asic_index,
                                         tbinfo, test_case,
@@ -159,6 +203,10 @@ def test_voq_chassis_app_db_consistency(duthosts, enum_rand_one_per_hwsku_fronte
                 int_facts = asichost.interface_facts()['ansible_facts']
                 if not int_facts['ansible_interface_facts'][tmp_portchannel]['link']:
                     return False
+                # Verify original portchannel is not in db
+                if not verify_data_not_in_db(pc, pc_members, duthosts, pc_nbr_ip, duthost, pc_nbr_ipv6):
+                    return False
+                # Verify tmp portchannel is in db
                 return verify_data_in_db(tmp_portchannel, pc_members, duthosts, pc_nbr_ip, duthost, pc_nbr_ipv6)
             except Exception as e:
                 logging.error("Failed to verify portchannel update: {}".format(e))


### PR DESCRIPTION
This test does not wait to ensure that the original port-channel's data is first removed before doing a config save. Meaning that when doing the config reload, there is an inconsistency between the CHASSIS_APP_DB dumps.

The fix is to add to the wait_until to ensure that the original PC's data is first removed before doing config save.

This PR is a backport of https://github.com/sonic-net/sonic-mgmt/pull/21854 as msft-202503 required additional updates to `tests/common/helpers/voq_lag.py`