### PR TITLE
[Otel] Enable OTEL feature when OTEL image exists (#22341)

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -152,6 +152,13 @@ class GenerateGoldenConfigDBModule(object):
             return True
         return True
 
+    def has_otel_image(self):
+        rc, out, _ = self.module.run_command("docker images --format '{{.Repository}}'")
+        if rc != 0:
+            return False
+        repos = [line.strip().lower() for line in out.splitlines() if line.strip()]
+        return "docker-sonic-otel" in repos
+
     def get_config_from_minigraph(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
         if rc != 0:
@@ -325,6 +332,10 @@ class GenerateGoldenConfigDBModule(object):
         else:
             config = "{}"
 
+        # Enable otel feature when docker-sonic-otel image exists
+        if self.has_otel_image():
+            config = self.overwrite_feature_golden_config_db_singleasic(config, "otel", "enabled", "enabled")
+            
         with open(GOLDEN_CONFIG_DB_PATH, "w") as temp_file:
             temp_file.write(config)
         self.module.run_command("sudo rm -f {}".format(TEMP_DHCP_SERVER_CONFIG_PATH))


### PR DESCRIPTION
What is the motivation for this PR?
Enable OTEL feature when OTEL image exists

How did you do it?
Add a function to check if otel docker image exists, if yes, enable otel feature.

How did you verify/test it?
Verified it in internal setup.

Any platform specific information?
Nvidia SN5640

Supported testbed topology if it's a new test case? to-isolated-d32u32s2