### PR TITLE
[202603] vpp: adapt test_techsupport to vpp arctos and kvm platform (#23383)

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -223,6 +223,8 @@ def mirroring(duthosts, enum_rand_one_per_hwsku_frontend_hostname, neighbor_ip,
     :param mirror_config: mirror_config fixture
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    if duthost.facts["asic_type"] == "vpp":
+        pytest.skip("Mirroring is not supported on VPP platform")
     logger.info("Adding mirror_session to DUT")
     acl_rule_file = os.path.join(mirror_setup['dut_tmp_dir'], ACL_RULE_PERSISTENT_FILE)
     extra_vars = {
@@ -540,6 +542,9 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     # Remove /proc/dma for armh
     elif duthost.facts["asic_type"] in ["marvell-prestera", "marvell"]:
         if 'armhf-' in duthost.facts["platform"] or 'arm64-' in duthost.facts["platform"]:
+            cmds.copy_proc_files.remove("/proc/dma")
+    elif duthost.facts["asic_type"] == "vpp":
+        if 'arm64-' in duthost.facts["platform"] or 'kvm' in duthost.facts["platform"]:
             cmds.copy_proc_files.remove("/proc/dma")
 
     return cmds_to_check


### PR DESCRIPTION
What is the motivation for this PR?
adapt test_techsupport to vpp arctos and kvm platform

vpp platforms doesn't support mirroring yet
vpp kvm platform and arm64 platform (arctos) do not have /proc/dma. The command needs to be removed similarly to other arm platforms. How did you do it?
Add pytest.skip to mirroring fixture if asic-type is vpp remove /proc/dma command if asic-type is vpp and platform contains arm64 or kvm. How did you verify/test it?
run sonic-mgmt

Any platform specific information?
vpp