### PR TITLE
disable autoneg for F2 golden config db.

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -354,6 +354,7 @@ class GenerateGoldenConfigDBModule(object):
             # Enable link_training for server facing ports
             if "Server" in config.get("description", ""):
                 config["link_training"] = "on"
+                config["autoneg"] = "off"
 
         return json.dumps({'PORT': golden_config['PORT']}, indent=4)
 


### PR DESCRIPTION
Fungible F2 connection between T0 and server requires the following setting:
- autonegation: off
- link_training: on

Need to disable autonegation too after https://github.com/sonic-net/sonic-mgmt/pull/23107

This change is only needed for 202503. other branches has the fix for https://github.com/sonic-net/sonic-mgmt/pull/20030, where it can be disabled via links.csv.