### PR TITLE
[202503] Fix test_xon_not_counted.py fanout port selection

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -120,6 +120,41 @@ def list_dut_fanout_connections(dut, fanouthosts):
     return candidates
 
 
+def eos_to_linux_intf(eos_intf_name, hwsku=None):
+    """
+    @Summary: Map EOS's interface name to Linux's interface name
+    @param eos_intf_name: Interface name in EOS
+    @return: Return the interface name in Linux
+    """
+    if hwsku == "MLNX-OS":
+        linux_intf_name = eos_intf_name.replace(
+            "ernet 1/", "sl1p").replace("/", "sp")
+    elif hwsku and "Nokia" in hwsku:
+        linux_intf_name = eos_intf_name
+    else:
+        linux_intf_name = eos_intf_name.replace(
+            'Ethernet', 'et').replace('/', '_')
+    return linux_intf_name
+
+
+def nxos_to_linux_intf(nxos_intf_name):
+    """
+        @Summary: Map NxOS's interface name to Linux's interface name
+        @param nxos_intf_name: Interface name in NXOS
+        @return: Return the interface name in Linux
+    """
+    return nxos_intf_name.replace('Ethernet', 'Eth').replace('/', '-')
+
+
+def sonic_to_linux_intf(sonic_intf_name):
+    """
+    @Summary: Map SONiC's interface name to Linux's interface name
+    @param sonic_intf_name: Interface name in SONiC
+    @return: Return the interface name in Linux
+    """
+    return sonic_intf_name
+
+
 def watch_system_status(dut):
     """
     Watch DUT's system status

--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -34,41 +34,6 @@ def ansible_stdout_to_str(ansible_stdout):
     return result
 
 
-def eos_to_linux_intf(eos_intf_name, hwsku=None):
-    """
-    @Summary: Map EOS's interface name to Linux's interface name
-    @param eos_intf_name: Interface name in EOS
-    @return: Return the interface name in Linux
-    """
-    if hwsku == "MLNX-OS":
-        linux_intf_name = eos_intf_name.replace(
-            "ernet 1/", "sl1p").replace("/", "sp")
-    elif hwsku and "Nokia" in hwsku:
-        linux_intf_name = eos_intf_name
-    else:
-        linux_intf_name = eos_intf_name.replace(
-            'Ethernet', 'et').replace('/', '_')
-    return linux_intf_name
-
-
-def nxos_to_linux_intf(nxos_intf_name):
-    """
-        @Summary: Map NxOS's interface name to Linux's interface name
-        @param nxos_intf_name: Interface name in NXOS
-        @return: Return the interface name in Linux
-    """
-    return nxos_intf_name.replace('Ethernet', 'Eth').replace('/', '-')
-
-
-def sonic_to_linux_intf(sonic_intf_name):
-    """
-    @Summary: Map SONiC's interface name to Linux's interface name
-    @param sonic_intf_name: Interface name in SONiC
-    @return: Return the interface name in Linux
-    """
-    return sonic_intf_name
-
-
 def get_phy_intfs(host_ans):
     """
     @Summary: Get the physical interfaces (e.g., EthernetX) of a DUT

--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -1,6 +1,6 @@
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa F401
+from tests.common.platform.device_utils import eos_to_linux_intf, nxos_to_linux_intf, sonic_to_linux_intf
 from .qos_fixtures import leaf_fanouts      # noqa F401
-from .qos_helpers import eos_to_linux_intf, nxos_to_linux_intf, sonic_to_linux_intf
 import os
 import time
 import pytest


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Follow test_pfc_counters.py, only select active port and convert fanout port to Linux interface name based on its OS.
Move name conversion helper functions to device_utils.py.
Manually cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/22114

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202503
- [x] 202511

### Approach
#### What is the motivation for this PR?
Test failed due to using non-Sonic fanout and we need to select active port only

#### How did you do it?
Fix it by following test_pfc_counters.py and move helper functions to device_utils.py

#### How did you verify/test it?
test_xon_not_counted.py passed with EOS fanout

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
