### PR TITLE
[202503] [loganalyzer] Ignore link-training status query errors

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -372,3 +372,7 @@ r, ".* ERR syncd#syncd: .*SAI_API_QUEUE:_brcm_sai_xgs_queue_pkt_trim_get_clear_c
 
 # Ignore SRV6 error CSP CS00012419486
 r, ".* ERR syncd#syncd: .*SAI_API_SWITCH:sai_object_type_get_availability:\d+ availablity my_sid failed with error .*"
+
+# Ignore link-training failure status query errors during port state transitions
+# SAI cannot read LT registers while the port serdes is mid-transition
+r, ".* ERR swss\d*#orchagent:.*getPortLinkTrainingFailure: Failed to get LT failure status for .*"


### PR DESCRIPTION
### Description of PR

Cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/23200 to 202503 branch.

Summary:
Add loganalyzer ignore patterns for link-training failure/rx status query errors during port transitions. SAI cannot read LT registers while the port serdes is mid-transition, causing transient ERR logs that are harmless.

### Type of change

- [x] Bug fix

### Approach
#### What is the motivation for this PR?
Transient ERR logs from `getPortLinkTrainingFailure` and `getPortLinkTrainingRxStatus` in orchagent cause loganalyzer failures during tests that toggle port admin state. These errors are expected during port transitions and resolve once the port stabilizes.

#### How did you do it?
Added two ignore patterns to `loganalyzer_common_ignore.txt` for the link-training query error messages.

#### How did you verify/test it?
Verified on upstream PR #23200 (merged).
