### PR TITLE
[202412][PR #21956]disable ipv6 for broadcom SONiC fanout devices.

### DIFF
--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202405.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202405.yml
@@ -153,4 +153,4 @@
     shell: "sysctl -p"
     become: yes
 
-  when: "'mellanox' in fanout_sonic_version.asic_type"
+  when: "fanout_sonic_version.asic_type in ['mellanox', 'broadcom']"


### PR DESCRIPTION
Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/21956 into 202412

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test_qos_sai failures due to unexpected ipv6 packets coming from fanout device

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Disable ipv6 for broadcom SONiC fanout devices.

#### How did you do it?
Add broadcom into the list.

#### How did you verify/test it?
physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
