### PR TITLE
[COPP] Improve RX PPS Calcuation for COPP Tests

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -293,7 +293,7 @@ class ARPTest(PolicyTest):
     def construct_packet(self, port_number):
         src_mac = self.my_mac[port_number]
         src_ip = self.myip
-        dst_ip = self.peerip
+        dst_ip = self.myip  # GARP to avoid triggering ARP response trap
 
         packet = testutils.simple_arp_packet(
             eth_dst='ff:ff:ff:ff:ff:ff',

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -153,48 +153,47 @@ class ControlPlaneBaseTest(BaseTest):
             self.log("Send %d and receive %d packets in the first second (PolicyTest)" % (
                 pre_send_count, rcv_pkt_cnt))
 
-        pre_test_ptf_tx_counter = self.dataplane.get_counters(*send_intf)
-        pre_test_ptf_rx_counter = self.dataplane.get_counters(*recv_intf)
-        pre_test_nn_tx_counter = self.dataplane.get_nn_counters(*send_intf)
-        pre_test_nn_rx_counter = self.dataplane.get_nn_counters(*recv_intf)
-
-        start_time = datetime.datetime.now()
-        end_time = datetime.datetime.now(
-        ) + datetime.timedelta(seconds=self.DEFAULT_SEND_INTERVAL_SEC)
-
         send_count = 0
+        first_capture_complete = False
+        second_capture_complete = False
+        datetime_five_seconds = datetime.timedelta(seconds=5)
+        datetime_fifteen_seconds = datetime.timedelta(seconds=15)
         self.dataplane.flush()
-        while datetime.datetime.now() < end_time:
+        start_time = datetime.datetime.now()
+        end_time = start_time + datetime.timedelta(seconds=self.DEFAULT_SEND_INTERVAL_SEC)
+        while datetime.datetime.now() < end_time + datetime_fifteen_seconds:
             testutils.send_packet(self, send_intf, packet)
             send_count += 1
+
+            if not first_capture_complete and datetime.datetime.now() > start_time + datetime_five_seconds:
+                first_capture_complete = True
+                pre_test_ptf_tx_counter = self.dataplane.get_counters(*send_intf)
+                pre_test_ptf_rx_counter = self.dataplane.get_counters(*recv_intf)
+                pre_test_nn_tx_counter = self.dataplane.get_nn_counters(*send_intf)
+                pre_test_nn_rx_counter = self.dataplane.get_nn_counters(*recv_intf)
+                first_capture_time = datetime.datetime.now()
+            elif not second_capture_complete and datetime.datetime.now() > end_time - datetime_five_seconds:
+                second_capture_complete = True
+                post_test_ptf_tx_counter = self.dataplane.get_counters(*send_intf)
+                post_test_ptf_rx_counter = self.dataplane.get_counters(*recv_intf)
+                post_test_nn_tx_counter = self.dataplane.get_nn_counters(*send_intf)
+                post_test_nn_rx_counter = self.dataplane.get_nn_counters(*recv_intf)
+                second_capture_time = datetime.datetime.now()
 
             # Depending on the server/platform combination it is possible for the server to
             # overwhelm the DUT, so we add an artificial delay here to rate-limit the server.
             time.sleep(1.0 / float(self.default_server_send_rate_limit_pps))
 
-        self.log("Sent out %d packets in %ds" %
-                 (send_count, self.DEFAULT_SEND_INTERVAL_SEC))
-
+        self.log("Sent out %d packets in %ds" % (send_count, self.DEFAULT_SEND_INTERVAL_SEC))
         # Wait a little bit for all the packets to make it through
         time.sleep(self.DEFAULT_RECEIVE_WAIT_TIME)
-        recv_count = testutils.count_matched_packets_all_ports(
-            self, packet, [recv_intf[1]], recv_intf[0], timeout=10)
-        self.log("Received %d packets after sleep %ds" %
-                 (recv_count, self.DEFAULT_RECEIVE_WAIT_TIME))
+        recv_count = testutils.count_matched_packets_all_ports(self, packet, [recv_intf[1]], recv_intf[0], timeout=10)
+        self.log("Received %d packets after sleep %ds" % (recv_count, self.DEFAULT_RECEIVE_WAIT_TIME))
 
-        post_test_ptf_tx_counter = self.dataplane.get_counters(*send_intf)
-        post_test_ptf_rx_counter = self.dataplane.get_counters(*recv_intf)
-        post_test_nn_tx_counter = self.dataplane.get_nn_counters(*send_intf)
-        post_test_nn_rx_counter = self.dataplane.get_nn_counters(*recv_intf)
-
-        ptf_tx_count = int(
-            post_test_ptf_tx_counter[1] - pre_test_ptf_tx_counter[1])
-        nn_tx_count = int(
-            post_test_nn_tx_counter[1] - pre_test_nn_tx_counter[1])
-        ptf_rx_count = int(
-            post_test_ptf_rx_counter[0] - pre_test_ptf_rx_counter[0])
-        nn_rx_count = int(
-            post_test_nn_rx_counter[0] - pre_test_nn_rx_counter[0])
+        ptf_tx_count = int(post_test_ptf_tx_counter[1] - pre_test_ptf_tx_counter[1])
+        nn_tx_count = int(post_test_nn_tx_counter[1] - pre_test_nn_tx_counter[1])
+        ptf_rx_count = int(post_test_ptf_rx_counter[0] - pre_test_ptf_rx_counter[0])
+        nn_rx_count = int(post_test_nn_rx_counter[0] - pre_test_nn_rx_counter[0])
 
         self.log("", True)
         self.log("Counters before the test:", True)
@@ -214,11 +213,10 @@ class ControlPlaneBaseTest(BaseTest):
         self.log("Recv from If on remote ptf_nn_agent:      %d" % ptf_rx_count)
         self.log("Recv from NN on from remote ptf_nn_agent: %d" % nn_rx_count)
 
-        time_delta = end_time - start_time
-        time_delta_ms = (time_delta.microseconds +
-                         time_delta.seconds * 10**6) / 1000
-        tx_pps = int(send_count / (float(time_delta_ms) / 1000))
-        rx_pps = int(recv_count / (float(time_delta_ms) / 1000))
+        time_delta = second_capture_time - first_capture_time
+        time_delta_ms = (time_delta.microseconds + time_delta.seconds * 10**6) / 1000
+        tx_pps = int(nn_tx_count / (float(time_delta_ms) / 1000))
+        rx_pps = int(nn_rx_count / (float(time_delta_ms) / 1000))
 
         return send_count, recv_count, time_delta, time_delta_ms, tx_pps, rx_pps
 


### PR DESCRIPTION
### Description of PR
The current calculation method for the RX PPS rate for the COPP tests is not very accurate (in some cases 130-150% above nominal) due to the reliance of sampling received packets at the ptf container on the testbed server after sending the packet stream, while also using a timeout to wait for said packets to finish arriving. This does not capture the in-flight RX PPS rate, but rather takes an average outside of the actual packet transmission window, and incurs additional inaccuracies due to the wait time at the end.

A more accurate approach implemented here is to take two snapshots of the RX packet count at the NN agent on the dut itself while the packet stream is already running, and calculate the difference.



Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412
- [x] 202511

### Approach
#### What is the motivation for this PR?
To fix neighbor_miss tests failing for TH5 duts on 202412, and enhance the COPP tests overall for more accurate results.

#### How did you do it?
Updated the calculation method used to get the RX PPS rate for the COPP tests.

#### How did you verify/test it?
Ran the copp tests and verified that the resulting RX PPS values were within range.