### PR TITLE
Fixing test errors in `test_ecn_config_update.py`

### DIFF
--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -140,7 +140,7 @@ def get_wred_profiles(duthost):
 
 
 # Determines how the value of each field should change to satisfy different constraints (explained below).
-def determine_delta_values(ecn_data, fields):
+def determine_delta_values(ecn_data, fields, wred_green_enabled):
     # Extra care should be taken when changing "green_min_threshold" and "green_max_threshold". "green_min_threshold"
     # must always be less than "green_max_threshold". Also, "green_max_threshold" must be less than the available
     # buffer pool size. Note that some platforms (e.g., Mellanox) round-up the value of "green_max_threshold" if
@@ -148,6 +148,9 @@ def determine_delta_values(ecn_data, fields):
     # less than the buffer pool size. So to avoid potential issues, we never attempt to increase
     # "green_max_threshold".
     delta = {"green_min_threshold": 0, "green_max_threshold": 0, "green_drop_probability": 0}
+
+    if not wred_green_enabled:  # If 'wred_green_enable' is false, don't change the WRED profile.
+        return delta
 
     min_threshold = int(ecn_data["green_min_threshold"])
     max_threshold = int(ecn_data["green_max_threshold"])
@@ -194,11 +197,18 @@ def determine_delta_values(ecn_data, fields):
     return delta
 
 
+@pytest.fixture
+def create_tmpfile(duthost):
+    tmpfile = generate_tmpfile(duthost)
+    yield tmpfile
+    delete_tmpfile(duthost, tmpfile)
+
+
 @pytest.mark.parametrize("configdb_field", ["green_min_threshold", "green_max_threshold", "green_drop_probability",
                          "green_min_threshold,green_max_threshold,green_drop_probability"])
 @pytest.mark.parametrize("operation", ["replace"])
-def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, operation):
-    tmpfile = generate_tmpfile(duthost)
+def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, operation, create_tmpfile):  # noqa F811
+    tmpfile = create_tmpfile
     logger.info("tmpfile {} created for json patch of field: {} and operation: {}"
                 .format(tmpfile, configdb_field, operation))
 
@@ -210,32 +220,34 @@ def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, opera
     # new_values is a dictionary from WRED profile name to its field-value mapping (with new values)
     # for the fields in configdb_field.
     new_values = {}
-    # Creating a JSON patch for all WRED profiles in CONFIG_DB.
+    # Creating a JSON patch for all WRED profiles in CONFIG_DB for which 'wred_green_enable' is true.
     for wred_profile in wred_profiles:
         ecn_data = duthost.shell(f"sonic-db-cli CONFIG_DB hgetall 'WRED_PROFILE|{wred_profile}'")["stdout"]
         ecn_data = ast.literal_eval(ecn_data)
-        delta = determine_delta_values(ecn_data, fields)
+        wred_green_enabled = ecn_data.get("wred_green_enable", "false").lower() == "true"
+        if not wred_green_enabled:
+            logger.info(f"Not modifying the WRED profile {wred_profile} since 'wred_green_enable' is false.")
+        delta = determine_delta_values(ecn_data, fields, wred_green_enabled)
         new_values[wred_profile] = {}
         for field in fields:
             value = int(ecn_data[field])
             value += delta[field]
             new_values[wred_profile][field] = value
+            if wred_green_enabled:
+                logger.info("value to be added to json patch: {}, operation: {}, field: {}"
+                            .format(value, operation, field))
+                json_patch.append(
+                                  {"op": "{}".format(operation),
+                                   "path": f"/WRED_PROFILE/{wred_profile}/{field}",
+                                   "value": "{}".format(value)})
 
-            logger.info("value to be added to json patch: {}, operation: {}, field: {}"
-                        .format(value, operation, field))
-
-            json_patch.append(
-                              {"op": "{}".format(operation),
-                               "path": f"/WRED_PROFILE/{wred_profile}/{field}",
-                               "value": "{}".format(value)})
+    if not json_patch:
+        pytest.skip("Not updating any WRED profiles, so skipping the test.")
 
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
-    try:
-        output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
-        if is_valid_platform_and_version(duthost, "WRED_PROFILE", "ECN tuning", operation):
-            expect_op_success(duthost, output)
-            ensure_application_of_updated_config(duthost, fields, new_values)
-        else:
-            expect_op_failure(output)
-    finally:
-        delete_tmpfile(duthost, tmpfile)
+    output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+    if is_valid_platform_and_version(duthost, "WRED_PROFILE", "ECN tuning", operation):
+        expect_op_success(duthost, output)
+        ensure_application_of_updated_config(duthost, fields, new_values)
+    else:
+        expect_op_failure(output)


### PR DESCRIPTION
When updating `green_min_threshold`, `green_max_threshold`, or `green_drop_probability` in WRED profiles for which `wred_green_enable` is false (or not set) using the `apply-patch` command, sometimes we see these errors:
```
ERR syncd#syncd: [none] SAI_API_PORT:_brcm_sai_cosq_gport_discard_set:6205 cosq gport discard set failed with error Invalid parameter (0xfffffffc)
ERR syncd#syncd: [none] SAI_API_QUEUE:_brcm_sai_qos_queue_wred_set:1760 sai cosq gport discard set failed with error -5.
ERR syncd#syncd: [none] SAI_API_WRED:_brcm_xgs_sai_reapply_wred_profile:882 Apply queue config failed with error -5.
```
This PR fixes this issue by modifying `test_ecn_config_update.py` to not generate JSON patches for WRED profiles for which `wred_green_enable` is false (or not set). After this fix, these tests passed on a device on which the same tests failed before the fix:
```
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_min_threshold] PASSED                                         [ 25%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_max_threshold] PASSED                                         [ 50%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_drop_probability] PASSED                                      [ 75%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_min_threshold,green_max_threshold,green_drop_probability] PASSED [100%]
```