### PR TITLE
[202503] Fix tests/override_config_table/test_override_config_table_masic.py to support LT2 / FT2

### DIFF
--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -6,7 +6,8 @@ from tests.common.utilities import skip_release
 from tests.common.utilities import update_pfcwd_default_state
 from tests.common.config_reload import config_reload
 from tests.common.utilities import backup_config, restore_config, get_running_config,\
-    reload_minigraph_with_golden_config, file_exists_on_dut, NON_USER_CONFIG_TABLES
+    reload_minigraph_with_golden_config, file_exists_on_dut, compare_dicts_ignore_list_order, \
+    NON_USER_CONFIG_TABLES
 
 GOLDEN_CONFIG = "/etc/sonic/golden_config_db.json"
 GOLDEN_CONFIG_BACKUP = "/etc/sonic/golden_config_db.json_before_override"
@@ -89,6 +90,9 @@ def load_minigraph_with_golden_empty_input(duthost):
     initial_asic0_config = get_running_config(duthost, "asic0")
 
     empty_input = {}
+
+    problem_tuples = []
+
     reload_minigraph_with_golden_config(duthost, empty_input)
 
     # Test host running config override
@@ -96,21 +100,30 @@ def load_minigraph_with_golden_empty_input(duthost):
     for table in initial_host_config:
         if table in NON_USER_CONFIG_TABLES:
             continue
-        pytest_assert(
-            initial_host_config[table] == host_current_config[table],
-            "empty input compare fail! {}".format(table)
-        )
+
+        if table == "ACL_TABLE":
+            if not compare_dicts_ignore_list_order(initial_host_config[table],
+                                                   host_current_config[table]):
+                problem_tuples.append((table, None))
+        else:
+            if not initial_host_config[table] == host_current_config[table]:
+                problem_tuples.append((table, None))
 
     # Test asic0 running config override
     asic0_current_config = get_running_config(duthost, "asic0")
     for table in initial_asic0_config:
         if table in NON_USER_CONFIG_TABLES:
             continue
-        pytest_assert(
-            initial_asic0_config[table] == asic0_current_config[table],
-            "empty input compare fail! {}".format(table)
-        )
 
+        if table == "ACL_TABLE":
+            if not compare_dicts_ignore_list_order(initial_asic0_config[table],
+                                                   asic0_current_config[table]):
+                problem_tuples.append((table, "asic0"))
+        else:
+            if not initial_asic0_config[table] == asic0_current_config[table]:
+                problem_tuples.append((table, "asic0"))
+
+    pytest_assert(not problem_tuples, "empty input compare fail: {}".format(problem_tuples))
 
 def load_minigraph_with_golden_partial_config(duthost):
     """Test Golden Config with partial config.

--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -9,6 +9,10 @@ from tests.common.utilities import backup_config, restore_config, get_running_co
     reload_minigraph_with_golden_config, file_exists_on_dut, compare_dicts_ignore_list_order, \
     NON_USER_CONFIG_TABLES
 
+# Tables known to be overriden in run-time config, which will appear different
+# if the golden config is overridden empty.
+GOLDEN_OVERRRIDDEN_TABLES = ["FEATURE", "PORT"]
+
 GOLDEN_CONFIG = "/etc/sonic/golden_config_db.json"
 GOLDEN_CONFIG_BACKUP = "/etc/sonic/golden_config_db.json_before_override"
 CONFIG_DB = "/etc/sonic/config_db.json"
@@ -98,7 +102,7 @@ def load_minigraph_with_golden_empty_input(duthost):
     # Test host running config override
     host_current_config = get_running_config(duthost)
     for table in initial_host_config:
-        if table in NON_USER_CONFIG_TABLES:
+        if table in NON_USER_CONFIG_TABLES or table in GOLDEN_OVERRRIDDEN_TABLES:
             continue
 
         if table == "ACL_TABLE":
@@ -112,7 +116,7 @@ def load_minigraph_with_golden_empty_input(duthost):
     # Test asic0 running config override
     asic0_current_config = get_running_config(duthost, "asic0")
     for table in initial_asic0_config:
-        if table in NON_USER_CONFIG_TABLES:
+        if table in NON_USER_CONFIG_TABLES or table in GOLDEN_OVERRRIDDEN_TABLES:
             continue
 
         if table == "ACL_TABLE":


### PR DESCRIPTION
These changes are very similar to https://github.com/Azure/sonic-mgmt.msft/pull/928.

They target the multi-ASIC version of the test case.

Two changes are made to the function load_minigraph_with_golden_empty_input.

The enhancement is to gather the names of all tables for which a mismatch occur so that the assertion lists all of them, rather than just the first one.

The second is to add exceptions for the "FEATURE" and "PORT" tables. With this change, the rest of the test case passes.