### PR TITLE
[202603][C0] Add c0 pytest mark to topology markers (#22833)

### DIFF
--- a/tests/arp/test_arpall.py
+++ b/tests/arp/test_arpall.py
@@ -11,7 +11,7 @@ from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # no
 
 
 pytestmark = [
-    pytest.mark.topology('t1', 't2', 'm1')
+    pytest.mark.topology('t1', 't2', 'm1', 'c0')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -9,7 +9,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('m1', 't1', 'ptf')
+    pytest.mark.topology('m1', 't1', 'ptf', 'c0')
 ]
 
 

--- a/tests/bgp/test_bgp_allow_list.py
+++ b/tests/bgp/test_bgp_allow_list.py
@@ -13,7 +13,7 @@ from bgp_helpers import check_routes_on_neighbors_empty_allow_list, checkout_bgp
 from bgp_helpers import bgp_allow_list_setup, prepare_eos_routes    # noqa:F401
 
 pytestmark = [
-    pytest.mark.topology('t1', 'm1'),
+    pytest.mark.topology('t1', 'm1', 'c0'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/bgp/test_bgp_command.py
+++ b/tests/bgp/test_bgp_command.py
@@ -6,7 +6,7 @@ from tests.common.helpers.assertions import pytest_assert
 
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", "m0", "mx", "m1"),
+    pytest.mark.topology("t0", "t1", "m0", "mx", "m1", "c0"),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -16,7 +16,7 @@ from tests.common.utilities import wait_until, delete_running_config
 from tests.common.utilities import is_ipv6_only_topology
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm1', 'lt2', 'ft2'),
+    pytest.mark.topology('t0', 't1', 't2', 'm1', 'lt2', 'ft2', 'c0'),
 ]
 
 TEST_ITERATIONS = 5

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 vrfname = 'default'
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", 'm1', 'lt2', 'ft2'),
+    pytest.mark.topology("t0", "t1", 'm1', 'lt2', 'ft2', 'c0'),
 ]
 
 

--- a/tests/bgp/test_bgp_session_flap.py
+++ b/tests/bgp/test_bgp_session_flap.py
@@ -29,7 +29,7 @@ cpuSpike = 10
 memSpike = 1.3
 
 pytestmark = [
-    pytest.mark.topology('t1', 't2', 'm1', 'lt2', 'ft2')
+    pytest.mark.topology('t1', 't2', 'm1', 'lt2', 'ft2', 'c0')
 ]
 
 

--- a/tests/bgp/test_bgp_stress_link_flap.py
+++ b/tests/bgp/test_bgp_stress_link_flap.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('t0', 't1', "m0", "mx", 'm1', 'lt2', 'ft2')
+    pytest.mark.topology('t0', 't1', "m0", "mx", 'm1', 'lt2', 'ft2', 'c0')
 ]
 
 stop_tasks = False

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -6,7 +6,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 'c0'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/platform_tests/test_idle_driver.py
+++ b/tests/platform_tests/test_idle_driver.py
@@ -11,7 +11,7 @@ from tests.common.helpers.assertions import pytest_assert
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('m0', 'mx'),
+    pytest.mark.topology('m0', 'mx', 'c0'),
 ]
 
 

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -32,7 +32,7 @@ from tests.common.helpers.dut_ports import get_vlan_interface_list, get_vlan_int
 COUNT = 10
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 'mx'),
+    pytest.mark.topology('t0', 'm0', 'mx', 'c0'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_default_route.py
+++ b/tests/snmp/test_snmp_default_route.py
@@ -4,7 +4,7 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 't1-multi-asic', 'lt2', 'ft2'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 't1-multi-asic', 'lt2', 'ft2', 'c0'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_fdb.py
+++ b/tests/snmp/test_snmp_fdb.py
@@ -21,7 +21,7 @@ from tests.common.helpers.assertions import pytest_assert
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 'mx', 'm1')
+    pytest.mark.topology('t0', 'm0', 'mx', 'm1', 'c0')
 ]
 
 # Use original ports intead of sub interfaces for ptfadapter if it's t0-backend

--- a/tests/snmp/test_snmp_link_local.py
+++ b/tests/snmp/test_snmp_link_local.py
@@ -4,7 +4,7 @@ from tests.common import config_reload
 from tests.common.utilities import wait_until
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 't1-multi-asic', 'lt2', 'ft2'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 't1-multi-asic', 'lt2', 'ft2', 'c0'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -4,7 +4,7 @@ import pytest
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 'lt2', 'ft2'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 'lt2', 'ft2', 'c0'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_loopback.py
+++ b/tests/snmp/test_snmp_loopback.py
@@ -5,7 +5,7 @@ from tests.common.devices.eos import EosHost
 from tests.common.utilities import skip_release
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 't1-multi-asic', 'lt2', 'ft2'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 't1-multi-asic', 'lt2', 'ft2', 'c0'),
     pytest.mark.device_type('vs')
 ]
 


### PR DESCRIPTION
* [C0] Add c0 pytest mark to topology markers

Add c0 topology mark to test cases in the following modules: arp, platform_tests, snmp

Only tests with specific topology marks are updated. Tests already marked with "any" are skipped as they implicitly support all topologies including c0.



* [C0] Remove c0 mark from test_service_warm_restart

This test uses PTF dataplane traffic to validate zero packet loss during service warm restarts. Since c0 does not support dataplane tests, remove the c0 mark.



* [C0] Remove c0 mark from dataplane-dependent tests

Remove c0 mark from tests that require PTF dataplane (packet send/receive), as c0 topology does not support dataplane tests:
- arp/test_arp_extended.py (ptfadapter send_packet/verify_packet)
- arp/test_arp_update.py (ptfadapter send_packet/verify_packet)
- arp/test_arpall.py (ptf_runner)
- arp/test_stress_arp.py (ptfadapter send_packet)
- arp/test_tagged_arp.py (ptfadapter send)
- arp/test_unknown_mac.py (ptfadapter send/verify_no_packet_any)
- snmp/test_snmp_fdb.py (ptfadapter send)



* [C0] Add c0 mark to dataplane tests and bgp/ip/lldp/route

Dataplane is now confirmed working on C0 (vpp across etp1-3). Re-add c0 mark to previously removed dataplane-dependent tests, and add c0 mark to tests in bgp, lldp, and route folders.

Tests with "any" topology are skipped (already support all topos). Tests with t2-only topology are skipped (not applicable to c0).



* [C0] Remove c0 mark from reboot-related tests

C0 does not need advanced-reboot or warm-reboot testcases. Remove c0 mark from:
- platform_tests/test_advanced_reboot.py
- platform_tests/test_cont_warm_reboot.py
- platform_tests/test_service_warm_restart.py



* [C0] Re-add c0 mark to test_service_warm_restart

test_service_warm_restart restarts individual SONiC services (containers), not the whole device. It is applicable to c0.



* [C0] Remove c0 mark from non-applicable tests

- arp/test_tagged_arp.py: C0 topo does not have VLAN
- arp/test_wr_arp.py: warm-reboot related, not needed for c0
- bgp/test_bgp_aggregate_address.py: C0 does not require BGP aggregation
- bgp/test_bgp_establish_combo.py: m1-only testcase



* [C0] Remove c0 mark from tests not marked with mx/m0/m1

Per review: c0 topology only applies to tests already marked with mx, m0, or m1. Remove c0 from all other tests.



---------