### PR TITLE
[cherry-pick] [golden_config_infra] xfail test_rendered_golden_config_override for t0-f2-d40u8

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1140,6 +1140,15 @@ gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart:
   skip:
     reason: "Test noisy due to restart issue not relevant to GNOI. Disabling them to rewrite."
 
+###############################################
+#####       golden_config_infra           #####
+###############################################
+golden_config_infra/test_config_reload_with_rendered_golden_config.py::test_rendered_golden_config_override:
+  xfail:
+    reason: "Ports not operationally up after golden config override on t0-f2-d40u8"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23198 and topo_name == 't0-f2-d40u8'"
+
 #######################################
 #####           hash              #####
 #######################################


### PR DESCRIPTION
### Description of PR

Cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/23197 to 202503 branch.

Summary:
Mark `test_rendered_golden_config_override` as xfail on `t0-f2-d40u8` topology using `tests_mark_conditions.yaml`, gated by issue https://github.com/sonic-net/sonic-mgmt/issues/23198.

### Type of change

- [x] Bug fix

### Approach
#### What is the motivation for this PR?
`test_rendered_golden_config_override` fails on `t0-f2-d40u8` topology because ports do not come operationally up after golden config override during minigraph load.

#### How did you do it?
Added an xfail entry in `tests_mark_conditions.yaml` with condition gated by GitHub issue #23198 and topo_name check.

#### How did you verify/test it?
Verified on sonic-net/sonic-mgmt PR #23197 (pre-commit checks passed).
