### PR TITLE
Cherrypick PR19074 skip speed change for Arista 7060x6 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1399,6 +1399,12 @@ iface_namingmode/test_iface_namingmode.py::TestConfigInterface:
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0']"
 
+iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_speed:
+  skip:
+    reason: "Arista-7060X6 doesn't support speed change as it's ASIC limitation. Skipping this test."
+    conditions:
+       - "'Arista-7060X6' in hwsku"
+
 iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup:
   xfail:
     reason: "Platform specific issue"


### PR DESCRIPTION
PR: https://github.com/sonic-net/sonic-mgmt/pull/19074 is missing backport to msft-202503