### PR TITLE
vpp: cleanup ip/test_ip_packet.py and route/test_route_perf.py

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -397,10 +397,23 @@ def is_mellanox_devices(hwsku):
         or 'mlnx' in hwsku
 
 
+def is_virtual_platform(duthost):
+    """Check if the DUT is running on a virtual (KVM) platform.
+
+    Args:
+        duthost: DUT host object.
+
+    Returns:
+        True if the platform is x86_64-kvm_x86_64-r0 (used by both VS and VPP testbeds),
+        False otherwise.
+    """
+    return duthost.facts.get("platform") == "x86_64-kvm_x86_64-r0"
+
+
 def is_mellanox_fanout(duthost, localhost):
     # Ansible localhost fixture which calls ansible playbook on the local host
 
-    if duthost.facts.get("asic_type") == "vs":
+    if is_virtual_platform(duthost):
         return False
 
     try:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3039,14 +3039,22 @@ ip/test_ip_packet.py:
     conditions:
       - "len(minigraph_interfaces) < 2 and len(minigraph_portchannels) < 2"
 
+ip/test_ip_packet.py::TestIPPacket::test_drop_l3_ip_packet_non_dut_mac:
+  skip:
+    reason: "vpp dpdk driver runs in non-promiscuous mode and drops packets that are not
+             destined to DUT MAC address. The packets are not seen by vpp so won't reflect in
+             drop counters."
+    conditions:
+      - "asic_type in ['vpp']"
+
 ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_drop:
   skip:
-    reason: "Broadcom, Cisco, Barefoot, and Marvell Asic will tolorate IP packets with 0xffff checksum
+    reason: "Broadcom, Cisco, Barefoot, VPP, and Marvell Asic will tolorate IP packets with 0xffff checksum
             / Skipping ip packet test since can't provide enough interfaces"
     conditions_logical_operator: or
     conditions:
 
-      - "asic_type in ['broadcom', 'cisco-8000', 'marvell', 'barefoot', 'marvell-teralynx', 'marvell-prestera'] and asic_subtype not in ['broadcom-dnx']"
+      - "asic_type in ['broadcom', 'cisco-8000', 'marvell', 'barefoot', 'marvell-teralynx', 'marvell-prestera', 'vpp'] and asic_subtype not in ['broadcom-dnx']"
       - "len(minigraph_interfaces) < 2 and len(minigraph_portchannels) < 2"
       - "topo_name in ['t2_2lc_36p-masic', 't2_2lc_min_ports-masic', 't2_5lc-mixed-96']"
 
@@ -3058,7 +3066,6 @@ ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_to
     conditions:
       - "asic_type in ['mellanox'] or asic_subtype in ['broadcom-dnx']"
       - "len(minigraph_interfaces) < 2 and len(minigraph_portchannels) < 2"
-
 ip/test_mgmt_ipv6_only.py:
   skip:
     reason: "Skipping mgmt ipv6 test for M* topo"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -570,22 +570,6 @@ golden_config_infra/test_config_reload_with_rendered_golden_config.py::test_rend
 #######################################
 #####           IP                #####
 #######################################
-ip/test_ip_packet.py::TestIPPacket::test_drop_l3_ip_packet_non_dut_mac:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_drop:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
 ip/test_mgmt_ipv6_only.py::test_ntp_ipv6_only:
   skip:
     reason: >
@@ -785,14 +769,6 @@ read_mac/test_read_mac_metadata.py::ReadMACMetadata:
 route/test_route_flow_counter.py:
   skip:
     reason: "per route counter is not supported in sonic-vpp but is supported in vpp dataplane. To be included after per route counter support is added in sonic-vpp."
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-route/test_route_perf.py::test_perf_add_remove_routes:
-  skip:
-    reason: >
-            Failed/Errored: To be included
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vpp']"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
1. With PR https://github.com/sonic-net/sonic-sairedis/pull/1794, route programming performance has improved. We can enable  remove the marker for route/test_route_perf.py.
2. properly mark test_forward_ip_packet_with_0xffff_chksum_drop as unsupported for vpp because it tolerates IP packets with 0xffff checksum.
3. skip test_drop_l3_ip_packet_non_dut_mac because vpp dpdk driver runs in non-promiscuous mode and drops the packet if dest MAC doesn't match DUT's MAC.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Clean up vpp conditional mark and enable test route/test_route_perf.py::test_perf_add_remove_routes

#### How did you do it?

#### How did you verify/test it?
Run sonic-mgmt test to verify
#### Any platform specific information?
vpp
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
