### PR TITLE
[cherry-pick] Stabilize default-routes test and handle AZNG upstream LC route-map behavior

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -48,7 +48,7 @@ def is_in_neighbor(neigh_types, neigh_name):
     return False
 
 
-def get_upstream_neigh(tb, device_neigh_metadata):
+def get_upstream_neigh(tb, device_neigh_metadata, af, nexthops):
     """
     Get the information for upstream neighbors present in the testbed
 
@@ -73,14 +73,14 @@ def get_upstream_neigh(tb, device_neigh_metadata):
         ipv6_addr = None
         for intf, intf_cfg in list(interfaces.items()):
             if 'Port-Channel' in intf:
-                if 'ipv4' in intf_cfg:
+                if 'ipv4' in intf_cfg and af in intf_cfg and interfaces[intf]['ipv4'].split('/')[0] in nexthops:
                     ipv4_addr = interfaces[intf]['ipv4'].split('/')[0]
-                if 'ipv6' in intf_cfg:
+                if 'ipv6' in intf_cfg and af in intf_cfg and interfaces[intf]['ipv6'].split('/')[0].lower() in nexthops:
                     ipv6_addr = interfaces[intf]['ipv6'].split('/')[0]
             elif 'Ethernet' in intf:
-                if 'ipv4' in intf_cfg:
+                if 'ipv4' in intf_cfg and af in intf_cfg and interfaces[intf]['ipv4'].split('/')[0] in nexthops:
                     ipv4_addr = interfaces[intf]['ipv4']
-                if 'ipv6' in intf_cfg:
+                if 'ipv6' in intf_cfg and af in intf_cfg and interfaces[intf]['ipv6'].split('/')[0].lower() in nexthops:
                     ipv6_addr = interfaces[intf]['ipv6']
             else:
                 continue
@@ -125,10 +125,10 @@ def verify_default_route_in_app_db(duthost, tbinfo, af, uplink_ns, device_neigh_
     pytest_assert(nexthops is not None, "Default route has not nexthops")
     logging.info("nexthops in app_db {}".format(nexthops))
 
-    upstream_neigh = get_upstream_neigh(tbinfo, device_neigh_metadata)
+    upstream_neigh = get_upstream_neigh(tbinfo, device_neigh_metadata, af, nexthops)
     pytest_assert(upstream_neigh is not None,
                   "No upstream neighbors in the testbed")
-
+    upstream_neigh = {k: v for k, v in upstream_neigh.items() if any(upstream_neigh.get(k))}
     if af == 'ipv4':
         upstream_neigh_ip = set([upstream_neigh[neigh][0]
                                 for neigh in upstream_neigh])


### PR DESCRIPTION
Manual Cherry-Picking PRs: https://github.com/sonic-net/sonic-mgmt/pull/15962 & https://github.com/sonic-net/sonic-mgmt/pull/16532

This PR fixes issue https://github.com/sonic-net/sonic-mgmt/issues/9052, where 'test_default_route_with_bgp_flap' fails with "Default route nexthops doesn't match the testbed topology" issue.

The count of the next hops is not matching with the upstream neighbor as per the topology (reading data from config facts).

In addition to the fix provided by https://github.com/sonic-net/sonic-mgmt/pull/15962 for the issue https://github.com/sonic-net/sonic-mgmt/issues/9052, this code change is also needed for handling AZNG route map changes on upstream LC.
