### PR TITLE
[202412] test_po_cleanup: fix loganalyzer marker loss under CPU stress

### DIFF
--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -1,8 +1,9 @@
+import time
 import pytest
 import logging
 from tests.common.utilities import wait_until
 from tests.common import config_reload
-from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
+from tests.common.plugins.loganalyzer.loganalyzer import DisableLogrotateCronContext, LogAnalyzer
 
 pytestmark = [
     pytest.mark.disable_route_check,
@@ -93,11 +94,37 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
         for i in range(host_vcpus):
             duthost.shell("nohup yes > /dev/null 2>&1 & sleep 1")
 
-        with loganalyzer:
-            logging.info("Reloading config..")
-            config_reload(duthost, wait=240, safe_reload=True, wait_for_bgp=True)
-
-        duthost.shell("killall yes")
+        # Disable logrotate during the test.  The config_reload under CPU
+        # stress generates heavy syslog traffic.  If the system logrotate
+        # timer fires mid-test it rotates /var/log/syslog, potentially
+        # moving the loganalyzer markers beyond syslog.1 into compressed
+        # archives that are not searched, causing a RuntimeError.
+        with DisableLogrotateCronContext(duthost):
+            with loganalyzer:
+                try:
+                    logging.info("Reloading config..")
+                    config_reload(duthost, wait=240, safe_reload=True, wait_for_bgp=True)
+                finally:
+                    # Kill CPU stress before loganalyzer __exit__ places the end
+                    # marker.  Under heavy CPU load the host rsyslogd cannot keep
+                    # up and its UDP receive buffer overflows, silently dropping
+                    # the marker.
+                    duthost.shell("killall yes", module_ignore_errors=True)
+                    # Wait for rsyslogd to drain the /dev/log socket buffer
+                    # backlog.  Under CPU stress, config_reload floods the socket
+                    # and the backlog can take minutes to drain even after the
+                    # stress ends.  Poll until /var/log/syslog stops growing
+                    # (stable for two consecutive 10-second intervals), meaning
+                    # rsyslogd has caught up and it is safe to place the end marker.
+                    prev_size = None
+                    for _ in range(30):
+                        result = duthost.shell("stat -c %s /var/log/syslog",
+                                               module_ignore_errors=True)
+                        curr_size = result.get('stdout', '').strip()
+                        if curr_size == prev_size:
+                            break
+                        prev_size = curr_size
+                        time.sleep(10)
     except Exception:
-        duthost.shell("killall yes")
+        duthost.shell("killall yes", module_ignore_errors=True)
         raise


### PR DESCRIPTION
### Description of PR

Backport of https://github.com/sonic-net/sonic-mgmt/pull/23291 to msft-202412.

Fix `test_po_cleanup_after_reload` failure caused by LogAnalyzer end marker being lost under heavy CPU stress and syslog load.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Approach
#### What is the motivation for this PR?

`test_po_cleanup_after_reload` fails consistently with:
```
RuntimeError: cannot find marker end-LogAnalyzer-port_channel_cleanup.xxx in /var/log/syslog
```

Two issues combine to lose the loganalyzer end marker:

1. **Logrotate fires mid-test**: The system logrotate timer can trigger during `config_reload` under CPU stress, rotating `/var/log/syslog`. Markers get pushed beyond `syslog.1` into compressed archives (`syslog.2.gz`) that loganalyzer does not search.

2. **Syslog UDP buffer overflow**: Under heavy CPU load (all cores running `yes`), rsyslogd cannot keep up with syslog traffic and its UDP receive buffer overflows, silently dropping the end marker written via `/dev/log`.

#### How did you do it?

Three changes to `test_po_cleanup_after_reload`:

1. **Wrap with `DisableLogrotateCronContext`** — stops the logrotate timer and cron job for the duration of the test, preventing mid-test syslog rotation.

2. **Move CPU stress cleanup into a `try/finally` block inside `with loganalyzer:`** — runs before loganalyzer `__exit__` places the end marker, so rsyslogd is no longer competing for CPU.

3. **Poll `/var/log/syslog` file size until stable** — after stopping CPU stress, wait for two consecutive 10-second intervals with no file growth before allowing the end marker to be placed. This ensures rsyslogd has drained any remaining socket buffer backlog.

#### How did you verify/test it?

1. **Without fix:** Test fails consistently with `RuntimeError: cannot find marker end-LogAnalyzer-...`
2. **With fix:** PASSED (1 passed in 1153s / 19:13)

#### Any platform specific information?

Not platform-specific.

### Documentation

N/A