### PR TITLE
Make stress/test_stress_routes.py robust in T2 testing (#17100)

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -43,6 +43,10 @@ Options:
     - option-name: path
       description: to figure out the path of topo_{}.yml
       required: False
+
+    - option-name: selected_route_set
+      description: the set of routes to be announced or withdrawn
+      required: False
 '''
 
 EXAMPLES = '''
@@ -875,7 +879,7 @@ We would have the following distribution:
 """
 
 
-def fib_t2_lag(topo, ptf_ip, action="announce"):
+def fib_t2_lag(topo, ptf_ip, action="announce", selected_route_set='all'):
     route_set = []
     vms = topo['topology']['VMs']
     # T1 VMs per linecard(asic) - key is the dut index, and value is a list of T1 VMs
@@ -895,8 +899,10 @@ def fib_t2_lag(topo, ptf_ip, action="announce"):
             if dut_index not in t3_vms:
                 t3_vms[dut_index] = list()
             t3_vms[dut_index].append(key)
-    route_set += generate_t2_routes(t1_vms, topo, ptf_ip, action)
-    route_set += generate_t2_routes(t3_vms, topo, ptf_ip, action)
+    if selected_route_set in ('all', 't1'):
+        route_set += generate_t2_routes(t1_vms, topo, ptf_ip, action)
+    if selected_route_set in ('all', 't3'):
+        route_set += generate_t2_routes(t3_vms, topo, ptf_ip, action)
     send_routes_in_parallel(route_set)
 
 
@@ -1040,6 +1046,8 @@ def main():
             ptf_ip=dict(required=True, type='str'),
             action=dict(required=False, type='str',
                         default='announce', choices=["announce", "withdraw"]),
+            selected_route_set=dict(required=False, type='str',
+                                    default='all', choices=['all', 't1', 't3']),
             path=dict(required=False, type='str', default=''),
             log_path=dict(required=False, type='str', default='')
         ),
@@ -1052,6 +1060,9 @@ def main():
     ptf_ip = module.params['ptf_ip']
     action = module.params['action']
     path = module.params['path']
+
+    if module.params['selected_route_set']:
+        selected_route_set = module.params['selected_route_set']
 
     topo = read_topo(topo_name, path)
     if not topo:
@@ -1070,7 +1081,7 @@ def main():
                 topo, ptf_ip, no_default_route=is_storage_backend, action=action)
             module.exit_json(changed=True)
         elif topo_type == "t2":
-            fib_t2_lag(topo, ptf_ip, action=action)
+            fib_t2_lag(topo, ptf_ip, action=action, selected_route_set=selected_route_set)
             module.exit_json(changed=True)
         elif topo_type == "t0-mclag":
             fib_t0_mclag(topo, ptf_ip, action=action)

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -20,9 +20,15 @@ pytestmark = [
 
 
 def announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name):
+    route_set = 'all'
+    # Due to https://github.com/sonic-net/sonic-mgmt/issues/16541, only announce and withdraw a small
+    # amount of routes in T2 testing to make test robust.
+    if topo_name == 't2':
+        route_set = 't1'
+
     logger.info("announce ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/",
-                              log_path="logs")
+                              log_path="logs", selected_route_set=route_set)
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") is True)
 
@@ -32,7 +38,7 @@ def announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name):
 
     logger.info("withdraw ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/",
-                              log_path="logs")
+                              log_path="logs", selected_route_set=route_set)
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
     sleep_to_wait(CRM_POLLING_INTERVAL * 5)


### PR DESCRIPTION
stress/test_stress_routes.py is flaky in T2 testing because ofhttps://github.com/https://github.com/sonic-net/sonic-mgmt/issues/16541. Only announce and withdraw a small amount of routes in T2 testing to make it robust.

Description of PR
Summary:
Fixes # (issue)

Type of change
 Bug fix
 Testbed and Framework(new/improvement)
 New Test case
 Skipped for non-supported platforms
 Test case improvement
Back port request
 202012
 202205
 202305
 202311
 202405
 202411
Approach
What is the motivation for this PR?
How did you do it?
How did you verify/test it?
Any platform specific information?
Supported testbed topology if it's a new test case?
Documentation