### PR TITLE
[Backport 202509] Fix hostname type check in facts_cache _get_default_zone

### DIFF
--- a/tests/common/cache/facts_cache.py
+++ b/tests/common/cache/facts_cache.py
@@ -205,7 +205,7 @@ def _get_default_zone(function, func_args, func_kargs):
     unicode_type = str if sys.version_info.major >= 3 else unicode      # noqa: F821
     if func_args:
         hostname = getattr(func_args[0], "hostname", None)
-    if not hostname or type(hostname) not in [str, unicode_type]:
+    if not hostname or not isinstance(hostname, (str, unicode_type)):
         raise ValueError("Failed to get attribute 'hostname' of type string from instance of type %s."
                          % type(func_args[0]))
     zone = hostname


### PR DESCRIPTION
Partial cherry-pick from sonic-net/sonic-mgmt#21729 to 202509 branch.

**Original PR:** https://github.com/sonic-net/sonic-mgmt/pull/21729
**Author:** @wiperi

### Why
The `_get_default_zone` function in `facts_cache.py` uses `type(hostname) not in [str]` for type checking, which fails for `str` subclasses like `AnsibleUnsafeText`. This causes `test_update_testbed_metadata` to error when creating `FanoutHost` for SONiC fanout devices.

### Fix
Replace `type(hostname) not in [str, unicode_type]` with `isinstance(hostname, (str, unicode_type))` — properly handles `str` subclasses.

### Verified
Tested on Nokia-7215-A1 mx topology testbed:
- Before: `test_update_testbed_metadata` ERROR (ValueError)
- After: **13 passed, 3 skipped, 0 errors**