### PR TITLE
Add gnmi to privileged containers skip list in container hardening te…

### DIFF
--- a/tests/container_hardening/test_container_hardening.py
+++ b/tests/container_hardening/test_container_hardening.py
@@ -20,6 +20,7 @@ PRIVILEGED_CONTAINERS = [
     "syncd",
     "gbsyncd",
     "swss",
+    "gnmi",
 ]
 
 


### PR DESCRIPTION
#### Why I did it

  Cherry-pick gnmi container hardening fix from sonic-net/sonic-mgmt to add gnmi to the privileged containers skip list.

  The gnmi container requires privileged mode to support gNOI operations (host command execution, filesystem access, firmware management), so it should be skipped in the
  container hardening test.

  #### How I did it

  Cherry-picked commit `bf9907b30` from sonic-net/sonic-mgmt:
  - Add gnmi to privileged containers skip list in container hardening test (#20916)

  #### How to verify it

  Run container hardening tests - gnmi container should be skipped instead of failing the privileged check.

  ```bash
  pytest tests/container_hardening/test_container_hardening.py

  Related PRs

  - sonic-net/sonic-mgmt#20916
