### PR TITLE
Cherry-pick: Upgrade network container to Trixie (#22682)

### DIFF
--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -140,7 +140,7 @@
   become: yes
   docker_container:
     name: net_{{ vm_set_name }}_{{ vm_name }}
-    image: "{{ docker_registry_host }}/debian:bookworm"
+    image: "{{ debian_docker_registry_host }}/debian:trixie"
     pull: no
     state: started
     restart: no

--- a/ansible/vars/docker_registry.yml
+++ b/ansible/vars/docker_registry.yml
@@ -1,1 +1,2 @@
 docker_registry_host: sonicdev-microsoft.azurecr.io:443
+debian_docker_registry_host: publicmirror.azurecr.io:443


### PR DESCRIPTION
## Summary

Cherry-pick of sonic-net/sonic-mgmt#22682 onto 202412.

Upgrades the net container from Bookworm to Trixie. Also adds a new variable for the Docker registry, since containers for newer Debian versions are mirrored in a different Docker registry.

## Original PR
- sonic-net/sonic-mgmt#22682 — Upgrade network container to Trixie
- Author: @saiarcot895
- Original commit: 67a06c13888c2c95c6281a96dc93595c98662cda

## Cherry-pick note
This is a clean cherry-pick with -x tracking the source commit.