### PR TITLE
[202503][PR:23107] Enable link training support in sonic-mgmt

### DIFF
--- a/ansible/library/conn_graph_facts.py
+++ b/ansible/library/conn_graph_facts.py
@@ -301,6 +301,7 @@ class LabGraph(object):
             vlan_mode = link["VlanMode"]
             autoneg_mode = link.get("AutoNeg")
             fec_disable = link.get("FECDisable", False)
+            linktraining_mode = link.get("LinkTraining", "")
 
             if start_device not in links:
                 links[start_device] = {}
@@ -327,6 +328,9 @@ class LabGraph(object):
             if autoneg_mode:
                 links[start_device][start_port].update({"autoneg": autoneg_mode})
                 links[end_device][end_port].update({"autoneg": autoneg_mode})
+            if linktraining_mode:
+                links[start_device][start_port].update({"linktraining": linktraining_mode})
+                links[end_device][end_port].update({"linktraining": linktraining_mode})
 
             port_vlans[start_device][start_port] = {
                 "mode": vlan_mode,

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -340,6 +340,23 @@ class GenerateGoldenConfigDBModule(object):
 
         return json.dumps(golden_config, indent=4)
 
+    def generate_t0_f2_golden_config_db(self):
+        """
+        Generate golden_config for t0-f2 to enable link_training on server facing ports.
+        """
+        SUPPORTED_TOPO = ["t0-f2-d40u8"]
+        if self.topo_name not in SUPPORTED_TOPO:
+            return "{}"
+        ori_config = json.loads(self.get_config_from_minigraph())
+        golden_config = ori_config
+        golden_config["PORT"] = ori_config.get("PORT", {})
+        for _, config in golden_config["PORT"].items():
+            # Enable link_training for server facing ports
+            if "Server" in config.get("description", ""):
+                config["link_training"] = "on"
+
+        return json.dumps(golden_config, indent=4)
+
     def generate(self):
         module_msg = "Success to generate golden_config_db.json"
         # topo check
@@ -351,6 +368,9 @@ class GenerateGoldenConfigDBModule(object):
             config = self.generate_smartswitch_golden_config_db()
             self.module.run_command("sudo rm -f {}".format(TEMP_SMARTSWITCH_CONFIG_PATH))
             module_msg = module_msg + " for smartswitch"
+        elif "t0-f2" in self.topo_name:
+            config = self.generate_t0_f2_golden_config_db()
+            module_msg = module_msg + " for t0-f2"
         elif "ft2" in self.topo_name or "lt2" in self.topo_name:
             config = self.generate_lt2_ft2_golden_config_db()
         elif "t2_single_node" in self.topo_name:

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -355,7 +355,7 @@ class GenerateGoldenConfigDBModule(object):
             if "Server" in config.get("description", ""):
                 config["link_training"] = "on"
 
-        return json.dumps(golden_config, indent=4)
+        return json.dumps({'PORT': golden_config['PORT']}, indent=4)
 
     def generate(self):
         module_msg = "Success to generate golden_config_db.json"

--- a/ansible/roles/fanout/templates/sonic_deploy_202405.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202405.j2
@@ -19,7 +19,7 @@
     {% if fanout_hwsku == "Arista-720DT-G48S4" and (fanout_port_config[port_name]['lanes'] | int) <= 24 %}
             "autoneg": "on",
     {% endif %}
-    {% if fanout_port_config[port_name]['speed'] | default('100000') in ["100000", "400000", "800000"] %}
+    {% if fanout_port_config[port_name]['speed'] | default('100000') in ["100000", "200000", "400000", "800000"] %}
             "fec" : "rs",
     {% endif %}
     {% if port_name in device_conn[inventory_hostname] %}

--- a/ansible/roles/fanout/templates/sonic_deploy_202405.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202405.j2
@@ -26,8 +26,6 @@
         {% if 'linktraining' in device_conn[inventory_hostname][port_name] %}
             {% if 'on' in device_conn[inventory_hostname][port_name]['linktraining'] %}
                 "link_training": "on",
-            {% elif 'off' in device_conn[inventory_hostname][port_name]['linktraining'] %}
-                "link_training": "off",
             {% endif %}
         {% endif %}
         {% if 'autoneg' in device_conn[inventory_hostname][port_name] %}

--- a/ansible/roles/fanout/templates/sonic_deploy_202405.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202405.j2
@@ -22,6 +22,25 @@
     {% if fanout_port_config[port_name]['speed'] | default('100000') in ["100000", "400000", "800000"] %}
             "fec" : "rs",
     {% endif %}
+    {% if port_name in device_conn[inventory_hostname] %}
+        {% if 'linktraining' in device_conn[inventory_hostname][port_name] %}
+            {% if 'on' in device_conn[inventory_hostname][port_name]['linktraining'] %}
+                "link_training": "on",
+            {% elif 'off' in device_conn[inventory_hostname][port_name]['linktraining'] %}
+                "link_training": "off",
+            {% endif %}
+        {% endif %}
+        {% if 'autoneg' in device_conn[inventory_hostname][port_name] %}
+                {% if 'on' in device_conn[inventory_hostname][port_name]['autoneg'] %}
+                    "autoneg": "on",
+                    {% if msft_an_enabled is defined %}
+                        "fec": "none",
+                    {% endif %}
+                {% elif 'off' in device_conn[inventory_hostname][port_name]['autoneg'] %}
+                    "autoneg": "off",
+                {% endif %}
+        {% endif %}
+    {% endif %}
     {% if 'broadcom' in fanout_sonic_version["asic_type"] or 'marvell' in fanout_sonic_version["asic_type"] or 'mellanox' in fanout_sonic_version["asic_type"] %}
         {% if port_name in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][port_name]["mode"].lower() == "access" %}
             "tpid": "0x9100",


### PR DESCRIPTION
cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/23107 into 202503.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable link-training support in sonic-mgmt

Currently, enabling them for all server facing ports in F2 T0 topo.  Once we have port-channel support, we can enable them only for port-channel in F2 topo.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Enable link-training support in sonic-mgmt

#### How did you do it?
Enabling link training in golden_config_db for F2 topology.

#### How did you verify/test it?
local testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
