### PR TITLE
Add Arista 7280DR3A* SKUs in sku-sensors-data.yml

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -6784,3 +6784,683 @@ sensors_checks:
       temp: [ ]
     psu_skips: { }
     sensor_skip_per_version: { }
+
+  x86_64-arista_7280dr3a_36:
+    alarms:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_alarm
+      - dps800-i2c-21-58/fan1/fan1_fault
+      - dps800-i2c-21-58/fan2/fan2_alarm
+      - dps800-i2c-21-58/fan2/fan2_fault
+      - dps800-i2c-22-58/fan1/fan1_alarm
+      - dps800-i2c-22-58/fan1/fan1_fault
+      - dps800-i2c-22-58/fan2/fan2_alarm
+      - dps800-i2c-22-58/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan1/fan1_fault
+      - scd_fan_p3-pci-00c7/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan3/fan3_fault
+      - scd_fan_p3-pci-00c7/fan4/fan4_fault
+      power:
+      - dps800-i2c-21-58/iin/curr1_crit_alarm
+      - dps800-i2c-21-58/iin/curr1_max_alarm
+      - dps800-i2c-21-58/iout1/curr2_crit_alarm
+      - dps800-i2c-21-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-21-58/iout1/curr2_max_alarm
+      - dps800-i2c-21-58/pin/power1_alarm
+      - dps800-i2c-21-58/pout1/power2_cap_alarm
+      - dps800-i2c-21-58/pout1/power2_crit_alarm
+      - dps800-i2c-21-58/pout1/power2_max_alarm
+      - dps800-i2c-21-58/vin/in1_crit_alarm
+      - dps800-i2c-21-58/vin/in1_lcrit_alarm
+      - dps800-i2c-21-58/vin/in1_max_alarm
+      - dps800-i2c-21-58/vin/in1_min_alarm
+      - dps800-i2c-21-58/vout1/in3_crit_alarm
+      - dps800-i2c-21-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-21-58/vout1/in3_max_alarm
+      - dps800-i2c-21-58/vout1/in3_min_alarm
+      - dps800-i2c-22-58/iin/curr1_crit_alarm
+      - dps800-i2c-22-58/iin/curr1_max_alarm
+      - dps800-i2c-22-58/iout1/curr2_crit_alarm
+      - dps800-i2c-22-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-22-58/iout1/curr2_max_alarm
+      - dps800-i2c-22-58/pin/power1_alarm
+      - dps800-i2c-22-58/pout1/power2_cap_alarm
+      - dps800-i2c-22-58/pout1/power2_crit_alarm
+      - dps800-i2c-22-58/pout1/power2_max_alarm
+      - dps800-i2c-22-58/vin/in1_crit_alarm
+      - dps800-i2c-22-58/vin/in1_lcrit_alarm
+      - dps800-i2c-22-58/vin/in1_max_alarm
+      - dps800-i2c-22-58/vin/in1_min_alarm
+      - dps800-i2c-22-58/vout1/in3_crit_alarm
+      - dps800-i2c-22-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-22-58/vout1/in3_max_alarm
+      - dps800-i2c-22-58/vout1/in3_min_alarm
+      temp:
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_min_alarm
+      - max6658-i2c-9-4c/temp1/temp1_crit_alarm
+      - max6658-i2c-9-4c/temp1/temp1_max_alarm
+      - max6658-i2c-9-4c/temp1/temp1_min_alarm
+      - max6658-i2c-9-4c/temp2/temp2_crit_alarm
+      - max6658-i2c-9-4c/temp2/temp2_fault
+      - max6658-i2c-9-4c/temp2/temp2_max_alarm
+      - max6658-i2c-9-4c/temp2/temp2_min_alarm
+      - nvme-pci-0500/Composite/temp1_alarm
+      - tmp464-i2c-28-48/temp1/temp1_crit_alarm
+      - tmp464-i2c-28-48/temp1/temp1_max_alarm
+      - tmp464-i2c-28-48/temp2/temp2_crit_alarm
+      - tmp464-i2c-28-48/temp2/temp2_fault
+      - tmp464-i2c-28-48/temp2/temp2_max_alarm
+      - tmp464-i2c-28-48/temp3/temp3_crit_alarm
+      - tmp464-i2c-28-48/temp3/temp3_fault
+      - tmp464-i2c-28-48/temp3/temp3_max_alarm
+      - tmp464-i2c-28-48/temp4/temp4_crit_alarm
+      - tmp464-i2c-28-48/temp4/temp4_fault
+      - tmp464-i2c-28-48/temp4/temp4_max_alarm
+      - tmp464-i2c-28-48/temp5/temp5_crit_alarm
+      - tmp464-i2c-28-48/temp5/temp5_fault
+      - tmp464-i2c-28-48/temp5/temp5_max_alarm
+      - tmp464-i2c-28-48/temp6/temp6_crit_alarm
+      - tmp464-i2c-28-48/temp6/temp6_fault
+      - tmp464-i2c-28-48/temp6/temp6_max_alarm
+      - tmp464-i2c-28-48/temp7/temp7_crit_alarm
+      - tmp464-i2c-28-48/temp7/temp7_fault
+      - tmp464-i2c-28-48/temp7/temp7_max_alarm
+      - tmp464-i2c-28-48/temp8/temp8_crit_alarm
+      - tmp464-i2c-28-48/temp8/temp8_fault
+      - tmp464-i2c-28-48/temp8/temp8_max_alarm
+      - tmp464-i2c-28-48/temp9/temp9_crit_alarm
+      - tmp464-i2c-28-48/temp9/temp9_fault
+      - tmp464-i2c-28-48/temp9/temp9_max_alarm
+
+    compares:
+      fan: [ ]
+      power: [ ]
+      temp:
+      - - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_input
+        - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit
+      - - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_input
+        - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_input
+        - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit
+      - - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_input
+        - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit
+      - - max6658-i2c-9-4c/temp1/temp1_input
+        - max6658-i2c-9-4c/temp1/temp1_crit
+      - - max6658-i2c-9-4c/temp2/temp2_input
+        - max6658-i2c-9-4c/temp2/temp2_crit
+      - - nvme-pci-0500/Composite/temp1_input
+        - nvme-pci-0500/Composite/temp1_crit
+      - - tmp464-i2c-28-48/temp1/temp1_input
+        - tmp464-i2c-28-48/temp1/temp1_crit
+      - - tmp464-i2c-28-48/temp2/temp2_input
+        - tmp464-i2c-28-48/temp2/temp2_crit
+      - - tmp464-i2c-28-48/temp3/temp3_input
+        - tmp464-i2c-28-48/temp3/temp3_crit
+      - - tmp464-i2c-28-48/temp4/temp4_input
+        - tmp464-i2c-28-48/temp4/temp4_crit
+      - - tmp464-i2c-28-48/temp5/temp5_input
+        - tmp464-i2c-28-48/temp5/temp5_crit
+
+    non_zero:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_input
+      - dps800-i2c-21-58/fan2/fan2_input
+      - dps800-i2c-22-58/fan1/fan1_input
+      - dps800-i2c-22-58/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan1/fan1_input
+      - scd_fan_p3-pci-00c7/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan3/fan3_input
+      - scd_fan_p3-pci-00c7/fan4/fan4_input
+      power: [ ]
+      temp: [ ]
+
+    psu_skips:
+      dps800-i2c-21-58:
+        number: 1
+        side: left
+        skip_list:
+        - dps800-i2c-21-58
+      dps800-i2c-22-58:
+        number: 2
+        side: right
+        skip_list:
+        - dps800-i2c-22-58
+
+    sensor_skip_per_version: { }
+
+  x86_64-arista_7280dr3ak_36:
+    alarms:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_alarm
+      - dps800-i2c-21-58/fan1/fan1_fault
+      - dps800-i2c-21-58/fan2/fan2_alarm
+      - dps800-i2c-21-58/fan2/fan2_fault
+      - dps800-i2c-22-58/fan1/fan1_alarm
+      - dps800-i2c-22-58/fan1/fan1_fault
+      - dps800-i2c-22-58/fan2/fan2_alarm
+      - dps800-i2c-22-58/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan1/fan1_fault
+      - scd_fan_p3-pci-00c7/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan3/fan3_fault
+      - scd_fan_p3-pci-00c7/fan4/fan4_fault
+      power:
+      - dps800-i2c-21-58/iin/curr1_crit_alarm
+      - dps800-i2c-21-58/iin/curr1_max_alarm
+      - dps800-i2c-21-58/iout1/curr2_crit_alarm
+      - dps800-i2c-21-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-21-58/iout1/curr2_max_alarm
+      - dps800-i2c-21-58/pin/power1_alarm
+      - dps800-i2c-21-58/pout1/power2_cap_alarm
+      - dps800-i2c-21-58/pout1/power2_crit_alarm
+      - dps800-i2c-21-58/pout1/power2_max_alarm
+      - dps800-i2c-21-58/vin/in1_crit_alarm
+      - dps800-i2c-21-58/vin/in1_lcrit_alarm
+      - dps800-i2c-21-58/vin/in1_max_alarm
+      - dps800-i2c-21-58/vin/in1_min_alarm
+      - dps800-i2c-21-58/vout1/in3_crit_alarm
+      - dps800-i2c-21-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-21-58/vout1/in3_max_alarm
+      - dps800-i2c-21-58/vout1/in3_min_alarm
+      - dps800-i2c-22-58/iin/curr1_crit_alarm
+      - dps800-i2c-22-58/iin/curr1_max_alarm
+      - dps800-i2c-22-58/iout1/curr2_crit_alarm
+      - dps800-i2c-22-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-22-58/iout1/curr2_max_alarm
+      - dps800-i2c-22-58/pin/power1_alarm
+      - dps800-i2c-22-58/pout1/power2_cap_alarm
+      - dps800-i2c-22-58/pout1/power2_crit_alarm
+      - dps800-i2c-22-58/pout1/power2_max_alarm
+      - dps800-i2c-22-58/vin/in1_crit_alarm
+      - dps800-i2c-22-58/vin/in1_lcrit_alarm
+      - dps800-i2c-22-58/vin/in1_max_alarm
+      - dps800-i2c-22-58/vin/in1_min_alarm
+      - dps800-i2c-22-58/vout1/in3_crit_alarm
+      - dps800-i2c-22-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-22-58/vout1/in3_max_alarm
+      - dps800-i2c-22-58/vout1/in3_min_alarm
+      temp:
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_min_alarm
+      - max6658-i2c-9-4c/temp1/temp1_crit_alarm
+      - max6658-i2c-9-4c/temp1/temp1_max_alarm
+      - max6658-i2c-9-4c/temp1/temp1_min_alarm
+      - max6658-i2c-9-4c/temp2/temp2_crit_alarm
+      - max6658-i2c-9-4c/temp2/temp2_fault
+      - max6658-i2c-9-4c/temp2/temp2_max_alarm
+      - max6658-i2c-9-4c/temp2/temp2_min_alarm
+      - nvme-pci-0500/Composite/temp1_alarm
+      - tmp464-i2c-28-48/temp1/temp1_crit_alarm
+      - tmp464-i2c-28-48/temp1/temp1_max_alarm
+      - tmp464-i2c-28-48/temp2/temp2_crit_alarm
+      - tmp464-i2c-28-48/temp2/temp2_fault
+      - tmp464-i2c-28-48/temp2/temp2_max_alarm
+      - tmp464-i2c-28-48/temp3/temp3_crit_alarm
+      - tmp464-i2c-28-48/temp3/temp3_fault
+      - tmp464-i2c-28-48/temp3/temp3_max_alarm
+      - tmp464-i2c-28-48/temp4/temp4_crit_alarm
+      - tmp464-i2c-28-48/temp4/temp4_fault
+      - tmp464-i2c-28-48/temp4/temp4_max_alarm
+      - tmp464-i2c-28-48/temp5/temp5_crit_alarm
+      - tmp464-i2c-28-48/temp5/temp5_fault
+      - tmp464-i2c-28-48/temp5/temp5_max_alarm
+      - tmp464-i2c-28-48/temp6/temp6_crit_alarm
+      - tmp464-i2c-28-48/temp6/temp6_fault
+      - tmp464-i2c-28-48/temp6/temp6_max_alarm
+      - tmp464-i2c-28-48/temp7/temp7_crit_alarm
+      - tmp464-i2c-28-48/temp7/temp7_fault
+      - tmp464-i2c-28-48/temp7/temp7_max_alarm
+      - tmp464-i2c-28-48/temp8/temp8_crit_alarm
+      - tmp464-i2c-28-48/temp8/temp8_fault
+      - tmp464-i2c-28-48/temp8/temp8_max_alarm
+      - tmp464-i2c-28-48/temp9/temp9_crit_alarm
+      - tmp464-i2c-28-48/temp9/temp9_fault
+      - tmp464-i2c-28-48/temp9/temp9_max_alarm
+
+    compares:
+      fan: [ ]
+      power: [ ]
+      temp:
+      - - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_input
+        - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit
+      - - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_input
+        - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_input
+        - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit
+      - - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_input
+        - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit
+      - - max6658-i2c-9-4c/temp1/temp1_input
+        - max6658-i2c-9-4c/temp1/temp1_crit
+      - - max6658-i2c-9-4c/temp2/temp2_input
+        - max6658-i2c-9-4c/temp2/temp2_crit
+      - - nvme-pci-0500/Composite/temp1_input
+        - nvme-pci-0500/Composite/temp1_crit
+      - - tmp464-i2c-28-48/temp1/temp1_input
+        - tmp464-i2c-28-48/temp1/temp1_crit
+      - - tmp464-i2c-28-48/temp2/temp2_input
+        - tmp464-i2c-28-48/temp2/temp2_crit
+      - - tmp464-i2c-28-48/temp3/temp3_input
+        - tmp464-i2c-28-48/temp3/temp3_crit
+      - - tmp464-i2c-28-48/temp4/temp4_input
+        - tmp464-i2c-28-48/temp4/temp4_crit
+      - - tmp464-i2c-28-48/temp5/temp5_input
+        - tmp464-i2c-28-48/temp5/temp5_crit
+
+    non_zero:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_input
+      - dps800-i2c-21-58/fan2/fan2_input
+      - dps800-i2c-22-58/fan1/fan1_input
+      - dps800-i2c-22-58/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan1/fan1_input
+      - scd_fan_p3-pci-00c7/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan3/fan3_input
+      - scd_fan_p3-pci-00c7/fan4/fan4_input
+      power: [ ]
+      temp: [ ]
+
+    psu_skips:
+      dps800-i2c-21-58:
+        number: 1
+        side: left
+        skip_list:
+        - dps800-i2c-21-58
+      dps800-i2c-22-58:
+        number: 2
+        side: right
+        skip_list:
+        - dps800-i2c-22-58
+
+    sensor_skip_per_version: { }
+
+  x86_64-arista_7280dr3ak_36s:
+    alarms:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_alarm
+      - dps800-i2c-21-58/fan1/fan1_fault
+      - dps800-i2c-21-58/fan2/fan2_alarm
+      - dps800-i2c-21-58/fan2/fan2_fault
+      - dps800-i2c-22-58/fan1/fan1_alarm
+      - dps800-i2c-22-58/fan1/fan1_fault
+      - dps800-i2c-22-58/fan2/fan2_alarm
+      - dps800-i2c-22-58/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan1/fan1_fault
+      - scd_fan_p3-pci-00c7/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan3/fan3_fault
+      - scd_fan_p3-pci-00c7/fan4/fan4_fault
+      power:
+      - dps800-i2c-21-58/iin/curr1_crit_alarm
+      - dps800-i2c-21-58/iin/curr1_max_alarm
+      - dps800-i2c-21-58/iout1/curr2_crit_alarm
+      - dps800-i2c-21-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-21-58/iout1/curr2_max_alarm
+      - dps800-i2c-21-58/pin/power1_alarm
+      - dps800-i2c-21-58/pout1/power2_cap_alarm
+      - dps800-i2c-21-58/pout1/power2_crit_alarm
+      - dps800-i2c-21-58/pout1/power2_max_alarm
+      - dps800-i2c-21-58/vin/in1_crit_alarm
+      - dps800-i2c-21-58/vin/in1_lcrit_alarm
+      - dps800-i2c-21-58/vin/in1_max_alarm
+      - dps800-i2c-21-58/vin/in1_min_alarm
+      - dps800-i2c-21-58/vout1/in3_crit_alarm
+      - dps800-i2c-21-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-21-58/vout1/in3_max_alarm
+      - dps800-i2c-21-58/vout1/in3_min_alarm
+      - dps800-i2c-22-58/iin/curr1_crit_alarm
+      - dps800-i2c-22-58/iin/curr1_max_alarm
+      - dps800-i2c-22-58/iout1/curr2_crit_alarm
+      - dps800-i2c-22-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-22-58/iout1/curr2_max_alarm
+      - dps800-i2c-22-58/pin/power1_alarm
+      - dps800-i2c-22-58/pout1/power2_cap_alarm
+      - dps800-i2c-22-58/pout1/power2_crit_alarm
+      - dps800-i2c-22-58/pout1/power2_max_alarm
+      - dps800-i2c-22-58/vin/in1_crit_alarm
+      - dps800-i2c-22-58/vin/in1_lcrit_alarm
+      - dps800-i2c-22-58/vin/in1_max_alarm
+      - dps800-i2c-22-58/vin/in1_min_alarm
+      - dps800-i2c-22-58/vout1/in3_crit_alarm
+      - dps800-i2c-22-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-22-58/vout1/in3_max_alarm
+      - dps800-i2c-22-58/vout1/in3_min_alarm
+      temp:
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_min_alarm
+      - max6658-i2c-9-4c/temp1/temp1_crit_alarm
+      - max6658-i2c-9-4c/temp1/temp1_max_alarm
+      - max6658-i2c-9-4c/temp1/temp1_min_alarm
+      - max6658-i2c-9-4c/temp2/temp2_crit_alarm
+      - max6658-i2c-9-4c/temp2/temp2_fault
+      - max6658-i2c-9-4c/temp2/temp2_max_alarm
+      - max6658-i2c-9-4c/temp2/temp2_min_alarm
+      - nvme-pci-0500/Composite/temp1_alarm
+      - tmp464-i2c-28-48/temp1/temp1_crit_alarm
+      - tmp464-i2c-28-48/temp1/temp1_max_alarm
+      - tmp464-i2c-28-48/temp2/temp2_crit_alarm
+      - tmp464-i2c-28-48/temp2/temp2_fault
+      - tmp464-i2c-28-48/temp2/temp2_max_alarm
+      - tmp464-i2c-28-48/temp3/temp3_crit_alarm
+      - tmp464-i2c-28-48/temp3/temp3_fault
+      - tmp464-i2c-28-48/temp3/temp3_max_alarm
+      - tmp464-i2c-28-48/temp4/temp4_crit_alarm
+      - tmp464-i2c-28-48/temp4/temp4_fault
+      - tmp464-i2c-28-48/temp4/temp4_max_alarm
+      - tmp464-i2c-28-48/temp5/temp5_crit_alarm
+      - tmp464-i2c-28-48/temp5/temp5_fault
+      - tmp464-i2c-28-48/temp5/temp5_max_alarm
+      - tmp464-i2c-28-48/temp6/temp6_crit_alarm
+      - tmp464-i2c-28-48/temp6/temp6_fault
+      - tmp464-i2c-28-48/temp6/temp6_max_alarm
+      - tmp464-i2c-28-48/temp7/temp7_crit_alarm
+      - tmp464-i2c-28-48/temp7/temp7_fault
+      - tmp464-i2c-28-48/temp7/temp7_max_alarm
+      - tmp464-i2c-28-48/temp8/temp8_crit_alarm
+      - tmp464-i2c-28-48/temp8/temp8_fault
+      - tmp464-i2c-28-48/temp8/temp8_max_alarm
+      - tmp464-i2c-28-48/temp9/temp9_crit_alarm
+      - tmp464-i2c-28-48/temp9/temp9_fault
+      - tmp464-i2c-28-48/temp9/temp9_max_alarm
+
+    compares:
+      fan: [ ]
+      power: [ ]
+      temp:
+      - - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_input
+        - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit
+      - - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_input
+        - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_input
+        - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit
+      - - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_input
+        - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit
+      - - max6658-i2c-9-4c/temp1/temp1_input
+        - max6658-i2c-9-4c/temp1/temp1_crit
+      - - max6658-i2c-9-4c/temp2/temp2_input
+        - max6658-i2c-9-4c/temp2/temp2_crit
+      - - nvme-pci-0500/Composite/temp1_input
+        - nvme-pci-0500/Composite/temp1_crit
+      - - tmp464-i2c-28-48/temp1/temp1_input
+        - tmp464-i2c-28-48/temp1/temp1_crit
+      - - tmp464-i2c-28-48/temp2/temp2_input
+        - tmp464-i2c-28-48/temp2/temp2_crit
+      - - tmp464-i2c-28-48/temp3/temp3_input
+        - tmp464-i2c-28-48/temp3/temp3_crit
+      - - tmp464-i2c-28-48/temp4/temp4_input
+        - tmp464-i2c-28-48/temp4/temp4_crit
+      - - tmp464-i2c-28-48/temp5/temp5_input
+        - tmp464-i2c-28-48/temp5/temp5_crit
+
+    non_zero:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_input
+      - dps800-i2c-21-58/fan2/fan2_input
+      - dps800-i2c-22-58/fan1/fan1_input
+      - dps800-i2c-22-58/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan1/fan1_input
+      - scd_fan_p3-pci-00c7/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan3/fan3_input
+      - scd_fan_p3-pci-00c7/fan4/fan4_input
+      power: [ ]
+      temp: [ ]
+
+    psu_skips:
+      dps800-i2c-21-58:
+        number: 1
+        side: left
+        skip_list:
+        - dps800-i2c-21-58
+      dps800-i2c-22-58:
+        number: 2
+        side: right
+        skip_list:
+        - dps800-i2c-22-58
+
+    sensor_skip_per_version: { }
+
+  x86_64-arista_7280dr3am_36:
+    alarms:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_alarm
+      - dps800-i2c-21-58/fan1/fan1_fault
+      - dps800-i2c-21-58/fan2/fan2_alarm
+      - dps800-i2c-21-58/fan2/fan2_fault
+      - dps800-i2c-22-58/fan1/fan1_alarm
+      - dps800-i2c-22-58/fan1/fan1_fault
+      - dps800-i2c-22-58/fan2/fan2_alarm
+      - dps800-i2c-22-58/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan1/fan1_fault
+      - scd_fan_p3-pci-00c7/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan3/fan3_fault
+      - scd_fan_p3-pci-00c7/fan4/fan4_fault
+      power:
+      - dps800-i2c-21-58/iin/curr1_crit_alarm
+      - dps800-i2c-21-58/iin/curr1_max_alarm
+      - dps800-i2c-21-58/iout1/curr2_crit_alarm
+      - dps800-i2c-21-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-21-58/iout1/curr2_max_alarm
+      - dps800-i2c-21-58/pin/power1_alarm
+      - dps800-i2c-21-58/pout1/power2_cap_alarm
+      - dps800-i2c-21-58/pout1/power2_crit_alarm
+      - dps800-i2c-21-58/pout1/power2_max_alarm
+      - dps800-i2c-21-58/vin/in1_crit_alarm
+      - dps800-i2c-21-58/vin/in1_lcrit_alarm
+      - dps800-i2c-21-58/vin/in1_max_alarm
+      - dps800-i2c-21-58/vin/in1_min_alarm
+      - dps800-i2c-21-58/vout1/in3_crit_alarm
+      - dps800-i2c-21-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-21-58/vout1/in3_max_alarm
+      - dps800-i2c-21-58/vout1/in3_min_alarm
+      - dps800-i2c-22-58/iin/curr1_crit_alarm
+      - dps800-i2c-22-58/iin/curr1_max_alarm
+      - dps800-i2c-22-58/iout1/curr2_crit_alarm
+      - dps800-i2c-22-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-22-58/iout1/curr2_max_alarm
+      - dps800-i2c-22-58/pin/power1_alarm
+      - dps800-i2c-22-58/pout1/power2_cap_alarm
+      - dps800-i2c-22-58/pout1/power2_crit_alarm
+      - dps800-i2c-22-58/pout1/power2_max_alarm
+      - dps800-i2c-22-58/vin/in1_crit_alarm
+      - dps800-i2c-22-58/vin/in1_lcrit_alarm
+      - dps800-i2c-22-58/vin/in1_max_alarm
+      - dps800-i2c-22-58/vin/in1_min_alarm
+      - dps800-i2c-22-58/vout1/in3_crit_alarm
+      - dps800-i2c-22-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-22-58/vout1/in3_max_alarm
+      - dps800-i2c-22-58/vout1/in3_min_alarm
+      temp:
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_min_alarm
+      - max6658-i2c-9-4c/temp1/temp1_crit_alarm
+      - max6658-i2c-9-4c/temp1/temp1_max_alarm
+      - max6658-i2c-9-4c/temp1/temp1_min_alarm
+      - max6658-i2c-9-4c/temp2/temp2_crit_alarm
+      - max6658-i2c-9-4c/temp2/temp2_fault
+      - max6658-i2c-9-4c/temp2/temp2_max_alarm
+      - max6658-i2c-9-4c/temp2/temp2_min_alarm
+      - nvme-pci-0500/Composite/temp1_alarm
+      - tmp464-i2c-28-48/temp1/temp1_crit_alarm
+      - tmp464-i2c-28-48/temp1/temp1_max_alarm
+      - tmp464-i2c-28-48/temp2/temp2_crit_alarm
+      - tmp464-i2c-28-48/temp2/temp2_fault
+      - tmp464-i2c-28-48/temp2/temp2_max_alarm
+      - tmp464-i2c-28-48/temp3/temp3_crit_alarm
+      - tmp464-i2c-28-48/temp3/temp3_fault
+      - tmp464-i2c-28-48/temp3/temp3_max_alarm
+      - tmp464-i2c-28-48/temp4/temp4_crit_alarm
+      - tmp464-i2c-28-48/temp4/temp4_fault
+      - tmp464-i2c-28-48/temp4/temp4_max_alarm
+      - tmp464-i2c-28-48/temp5/temp5_crit_alarm
+      - tmp464-i2c-28-48/temp5/temp5_fault
+      - tmp464-i2c-28-48/temp5/temp5_max_alarm
+      - tmp464-i2c-28-48/temp6/temp6_crit_alarm
+      - tmp464-i2c-28-48/temp6/temp6_fault
+      - tmp464-i2c-28-48/temp6/temp6_max_alarm
+      - tmp464-i2c-28-48/temp7/temp7_crit_alarm
+      - tmp464-i2c-28-48/temp7/temp7_fault
+      - tmp464-i2c-28-48/temp7/temp7_max_alarm
+      - tmp464-i2c-28-48/temp8/temp8_crit_alarm
+      - tmp464-i2c-28-48/temp8/temp8_fault
+      - tmp464-i2c-28-48/temp8/temp8_max_alarm
+      - tmp464-i2c-28-48/temp9/temp9_crit_alarm
+      - tmp464-i2c-28-48/temp9/temp9_fault
+      - tmp464-i2c-28-48/temp9/temp9_max_alarm
+
+    compares:
+      fan: [ ]
+      power: [ ]
+      temp:
+      - - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_input
+        - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit
+      - - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_input
+        - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_input
+        - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit
+      - - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_input
+        - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit
+      - - max6658-i2c-9-4c/temp1/temp1_input
+        - max6658-i2c-9-4c/temp1/temp1_crit
+      - - max6658-i2c-9-4c/temp2/temp2_input
+        - max6658-i2c-9-4c/temp2/temp2_crit
+      - - nvme-pci-0500/Composite/temp1_input
+        - nvme-pci-0500/Composite/temp1_crit
+      - - tmp464-i2c-28-48/temp1/temp1_input
+        - tmp464-i2c-28-48/temp1/temp1_crit
+      - - tmp464-i2c-28-48/temp2/temp2_input
+        - tmp464-i2c-28-48/temp2/temp2_crit
+      - - tmp464-i2c-28-48/temp3/temp3_input
+        - tmp464-i2c-28-48/temp3/temp3_crit
+      - - tmp464-i2c-28-48/temp4/temp4_input
+        - tmp464-i2c-28-48/temp4/temp4_crit
+      - - tmp464-i2c-28-48/temp5/temp5_input
+        - tmp464-i2c-28-48/temp5/temp5_crit
+
+    non_zero:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_input
+      - dps800-i2c-21-58/fan2/fan2_input
+      - dps800-i2c-22-58/fan1/fan1_input
+      - dps800-i2c-22-58/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan1/fan1_input
+      - scd_fan_p3-pci-00c7/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan3/fan3_input
+      - scd_fan_p3-pci-00c7/fan4/fan4_input
+      power: [ ]
+      temp: [ ]
+
+    psu_skips:
+      dps800-i2c-21-58:
+        number: 1
+        side: left
+        skip_list:
+        - dps800-i2c-21-58
+      dps800-i2c-22-58:
+        number: 2
+        side: right
+        skip_list:
+        - dps800-i2c-22-58
+
+    sensor_skip_per_version: { }


### PR DESCRIPTION
Cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/22477

Summary:
The SKU sensors data is needed to run platform_tests/test_sensors.py::test_sensors

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
    - [x] Adding support for new SKUs 
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Approach
#### What is the motivation for this PR?
Add sensors data support for Arista 7280DR3A* SKUs 

#### How did you do it?
Modified sku-sensors-data.yml

#### How did you verify/test it?
Successfully ran platform_tests/test_sensors.py::test_sensors

#### Any platform specific information?
Only applicable to the mentioned Arista SKUs
