### PR TITLE
[hft]: Remove default golden config of high frequency telemetry (#21634)

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -310,19 +310,6 @@ class GenerateGoldenConfigDBModule(object):
 
         return json.dumps(gold_config_db, indent=4)
 
-    def generate_dummy_hft_config_db(self, config):
-        json_config = json.loads(config)
-        json_config["HIGH_FREQUENCY_TELEMETRY_PROFILE"] = {
-            "default": {
-                "stream_state": "disabled",
-                "poll_interval": "10000"
-            }
-        }
-        json_config["HIGH_FREQUENCY_TELEMETRY_GROUP"] = {
-            "default|PORT": {}
-        }
-        return json.dumps(json_config, indent=4)
-
     def generate(self):
         module_msg = "Success to generate golden_config_db.json"
         # topo check
@@ -337,10 +324,6 @@ class GenerateGoldenConfigDBModule(object):
             config = self.generate_full_lossy_golden_config_db()
         else:
             config = "{}"
-
-        # Generate dummy table for HFT
-        if not multi_asic.is_multi_asic():
-            config = self.generate_dummy_hft_config_db(config)
 
         with open(GOLDEN_CONFIG_DB_PATH, "w") as temp_file:
             temp_file.write(config)


### PR DESCRIPTION
What is the motivation for this PR?
The default HFT configuration isn't needed, because the GCU doesn't require an existing table.

How did you do it?
Remove the default golden configuration of HFT

How did you verify/test it?
Check the Azp that doesn't have regression

Original PR: https://github.com/sonic-net/sonic-mgmt/pull/21634