### PR TITLE
[202412] Add Non-Lag v6 Topologies to GCU Dynamic ACL Non-Lag List (cherry-pick #22575)

### DIFF
--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -166,6 +166,16 @@ def setup(rand_selected_dut, rand_unselected_dut, tbinfo, vlan_name, topo_scenar
         't1-isolated-d28u1',
         't1-isolated-d28',
         't0-d18u8s4',
+        't0-isolated-v6-d256u256s2',
+        't0-isolated-v6-d128u128s2',
+        't0-isolated-v6-d96u32s2',
+        't0-isolated-v6-d32u32s2',
+        't0-isolated-v6-d16u16s1',
+        't0-isolated-v6-d16u16s2',
+        't1-isolated-v6-d224u8',
+        't1-isolated-v6-d128',
+        't1-isolated-v6-d56u2',
+        't1-isolated-v6-d28u1',
     )
 
     if topo == "m0_l3" or tbinfo['topo']['name'] in topos_no_portchannels:


### PR DESCRIPTION
Cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/22575 into the 202412 branch.

**Original PR:** Add Non-Lag v6 Topologies to GCU Dynamic ACL Non-Lag List
**Author:** Christopher Croy (ccroy-arista)

### Description
The non-lag list of topologies in the GCU `test_dynamic_acl` test was missing the v6 topologies, resulting in improper accounting of upstream ports, yielding `IndexError: list index out of range` when referencing `upstream_ports[0]`.

### Type of change
- [x] Bug fix