### PR TITLE
[202503] Update cEOS image version from 4.29.3M to 4.32.5M

### DIFF
--- a/ansible/group_vars/vm_host/ceos.yml
+++ b/ansible/group_vars/vm_host/ceos.yml
@@ -1,13 +1,13 @@
-ceos_image_filename: cEOS64-lab-4.29.3M.tar
-ceos_image_orig: ceosimage:4.29.3M
-ceos_image: ceosimage:4.29.3M-1
+ceos_image_filename: cEOS64-lab-4.32.5M.tar
+ceos_image_orig: ceosimage:4.32.5M
+ceos_image: ceosimage:4.32.5M-1
 # Please update ceos_image_url to the actual URL of the cEOS image file in your environment. If the cEOS image file
 # is not available on test server, the cEOS image file will be downloaded from this URL.
 # The ceos_image_url can be a string as single URL or a list of strings as multiple URLs. If it is a list, the code
 # logic will automatically try each URL in the list
 ceos_image_url:
-  - "http://example1.com/cEOS64-lab-4.29.3M.tar"
-  - "http://example2.com/cEOS64-lab-4.29.3M.tar"
+  - "http://example1.com/cEOS64-lab-4.32.5M.tar"
+  - "http://example2.com/cEOS64-lab-4.32.5M.tar"
 skip_ceos_image_downloading: false
 
 # Registry settings for pulling ceos docker image. If ceos_registry is defined, the code will first


### PR DESCRIPTION
### Description of PR

Summary:
Update cEOS image version on 202503 branch from 4.29.3M to 4.32.5M to align with master branch.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Approach
#### What is the motivation for this PR?

The 202503 branch is using cEOS 4.29.3M while master has been updated to 4.32.5M. This misalignment can cause test inconsistencies.

#### How did you do it?

Updated `ansible/group_vars/vm_host/ceos.yml` to match the master branch version (4.32.5M).

#### How did you verify/test it?

Diff verified against master branch - file now matches.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A