### PR TITLE
Improve BGP test to support BGP confederation

### DIFF
--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -46,6 +46,9 @@ def common_setup_teardown(
 
     dut_asn = mg_facts["minigraph_bgp_asn"]
 
+    confed_asn = duthost.get_bgp_confed_asn()
+    use_vtysh = False
+
     dut_type = ""
     for k, v in list(mg_facts["minigraph_devices"].items()):
         if k == duthost.hostname:
@@ -55,6 +58,9 @@ def common_setup_teardown(
         neigh_type = "LeafRouter"
     elif dut_type in ["UpperSpineRouter", "FabricSpineRouter"]:
         neigh_type = "LowerSpineRouter"
+        if dut_type == "FabricSpineRouter" and confed_asn is not None:
+            # For FT2, we need to use vtysh to configure BGP neigh if BGP confed is enabled
+            use_vtysh = True
     else:
         neigh_type = "ToRRouter"
     logging.info(
@@ -73,7 +79,7 @@ def common_setup_teardown(
             ptfhost,
             "pseudoswitch0",
             conn0["neighbor_addr"].split("/")[0],
-            dut_asn if dut_type == "FabricSpineRouter" else NEIGHBOR_ASN0,
+            NEIGHBOR_ASN0,
             conn0["local_addr"].split("/")[0],
             dut_asn,
             NEIGHBOR_PORT0,
@@ -81,10 +87,12 @@ def common_setup_teardown(
             conn0_ns,
             is_multihop=is_quagga or is_dualtor,
             is_passive=False,
+            confed_asn=confed_asn,
+            use_vtysh=use_vtysh
         )
     )
 
-    yield bgp_neighbor
+    yield bgp_neighbor, use_vtysh
 
     # Cleanup suppress-fib-pending config
     delete_tacacs_json = [
@@ -144,7 +152,7 @@ def match_bgp_notification(packet, src_ip, dst_ip, action, bgp_session_down_time
         # error_code 6: Cease, error_subcode 3: Peer De-configured. References: RFC 4271
         return (bgp_fields["error_code"] == 6 and
                 bgp_fields["error_subcode"] == 3 and
-                float(packet.time) < bgp_session_down_time)
+                (bgp_session_down_time is None or float(packet.time) < bgp_session_down_time))
     else:
         return False
 
@@ -191,7 +199,7 @@ def test_bgp_peer_shutdown(
     request,
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    n0 = common_setup_teardown
+    n0, use_vtysh = common_setup_teardown
     announced_route = {"prefix": "10.10.100.0/27", "nexthop": n0.ip}
 
     for _ in range(TEST_ITERATIONS):
@@ -234,7 +242,11 @@ def test_bgp_peer_shutdown(
                     bgp_packet.show(dump=True),
                 )
 
-                bgp_session_down_time = get_bgp_down_timestamp(duthost, n0.namespace, n0.ip, timestamp_before_teardown)
+                if not use_vtysh:
+                    bgp_session_down_time = get_bgp_down_timestamp(duthost, n0.namespace, n0.ip, timestamp_before_teardown)  # noqa: E501
+                else:
+                    # There is no syslog if use vtysh to manage BGP neigh
+                    bgp_session_down_time = None
                 if not match_bgp_notification(bgp_packet, n0.ip, n0.peer_ip, "cease", bgp_session_down_time):
                     pytest.fail("BGP notification packet does not match expected values")
 

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -88,6 +88,8 @@ def common_setup_teardown(
     )
 
     dut_asn = mg_facts["minigraph_bgp_asn"]
+    confed_asn = duthost.get_bgp_confed_asn()
+    use_vtysh = False
 
     dut_type = ""
     for k, v in list(mg_facts["minigraph_devices"].items()):
@@ -98,9 +100,9 @@ def common_setup_teardown(
         neigh_type = "LeafRouter"
     elif dut_type in ["UpperSpineRouter", "FabricSpineRouter"]:
         neigh_type = "LowerSpineRouter"
-        if dut_type == "FabricSpineRouter":
-            global NEIGHBOR_ASN0, NEIGHBOR_ASN1
-            NEIGHBOR_ASN0 = NEIGHBOR_ASN1 = dut_asn
+        if dut_type == "FabricSpineRouter" and confed_asn is not None:
+            # For FT2, we need to use vtysh to configure an external BGP neighbor
+            use_vtysh = True
     else:
         neigh_type = "ToRRouter"
 
@@ -136,6 +138,8 @@ def common_setup_teardown(
             conn0_ns,
             is_multihop=is_quagga or is_dualtor,
             is_passive=False,
+            confed_asn=confed_asn,
+            use_vtysh=use_vtysh
         ),
         BGPNeighbor(
             duthost,
@@ -150,10 +154,12 @@ def common_setup_teardown(
             conn1_ns,
             is_multihop=is_quagga or is_dualtor,
             is_passive=False,
+            confed_asn=confed_asn,
+            use_vtysh=use_vtysh
         ),
     )
 
-    yield bgp_neighbors
+    yield bgp_neighbors, use_vtysh
 
     # Cleanup suppress-fib-pending config
     delete_tacacs_json = [
@@ -276,7 +282,7 @@ def test_bgp_update_timer_single_route(
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-    n0, n1 = common_setup_teardown
+    (n0, n1), _ = common_setup_teardown
     try:
         n0.start_session()
         n1.start_session()
@@ -398,7 +404,7 @@ def test_bgp_update_timer_session_down(
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-    n0, n1 = common_setup_teardown
+    (n0, n1), use_vtysh = common_setup_teardown
     try:
         n0.start_session()
         n1.start_session()
@@ -422,8 +428,24 @@ def test_bgp_update_timer_session_down(
                 pytest.fail("announce route %s from n0 to dut failed" % route["prefix"])
         # close bgp session n0, monitor withdraw info from dut to n1
         bgp_pcap = BGP_DOWN_LOG_TMPL
+
+        def _shutdown_bgp_session():
+            """Shutdown bgp session on dut."""
+            if use_vtysh:
+                dut_asn = n0.peer_asn
+                neigh_ip = n0.ip
+                cmd = (
+                    "vtysh "
+                    "-c 'configure terminal' "
+                    f"-c 'router bgp {dut_asn}' "
+                    f"-c 'neighbor {neigh_ip} shutdown' ")
+            else:
+                cmd = "config bgp shutdown neighbor {}".format(n0.name)
+
+            return duthost.shell(cmd)
+
         with capture_bgp_packages_to_file(duthost, "any", bgp_pcap, n0.namespace):
-            result = duthost.shell("config bgp shutdown neighbor {}".format(n0.name))
+            result = _shutdown_bgp_session()
             bgp_shutdown_time = datetime.strptime(result['end'], "%Y-%m-%d %H:%M:%S.%f").timestamp()
             time.sleep(constants.sleep_interval)
 

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -884,3 +884,21 @@ class MultiAsicSonicHost(object):
             return self.command(f"sudo config interface -n {asic_ns} startup {port}")
         else:
             return self.command(f"sudo config interface startup {port}")
+
+    def get_bgp_confed_asn(self):
+        """
+        Get BGP confederation ASN from running config
+        Return None if not configured
+        """
+        if self.sonichost.is_multi_asic:
+            asic = self.frontend_asics[0]
+            config_facts = asic.config_facts(
+                host=self.hostname, source="running", namespace=asic.namespace
+            )['ansible_facts']
+        else:
+            config_facts = self.sonichost.config_facts(
+                host=self.hostname, source="running"
+            )['ansible_facts']
+
+        bgp_confed_asn = config_facts.get('BGP_DEVICE_GLOBAL', {}).get('CONFED', {}).get('asn', None)
+        return bgp_confed_asn

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -20,6 +20,45 @@ def _write_variable_from_j2_to_configdb(duthost, template_file, **kwargs):
         duthost.file(path=save_dest_path, state="absent")
 
 
+def _config_bgp_neighbor_with_vtysh(duthost, peer_addr, peer_asn, dut_addr, dut_asn):
+    """Configure BGP neighbor using vtysh command"""
+    cmd = (
+        "vtysh "
+        "-c 'configure terminal' "
+        "-c 'router bgp {dut_asn}' "
+        "-c 'neighbor {peer_addr} remote-as {peer_asn}' "
+        "-c 'neighbor {peer_addr} activate' "
+    )
+    duthost.shell(cmd.format(peer_addr=peer_addr,
+                             peer_asn=peer_asn,
+                             dut_addr=dut_addr,
+                             dut_asn=dut_asn))
+
+
+def _remove_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn):
+    """Remove BGP neighbor using vtysh command"""
+    cmd = (
+        "vtysh "
+        "-c 'configure terminal' "
+        "-c 'router bgp {dut_asn}' "
+        "-c 'no neighbor {peer_addr}' "
+    )
+    duthost.shell(cmd.format(peer_addr=peer_addr,
+                             dut_asn=dut_asn))
+
+
+def _shutdown_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn):
+    """Shutdown BGP neighbor using vtysh command"""
+    cmd = (
+        "vtysh "
+        "-c 'configure terminal' "
+        "-c 'router bgp {dut_asn}' "
+        "-c 'neighbor {peer_addr} shutdown' "
+    )
+    duthost.shell(cmd.format(peer_addr=peer_addr,
+                             dut_asn=dut_asn))
+
+
 def run_bgp_facts(duthost, enum_asic_index):
     """compare the bgp facts between observed states and target state"""
 
@@ -59,7 +98,8 @@ class BGPNeighbor(object):
     def __init__(self, duthost, ptfhost, name,
                  neighbor_ip, neighbor_asn,
                  dut_ip, dut_asn, port, neigh_type=None,
-                 namespace=None, is_multihop=False, is_passive=False, debug=False):
+                 namespace=None, is_multihop=False, is_passive=False, debug=False,
+                 confed_asn=None, use_vtysh=False):
         self.duthost = duthost
         self.ptfhost = ptfhost
         self.ptfip = ptfhost.mgmt_ip
@@ -74,12 +114,22 @@ class BGPNeighbor(object):
         self.is_passive = is_passive
         self.is_multihop = not is_passive and is_multihop
         self.debug = debug
+        self.use_vtysh = use_vtysh
+        self.confed_asn = confed_asn
 
     def start_session(self):
         """Start the BGP session."""
         logging.debug("start bgp session %s", self.name)
 
-        if not self.is_passive:
+        if self.use_vtysh:
+            _config_bgp_neighbor_with_vtysh(
+                self.duthost,
+                peer_addr=self.ip,
+                peer_asn=self.asn,
+                dut_addr=self.peer_ip,
+                dut_asn=self.peer_asn
+            )
+        elif not self.is_passive:
             _write_variable_from_j2_to_configdb(
                 self.duthost,
                 "bgp/templates/neighbor_metadata_template.j2",
@@ -111,7 +161,7 @@ class BGPNeighbor(object):
             router_id=self.ip,
             peer_ip=self.peer_ip,
             local_asn=self.asn,
-            peer_asn=self.peer_asn,
+            peer_asn=self.confed_asn if self.confed_asn is not None else self.peer_asn,
             port=self.port,
             debug=self.debug
         )
@@ -131,10 +181,18 @@ class BGPNeighbor(object):
     def stop_session(self):
         """Stop the BGP session."""
         logging.debug("stop bgp session %s", self.name)
-        if not self.is_passive:
+
+        if self.use_vtysh:
+            _remove_bgp_neighbor_with_vtysh(
+                self.duthost,
+                peer_addr=self.ip,
+                dut_asn=self.peer_asn
+            )
+        elif not self.is_passive:
             for asichost in self.duthost.asics:
                 asichost.run_sonic_db_cli_cmd("CONFIG_DB del 'BGP_NEIGHBOR|{}'".format(self.ip))
                 asichost.run_sonic_db_cli_cmd("CONFIG_DB del 'DEVICE_NEIGHBOR_METADATA|{}'".format(self.name))
+
         self.ptfhost.exabgp(name=self.name, state="absent")
 
     def teardown_session(self):
@@ -148,7 +206,14 @@ class BGPNeighbor(object):
         assert resp.status_code == 200
 
         self.ptfhost.exabgp(name=self.name, state="stopped")
-        if not self.is_passive:
+
+        if self.use_vtysh:
+            _shutdown_bgp_neighbor_with_vtysh(
+                self.duthost,
+                peer_addr=self.ip,
+                dut_asn=self.peer_asn
+            )
+        elif not self.is_passive:
             for asichost in self.duthost.asics:
                 if asichost.namespace == self.namespace:
                     logging.debug("update CONFIG_DB admin_status to down on {}".format(asichost.namespace))


### PR DESCRIPTION
Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/21890

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to improve existing BGP tests to support BGP confederation.
Below two tests are improved
-  [test_bgp_peer_shutdown.py](https://github.com/sonic-net/sonic-mgmt/compare/fix_bgp_confed_test?expand=1#diff-9d72d8d9e2fcf1b7573aadae84686354be322286dfce64199d0b158d8002cda0)
- [test_bgp_update_timer.py](https://github.com/sonic-net/sonic-mgmt/compare/fix_bgp_confed_test?expand=1#diff-85d6c9d73bdee5ce2f7bca42ac67428028046115c26e6223a0df78e8706e3bd6)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
This PR is to improve existing BGP tests to support BGP confederation.

#### How did you do it?
1. Improve [bgp.py](https://github.com/sonic-net/sonic-mgmt/compare/fix_bgp_confed_test?expand=1#diff-a6848e9239af6d197528a7960ad94553f237dc318bd195837d5a31a210ff879c) to support using `vtysh` to configure BGP neighbors
2. Improve [multi_asic.py](https://github.com/sonic-net/sonic-mgmt/compare/fix_bgp_confed_test?expand=1#diff-9b70276a3c2fb324d2737f57ab8ae139d7eb30cc886d3717f185088a9f8f241a) to add a helper function to retrieve BGP confederation ASN.

#### How did you verify/test it?
Both tests are verified on LT2/FT2 testbeds.
```
collected 2 items                                                                                                                                                                                                                                              

bgp/test_bgp_update_timer.py::test_bgp_update_timer_single_route[default]  ^HPASSED                                                                                                                                                       [ 50%]
bgp/test_bgp_update_timer.py::test_bgp_update_timer_session_down[default] PASSED                                                                                                                                                       [100%]

collected 1 item                                                                                                                                                                                                                                               

bgp/test_bgp_peer_shutdown.py::test_bgp_peer_shutdown[default]  ^HPASSED                                                                                                                                                                  [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
