### PR TITLE
[Backport 202509] add test for feature switch frr_bmp (#18346)

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -172,9 +172,10 @@ class GenerateGoldenConfigDBModule(object):
             config[namespace] = {k: ns_data[k] for k in ns_data if k == "FEATURE"}
         return config
 
-    def overwrite_feature_golden_config_db_multiasic(self, config, feature_key):
+    def overwrite_feature_golden_config_db_multiasic(self, config, feature_key,
+                                                     auto_restart="enabled", state="enabled"):
         full_config = json.loads(config)
-        if config == "{}" or "FEATURE" not in config["localhost"]:
+        if full_config == {} or "FEATURE" not in full_config.get("localhost", {}):
             # need dump running config FEATURE + selected feature
             gold_config_db = self.get_multiasic_feature_config()
         else:
@@ -183,14 +184,14 @@ class GenerateGoldenConfigDBModule(object):
 
         feature_data = {
             feature_key: {
-                "auto_restart": "enabled",
+                "auto_restart": auto_restart,
                 "check_up_status": "false",
                 "delayed": "False",
                 "has_global_scope": "False",
                 "has_per_asic_scope": "True",
                 "high_mem_alert": "disabled",
                 "set_owner": "local",
-                "state": "enabled",
+                "state": state,
                 "support_syslog_rate_limit": "false"
             }
         }
@@ -202,7 +203,8 @@ class GenerateGoldenConfigDBModule(object):
 
         return json.dumps(gold_config_db, indent=4)
 
-    def overwrite_feature_golden_config_db_singleasic(self, config, feature_key):
+    def overwrite_feature_golden_config_db_singleasic(self, config, feature_key,
+                                                      auto_restart="enabled", state="enabled"):
         full_config = config
         onlyFeature = config == "{}"  # FEATURE needs special handling since it does not support incremental update.
         if config == "{}":
@@ -216,14 +218,14 @@ class GenerateGoldenConfigDBModule(object):
 
         # Append the specified feature section to the original "FEATURE" section
         ori_config_db.setdefault("FEATURE", {}).setdefault(feature_key, {}).update({
-            "auto_restart": "enabled",
+            "auto_restart": auto_restart,
             "check_up_status": "false",
             "delayed": "False",
             "has_global_scope": "True",
             "has_per_asic_scope": "False",
             "high_mem_alert": "disabled",
             "set_owner": "local",
-            "state": "enabled",
+            "state": state,
             "support_syslog_rate_limit": "false"
         })
 
@@ -424,6 +426,16 @@ class GenerateGoldenConfigDBModule(object):
 
         # update dns config
         config = self.update_dns_config(config)
+
+        # To enable bmp feature when the image version is >= 202411 and the device is not supervisor
+        # Note: the Chassis supervisor is not holding any BGP sessions so the BMP feature is not needed
+        if self.check_version_for_bmp() is True and device_info.is_supervisor() is False:
+            if multi_asic.is_multi_asic():
+                config = self.overwrite_feature_golden_config_db_multiasic(config, "frr_bmp", "disabled", "enabled")
+                config = self.overwrite_feature_golden_config_db_multiasic(config, "bmp")
+            else:
+                config = self.overwrite_feature_golden_config_db_singleasic(config, "frr_bmp", "disabled", "enabled")
+                config = self.overwrite_feature_golden_config_db_singleasic(config, "bmp")
 
         with open(GOLDEN_CONFIG_DB_PATH, "w") as temp_file:
             temp_file.write(config)

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -20,6 +20,7 @@ def enable_container_autorestart(duthosts, rand_one_dut_hostname):
     # Enable autorestart for all features
     duthost = duthosts[rand_one_dut_hostname]
     feature_list, _ = duthost.get_feature_status()
+    feature_list.pop('frr_bmp', None)
     container_autorestart_states = duthost.get_container_autorestart_states()
     for feature, status in list(feature_list.items()):
         # Enable container autorestart only if the feature is enabled and container autorestart is disabled.

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1597,6 +1597,9 @@ Totals               6450                 6449
         for line in show_cmd_output["stdout_lines"]:
             container_name = line.split()[0].strip()
             container_state = line.split()[1].strip()
+            if container_name == "frr_bmp":
+                continue
+
             if container_state in ["enabled", "disabled"]:
                 container_autorestart_states[container_name] = container_state
 

--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -228,7 +228,8 @@ def get_disabled_container_list(duthost):
     for container_name, status in list(container_status.items()):
         if "disabled" in status:
             disabled_containers.append(container_name)
-
+        if "enabled" in status and container_name == "frr_bmp":
+            disabled_containers.append(container_name)
     return disabled_containers
 
 

--- a/tests/monit/test_monit_status.py
+++ b/tests/monit/test_monit_status.py
@@ -77,6 +77,19 @@ def check_monit_last_output(duthost):
         return False
 
 
+def check_monit_expected_container_logging(duthost):
+    """Checks whether alerting message appears as syslog if
+    there is unexpected container not running.
+    Args:
+        duthost: An AnsibleHost object of DuT.
+    Returns:
+        None.
+    """
+    syslog_output = duthost.command("sudo grep 'ERR monit' /var/log/syslog")["stdout"]
+    pytest_assert("Expected containers not running" not in syslog_output,
+                  f"Expected containers not running found in syslog. Output was:\n{syslog_output}")
+
+
 def test_monit_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """Checks whether the Monit service was running or not.
 
@@ -126,5 +139,5 @@ def test_monit_reporting_message(duthosts, enum_rand_one_per_hwsku_frontend_host
 
     pytest_assert(wait_until(180, 60, 0, check_monit_last_output, duthost),
                   "Expected Monit reporting message not found")
-
+    wait_until(180, 60, 0, check_monit_expected_container_logging, duthost)
     logger.info("Checking the format of Monit alerting message was done!")

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -196,6 +196,8 @@ def test_disable_rsyslog_rate_limit(duthosts):
             if (is_dhcp_server_enable is not None and "enabled" in is_dhcp_server_enable and
                     feature_name == "dhcp_relay"):
                 continue
+            if feature_name == "frr_bmp":
+                continue
             if feature_name == "telemetry":
                 # Skip telemetry if there's no docker image
                 output = dut.shell("docker images", module_ignore_errors=True)['stdout']


### PR DESCRIPTION
Cherry-pick of sonic-net/sonic-mgmt#18346 to 202509 branch.

**Original PR:** https://github.com/sonic-net/sonic-mgmt/pull/18346
**Author:** @FengPan-Frank

### Why
frr_bmp is not a real container - it is a feature switch that tells bgpd to start with BMP module. Tests that iterate enabled features and run docker exec on them fail because there is no frr_bmp container.

### Changes
- Skip frr_bmp in test_pretest.py::test_disable_rsyslog_rate_limit
- Add frr_bmp golden config overwrite in generate_golden_config_db.py
- Add check_version_for_bmp handling in sonic.py and dut_utils.py
- Add monit test coverage for frr_bmp

### Verified
Tested on Nokia-7215-A1-MGX-G48S4 (testbed-bjw3-can-7215a1d-1), test_disable_rsyslog_rate_limit passes with this fix.