### PR TITLE
Skip pfc storm event based on hwsku

### DIFF
--- a/tests/common/broadcom_data.py
+++ b/tests/common/broadcom_data.py
@@ -4,3 +4,6 @@ def is_broadcom_device(dut):
 
 LOSSY_ONLY_HWSKUS = ['Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8',
                      'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']
+NO_QOS_HWSKUS = ['Arista-7050CX3-32C-C28S16', 'Arista-7050CX3-32C-S128',
+                 'Arista-7050CX3-32C-C6S104', 'Arista-720DT-G48S4',
+                 'Arista-720DT-48S']

--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -13,6 +13,7 @@ SWITCH_HWSKUS = SPC1_HWSKUS + SPC2_HWSKUS + SPC3_HWSKUS + SPC4_HWSKUS + SPC5_HWS
 
 LOSSY_ONLY_HWSKUS = ['Mellanox-SN5600-C256S1', 'Mellanox-SN5600-C224O8', 'Mellanox-SN5640-C512S2',
                      'Mellanox-SN5640-C448O16']
+NO_QOS_HWSKUS = []
 
 PSU_CAPABILITIES = [
     ['psu{}_curr', 'psu{}_curr_in', 'psu{}_power', 'psu{}_power_in', 'psu{}_volt', 'psu{}_volt_in', 'psu{}_volt_out'],

--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -6,7 +6,10 @@ import random
 import re
 
 from run_events_test import run_test
-from tests.common.mellanox_data import LOSSY_ONLY_HWSKUS
+from tests.common.mellanox_data import LOSSY_ONLY_HWSKUS as MELLANOX_LOSSY_ONLY_HWSKUS
+from tests.common.broadcom_data import LOSSY_ONLY_HWSKUS as BROADCOM_LOSSY_ONLY_HWSKUS
+from tests.common.mellanox_data import NO_QOS_HWSKUS as MELLANOX_NO_QOS_HWSKUS
+from tests.common.broadcom_data import NO_QOS_HWSKUS as BROADCOM_NO_QOS_HWSKUS
 from tests.common.utilities import wait_until
 
 random.seed(10)
@@ -30,15 +33,22 @@ WAIT_TIME = 3
 
 
 def test_event(duthost, gnxi_path, ptfhost, ptfadapter, data_dir, validate_yang):
-    if duthost.topo_type.lower() in ["m0", "mx"]:
-        logger.info("Skipping swss events test on MGFX topologies")
-        return
     logger.info("Beginning to test swss events")
     run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, shutdown_interface,
              "if_state.json", "sonic-events-swss:if-state", tag)
-    if duthost.facts["hwsku"] not in LOSSY_ONLY_HWSKUS:
+
+    asic_type = duthost.facts["asic_type"]
+    if asic_type == "mellanox":
+        skip_pfc_hwskus = [*MELLANOX_LOSSY_ONLY_HWSKUS, *MELLANOX_NO_QOS_HWSKUS]
+    elif asic_type == "broadcom":
+        skip_pfc_hwskus = [*BROADCOM_LOSSY_ONLY_HWSKUS, *BROADCOM_NO_QOS_HWSKUS]
+    else:
+        skip_pfc_hwskus = []
+
+    if duthost.facts["hwsku"] not in skip_pfc_hwskus:
         run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, generate_pfc_storm,
                  "pfc_storm.json", "sonic-events-swss:pfc-storm", tag)
+
     run_test(duthost, gnxi_path, ptfhost, data_dir, validate_yang, trigger_crm_threshold_exceeded,
              "chk_crm_threshold.json", "sonic-events-swss:chk_crm_threshold", tag)
 


### PR DESCRIPTION
### Description of PR

Summary:
Skipping swss event verification in telemetry/test_events.py for m1 and m2 topos as this testing is out of scope for the deployment.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Approach
#### What is the motivation for this PR?
We were seeing failures while trying to verify the pfc storm event on m1 topos. This is because there is no QoS config. After inquiring with Microsoft we decided to skip this part of the test since QoS is not needed for the deployment.

#### How did you do it?
Refactored existing skip logic to use a list of hwsku's for skipping instead of topology.

#### How did you verify/test it?
Verified the expected hwsku's were being skipped for broadcom.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
