### PR TITLE
Fix import for bgp tests

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -17,6 +17,7 @@ from tests.common.helpers.parallel import parallel_run
 from tests.common.helpers.parallel import reset_ansible_local_tmp
 from tests.common.utilities import wait_until, get_plt_reboot_ctrl
 from tests.common.utilities import wait_tcp_connection
+from tests.common.utilities import is_ipv6_only_topology
 from tests.common import config_reload
 from bgp_helpers import define_config, apply_default_bgp_config, DUT_TMP_DIR, TEMPLATE_DIR, BGP_PLAIN_TEMPLATE,\
     BGP_NO_EXPORT_TEMPLATE, DUMP_FILE, CUSTOM_DUMP_SCRIPT, CUSTOM_DUMP_SCRIPT_DEST,\


### PR DESCRIPTION
During BGP tests it will through the error of `NameError: name 'is_ipv6_only_topology' is not defined`
<img width="1328" height="222" alt="image" src="https://github.com/user-attachments/assets/2bedca73-0579-43f4-b701-85e18cbe2bb2" />

Issue come from cherry-pick error,
The original PR do have the import of `is_ipv6_only_topology` in _tests/bgp/conftest.py_
https://github.com/sonic-net/sonic-mgmt/pull/21453/changes#diff-8866e4a46077c5e2198dc61b5dcccbed75cdecdcb7e00580cb49f789b547aa00R20

But during cherry-pick the import line was dropped:
https://github.com/Azure/sonic-mgmt.msft/pull/965/changes#diff-8866e4a46077c5e2198dc61b5dcccbed75cdecdcb7e00580cb49f789b547aa00R188

Verify the fix by remove/adding the import line, reproduce and re-run the test:
<img width="2948" height="122" alt="image" src="https://github.com/user-attachments/assets/b6d9665c-ee7c-4a93-a6f4-cbec0b5850ee" />
