### PR TITLE
[202503] Fix check_other_vms in test_bgp_bbr.py

### DIFF
--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -371,29 +371,38 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
 
         dut_asn = setup['dut_asn']
         tor1_asn = setup['tor1_asn']
+        vm_route = None
 
-        vm_route = nbrhosts[node]['host'].get_route(route.prefix)
-        if not isinstance(vm_route, dict):
-            logging.warning("DEBUG: unexpected vm_route type {}, {}".format(type(vm_route), vm_route))
-        vm_route['failed'] = False
-        vm_route['message'] = 'Checking route {} on {} passed'.format(str(route), node)
-        if accepted:
-            if route.prefix not in list(vm_route['vrfs']['default']['bgpRouteEntries'].keys()):
-                vm_route['failed'] = True
-                vm_route['message'] = 'No route for {} found on {}'.format(route.prefix, node)
-            else:
-                tor_route_aspath = vm_route['vrfs']['default']['bgpRouteEntries'][route.prefix]['bgpRoutePaths'][0]\
-                    ['asPathEntry']['asPath']   # noqa E211
-                # Route path from other VMs: -> DUT(T1) -> TOR1 -> aspath(other T1 -> DUMMY_ASN1)
-                tor_route_aspath_expected = '{} {} {}'.format(dut_asn, tor1_asn, route.aspath)
-                if tor_route_aspath != tor_route_aspath_expected:
+        def _check_route():
+            nonlocal vm_route
+            vm_route = nbrhosts[node]['host'].get_route(route.prefix)
+            if not isinstance(vm_route, dict):
+                logging.warning("DEBUG: unexpected vm_route type {}, {}".format(type(vm_route), vm_route))
+            vm_route['failed'] = False
+            vm_route['message'] = 'Checking route {} on {} passed'.format(str(route), node)
+            if accepted:
+                if route.prefix not in list(vm_route['vrfs']['default']['bgpRouteEntries'].keys()):
                     vm_route['failed'] = True
-                    vm_route['message'] = 'On {} expected aspath: {}, actual aspath: {}'\
-                        .format(node, tor_route_aspath_expected, tor_route_aspath)
-        else:
-            if route.prefix in list(vm_route['vrfs']['default']['bgpRouteEntries'].keys()):
-                vm_route['failed'] = True
-                vm_route['message'] = 'No route {} expected on {}'.format(route.prefix, node)
+                    vm_route['message'] = 'No route for {} found on {}'.format(route.prefix, node)
+                    return False
+                else:
+                    tor_route_aspath = vm_route['vrfs']['default']['bgpRouteEntries'][route.prefix]\
+                        ['bgpRoutePaths'][0]['asPathEntry']['asPath']   # noqa E211
+                    # Route path from other VMs: -> DUT(T1) -> TOR1 -> aspath(other T1 -> DUMMY_ASN1)
+                    tor_route_aspath_expected = '{} {} {}'.format(dut_asn, tor1_asn, route.aspath)
+                    if tor_route_aspath != tor_route_aspath_expected:
+                        vm_route['failed'] = True
+                        vm_route['message'] = 'On {} expected aspath: {}, actual aspath: {}'\
+                            .format(node, tor_route_aspath_expected, tor_route_aspath)
+                        return False
+            else:
+                if route.prefix in list(vm_route['vrfs']['default']['bgpRouteEntries'].keys()):
+                    vm_route['failed'] = True
+                    vm_route['message'] = 'No route {} expected on {}'.format(route.prefix, node)
+                    return False
+            return True
+
+        wait_until(30, 2, 0, _check_route)
         results[node] = vm_route
 
     other_vms = setup['other_vms']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add wait_until to fix the flakiness of check_other_vms.
Fixes [#21954 ](https://github.com/sonic-net/sonic-mgmt/issues/21954)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202412
- [x] 202505
- [x] 202511
- [x] 202503

### Approach
#### What is the motivation for this PR?
The test is flaky because no retries on check_other_vms

#### How did you do it?
Add wait_until to fix flakiness

#### How did you verify/test it?
Test passed on t1-64-lag topo

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
