### PR TITLE
[Otel] Fix argument mismatch in overwrite_feature_golden_config_db_singleasic call

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -334,8 +334,7 @@ class GenerateGoldenConfigDBModule(object):
 
         # Enable otel feature when docker-sonic-otel image exists
         if self.has_otel_image():
-            config = self.overwrite_feature_golden_config_db_singleasic(config, "otel", "enabled", "enabled")
-            
+            config = self.overwrite_feature_golden_config_db_singleasic(config, "otel")
         with open(GOLDEN_CONFIG_DB_PATH, "w") as temp_file:
             temp_file.write(config)
         self.module.run_command("sudo rm -f {}".format(TEMP_DHCP_SERVER_CONFIG_PATH))


### PR DESCRIPTION
## What is the motivation for this PR?

PR #1067 cherry-picked the otel feature enablement from upstream PR sonic-net/sonic-mgmt#22341, but introduced a runtime bug.

## What is the issue?

The upstream `overwrite_feature_golden_config_db_singleasic()` accepts optional `auto_restart` and `state` parameters:
```python
def overwrite_feature_golden_config_db_singleasic(self, config, feature_key, auto_restart="enabled", state="enabled"):
```

But the 202412 branch version only accepts `(config, feature_key)` and hardcodes both as `"enabled"`:
```python
def overwrite_feature_golden_config_db_singleasic(self, config, feature_key):
```

The cherry-picked call passes 4 arguments:
```python
config = self.overwrite_feature_golden_config_db_singleasic(config, "otel", "enabled", "enabled")
```

This causes a **TypeError** at runtime:
```
TypeError: overwrite_feature_golden_config_db_singleasic() takes 3 positional arguments but 5 were given
```

## How did you fix it?

Removed the extra `"enabled", "enabled"` arguments since the 202412 branch already hardcodes those values.

## How did you verify/test it?

Verified the method signature matches the call site. Python syntax check passes.