### PR TITLE
Cherry-pick sonic-mgmt PR20985 to msft-202503

### DIFF
--- a/tests/snmp/test_snmp_link_local.py
+++ b/tests/snmp/test_snmp_link_local.py
@@ -57,7 +57,7 @@ def test_snmp_link_local_ip(duthosts,
     # Restart snmp service to regenerate snmpd.conf with
     # link local IP configured in MGMT_INTERFACE
     duthost.shell("config snmpagentaddress add {}%eth0".format(link_local_ip))
-    if not wait_until(60, 5, 0, is_snmpagent_listen_on_ip, duthost, link_local_ip):
+    if not wait_until(300, 5, 0, is_snmpagent_listen_on_ip, duthost, link_local_ip):
         pytest.fail("SNMP agent not listen on link local IP {}".format(link_local_ip))
     stdout_lines = duthost.shell("docker exec snmp snmpget \
                                  -v2c -c {} {}%eth0 {}"


### PR DESCRIPTION
Cherry-pick changes from https://github.com/sonic-net/sonic-mgmt/pull/20985

See the PR for more details.

> Summary:
At the end of the snmp/test_snmp_link_local.py test, the test will run a config_reload to clean up the test, then check that the snmp container is up and running before ending the test.
Currently, the test gives 60s for the snmp container to come back up after config_reload. This is sufficient for small topos but nowhere enough for large topos such as qspf t0-d32u32s2 - it takes 7 minutes from running config_reload to seeing interfaces coming back up.