### PR TITLE
[202603] Add set_loopback(), bridge() utilities to SonicHost class (#21726)

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1,4 +1,3 @@
-
 import ipaddress
 import json
 import logging
@@ -25,6 +24,19 @@ from tests.common.helpers.platform_api.chassis import is_inband_port
 from tests.common.helpers.parallel import parallel_run_threaded
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common import constants
+from typing import TypedDict
+
+
+class ShellResult(TypedDict):
+    cmd: str
+    rc: int
+    stdout: str
+    stderr: str
+    stdout_lines: list
+    stderr_lines: list
+    failed: bool
+    changed: bool
+
 
 logger = logging.getLogger(__name__)
 PROCESS_TO_CONTAINER_MAP = {
@@ -431,6 +443,25 @@ class SonicHost(AnsibleHostBase):
             node. If we add more types of nodes, then we need to exclude them from this method as well.
         """
         return not self.is_supervisor_node()
+
+    def is_console_switch(self):
+        """
+        Check if this device has console functionality enabled.
+
+        Returns:
+            bool: True if console is enabled, False otherwise
+        """
+        try:
+            result = self.shell(
+                'sonic-db-cli CONFIG_DB hget "CONSOLE_SWITCH|console_mgmt" enabled',
+                module_ignore_errors=True
+            )
+            if result["rc"] == 0:
+                output = result["stdout"].strip().lower()
+                return output == 'yes'
+            return False
+        except Exception:
+            return False
 
     def is_macsec_capable_node(self):
         im = self.host.options['inventory_manager']
@@ -2978,6 +3009,272 @@ Totals               6450                 6449
                 return {"mgmt_ip": match.group(1), "version": "v6"}
 
         assert False, "Failed to find duthost mgmt ip"  # noqa: F631
+
+    def is_file_existed(self, device_path: str) -> bool:
+        """Check if device path exists. Returns True if exists, False otherwise."""
+        res: ShellResult = self.shell(f"test -e {device_path}", module_ignore_errors=True)
+        return True if res['rc'] == 0 else False
+
+    def is_file_opened(self, device_path: str) -> bool:
+        """Check if device path is not in use. Returns True if file is opened, False otherwise."""
+        res: ShellResult = self.shell(f"sudo lsof {device_path}", module_ignore_errors=True)
+        return True if res["stdout"] else False
+
+    def _get_serial_device_prefix(self) -> str:
+        """
+        Get the serial device prefix for the platform.
+
+        Returns:
+            str: The device prefix (e.g., "/dev/C0-", "/dev/ttyUSB-")
+        """
+        # Reads udevprefix.conf from the platform directory to determine the correct device prefix
+        # Falls back to /dev/ttyUSB- if the config file doesn't exist
+        script = '''
+from sonic_py_common import device_info
+import os
+
+platform_path, _ = device_info.get_paths_to_platform_and_hwsku_dirs()
+config_file = os.path.join(platform_path, "udevprefix.conf")
+
+if os.path.exists(config_file):
+    with open(config_file, 'r') as f:
+        device_prefix = "/dev/" + f.readline().rstrip()
+else:
+    raise FileNotFoundError("Config file not found")
+
+print(device_prefix)
+'''
+        cmd = f"python3 << 'EOF'\n{script}\nEOF"
+        res: ShellResult = self.shell(cmd, module_ignore_errors=True)
+
+        if res['rc'] != 0 or not res['stdout'].strip():
+            logging.warning("Failed to get serial device prefix, using default /dev/ttyUSB-")
+            device_prefix = "/dev/ttyUSB-"
+        else:
+            device_prefix = res['stdout'].strip()
+
+        return device_prefix
+
+    def _get_serial_device_path(self, port: int) -> str:
+        """
+        Get the full serial device path for a given port.
+
+        Args:
+            port: Port number (e.g., 1, 2)
+
+        Returns:
+            str: The full device path (e.g., "/dev/C0-1", "/dev/ttyUSB-1")
+        """
+        device_prefix = self._get_serial_device_prefix()
+        return f"{device_prefix}{port}"
+
+    def set_loopback(self, port: int, baud_rate: int = 9600, flow_control: bool = False) -> None:
+        """Set loopback on the specified port. Raises RuntimeError on failure."""
+        if not self.is_console_switch():
+            error_msg = "This operation is only supported on console switches"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        device_path = self._get_serial_device_path(port)
+
+        # Check if device path exists and is not in use or raise error
+        if not self.is_file_existed(device_path):
+            error_msg = f"Device path {device_path} does not exist"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+        if self.is_file_opened(device_path):
+            error_msg = f"Device path {device_path} is already in use"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        # Set hardware flow control option
+        crtscts_val = "1" if flow_control else "0"
+
+        # Execute loopback command
+        command = (
+            f"sudo socat -d -d "
+            f"FILE:{device_path},raw,echo=0,nonblock,b{baud_rate},cs8,"
+            f"parenb=0,cstopb=0,ixon=0,ixoff=0,crtscts={crtscts_val},icrnl=0,onlcr=0,opost=0,isig=0,icanon=0 "
+            f"EXEC:'/bin/cat' "
+            f"& echo $! "
+        )
+
+        res: ShellResult = self.shell(command, module_ignore_errors=True)
+        if res['failed']:
+            error_msg = f"Failed to start socat on port {port}: {res.get('stderr', '')}"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        logging.info(f"Successfully started socat loopback on port {port}")
+
+    def unset_loopback(self, port: int) -> None:
+        """Unset loopback on the specified port. Raises RuntimeError on failure."""
+        if not self.is_console_switch():
+            error_msg = "This operation is only supported on console switches"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        # Find all related socat processes
+        device_path = self._get_serial_device_path(port)
+        if not self.is_file_existed(device_path):
+            error_msg = f"Device path {device_path} does not exist"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        res: ShellResult = self.shell(f"pgrep -f 'socat .*{device_path}'", module_ignore_errors=True)
+        pids = res['stdout'].strip().split('\n')
+
+        # Kill all related socat processes
+        for pid in pids:
+            self.shell(f"sudo kill {pid}", module_ignore_errors=True)
+
+        time.sleep(0.5)
+
+        # Confirm all related processes for the port have stopped
+        res: ShellResult = \
+            self.shell(f"ps aux | grep 'socat .*{device_path}' | grep -v grep", module_ignore_errors=True)
+
+        if res['stdout'].strip():
+            error_msg = f"Failed to stop socat process for device path {device_path}"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        logging.info(f"Successfully stopped socat loopback on port {port}")
+
+    def bridge(self, port1: int, port2: int, baud_rate: int = 9600, flow_control: bool = False) -> None:
+        """Bridge two ports together. Raises RuntimeError on failure."""
+        if not self.is_console_switch():
+            error_msg = "This operation is only supported on console switches"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        device_path1 = self._get_serial_device_path(port1)
+        device_path2 = self._get_serial_device_path(port2)
+
+        # Check if both device paths exist and are not in use or raise error
+        if not self.is_file_existed(device_path1):
+            error_msg = f"Device path {device_path1} does not exist"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+        if not self.is_file_existed(device_path2):
+            error_msg = f"Device path {device_path2} does not exist"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+        if self.is_file_opened(device_path1):
+            error_msg = f"Device path {device_path1} is already in use"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+        if self.is_file_opened(device_path2):
+            error_msg = f"Device path {device_path2} is already in use"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        # Set hardware flow control option
+        crtscts_val = "1" if flow_control else "0"
+
+        # Execute bridge command
+        command = (
+            f"sudo socat -d -d "
+            f"FILE:{device_path1},raw,echo=0,nonblock,b{baud_rate},cs8,"
+            f"parenb=0,cstopb=0,ixon=0,ixoff=0,crtscts={crtscts_val},icrnl=0,onlcr=0,opost=0,isig=0,icanon=0 "
+            f"FILE:{device_path2},raw,echo=0,nonblock,b{baud_rate},cs8,"
+            f"parenb=0,cstopb=0,ixon=0,ixoff=0,crtscts={crtscts_val},icrnl=0,onlcr=0,opost=0,isig=0,icanon=0 "
+            f"& echo $! "
+        )
+
+        res: ShellResult = self.shell(command, module_ignore_errors=True)
+        if res['failed']:
+            error_msg = f"Failed to bridge ports {port1} and {port2}: {res.get('stderr', '')}"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        logging.info(f"Successfully bridged ports {port1} and {port2}")
+
+    def unbridge(self, port1: int, port2: int) -> None:
+        """Remove bridge between two ports. Raises RuntimeError on failure."""
+        if not self.is_console_switch():
+            error_msg = "This operation is only supported on console switches"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        device_path1 = self._get_serial_device_path(port1)
+        device_path2 = self._get_serial_device_path(port2)
+
+        if not self.is_file_existed(device_path1):
+            error_msg = f"Device path {device_path1} does not exist"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+        if not self.is_file_existed(device_path2):
+            error_msg = f"Device path {device_path2} does not exist"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        # Find all related socat processes for both ports
+        res: ShellResult = self.shell(
+            f"pgrep -f 'socat .*{device_path1}.*{device_path2}|socat .*{device_path2}.*{device_path1}'",
+            module_ignore_errors=True
+        )
+        pids = res['stdout'].strip().split('\n') if res['stdout'].strip() else []
+
+        if not pids or pids == ['']:
+            error_msg = f"No bridge found between {device_path1} and {device_path2}"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        # Kill all related socat processes
+        for pid in pids:
+            if pid:  # Skip empty strings
+                self.shell(f"sudo kill {pid}", module_ignore_errors=True)
+
+        time.sleep(0.5)
+
+        # Confirm all related processes have stopped
+        res: ShellResult = self.shell(
+            f"ps aux | "
+            f"grep -E 'socat.*{device_path1}.*{device_path2}|socat.*{device_path2}.*{device_path1}' | "
+            f"grep -v grep",
+            module_ignore_errors=True
+        )
+
+        if res['stdout'].strip():
+            error_msg = f"Failed to stop bridge process between {device_path1} and {device_path2}"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        logging.info(f"Successfully unbridged ports {port1} and {port2}")
+
+    def bridge_remote(self, port: int, remote_host: int, remote_port: int):
+        raise NotImplementedError("Bridge method is not implemented yet")
+
+    def unbridge_remote(self, port: int):
+        raise NotImplementedError("Bridge method is not implemented yet")
+
+    def cleanup_all_console_sessions(self) -> None:
+        """Clean up all console sessions. Raises RuntimeError on failure."""
+        if not self.is_console_switch():
+            error_msg = "This operation is only supported on console switches"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        device_prefix = self._get_serial_device_prefix()
+        pattern = f"{device_prefix}*"
+
+        # Find all related serial port processes
+        res: ShellResult = self.shell(f"sudo lsof -t {pattern}", module_ignore_errors=True)
+        pids = res['stdout'].strip().split('\n')
+
+        # Kill all related processes
+        for pid in pids:
+            self.shell(f"sudo kill {pid}", module_ignore_errors=True)
+
+        # Check that no serial ports are in use
+        res: ShellResult = self.shell(f"sudo lsof {pattern}", module_ignore_errors=True)
+        if res['stdout'].strip() or res['stderr'].strip():
+            error_msg = "Failed to clean up all console sessions: some ports are still in use"
+            logging.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        logging.info("Successfully cleaned up all console sessions")
 
 
 def assert_exit_non_zero(shell_output):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -957,11 +957,12 @@ def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, cred
     For Ethernet connections: Uses device_conn from conn_graph_facts
     For Serial connections: Uses device_serial_link from conn_graph_facts
     """
+
     # Internal helper functions
     def create_or_get_fanout(fanout_hosts, fanout_name, dut_host) -> Optional[FanoutHost]:
         """
         Create FanoutHost if not exists, or return existing one.
-        This centralizes fanout creation logic for both Ethernet and Serial connections.
+        Fanout creation logic for both Ethernet and Serial connections.
 
         Args:
             fanout_hosts (dict): Dictionary of existing fanout hosts
@@ -1005,11 +1006,9 @@ def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, cred
             fanout_password = creds.get('fanout_mlnx_password', None)
         elif os_type == 'ixia':
             # Skip for ixia device which has no fanout
-            logging.info(f"Skipping ixia device {fanout_name}")
             return None
         else:
-            logging.warning(f"Unsupported fanout OS type: {os_type}")
-            return None
+            pytest.fail(f"Unsupported fanout OS type {os_type} for fanout {fanout_name}")
 
         # EOS specific shell credentials
         eos_shell_user = None
@@ -1044,25 +1043,28 @@ def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, cred
         return fanout
 
     # Main fixture logic
+
     fanout_hosts = {}
 
-    # Skip NUT topologies that have no fanout
+    # Skip special topologies that have no fanout
     if tbinfo['topo']['name'].startswith('nut-'):
         logging.info("Nut topology has no fanout")
         return fanout_hosts
 
     # Process Ethernet connections
+
     dev_conn = conn_graph_facts.get('device_conn', {})
 
-    for dut_host, ethernet_ports in dev_conn.items():
+    for dut_name, ethernet_ports in dev_conn.items():
 
-        duthost = duthosts[dut_host]
+        duthost = duthosts[dut_name]
 
         # Skip virtual testbed which has no fanout
         if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
-            logging.info(f"Skipping kvm platform {dut_host}")
+            logging.info(f"Skipping kvm platform {dut_name}")
             continue
 
+        # Get minigraph facts for port alias mapping
         mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
 
         # Process each Ethernet port connection
@@ -1071,12 +1073,12 @@ def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, cred
             fanout_port = str(fanout_rec['peerport'])
 
             # Create or get fanout object
-            fanout = create_or_get_fanout(fanout_hosts, fanout_host, dut_host)
+            fanout = create_or_get_fanout(fanout_hosts, fanout_host, dut_name)
             if fanout is None:
                 continue
 
             # Add Ethernet port mapping: DUT port -> Fanout port
-            fanout.add_port_map(encode_dut_port_name(dut_host, dut_port), fanout_port)
+            fanout.add_port_map(encode_dut_port_name(dut_name, dut_port), fanout_port)
 
             # Handle port alias mapping if available
             if dut_port in mg_facts.get('minigraph_port_alias_to_name_map', {}):
@@ -1088,37 +1090,40 @@ def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, cred
                 # Ethernet108   Ethernet32
                 # Ethernet32    Ethernet13/1
                 if mapped_port not in list(ethernet_ports.keys()):
-                    fanout.add_port_map(encode_dut_port_name(dut_host, mapped_port), fanout_port)
+                    fanout.add_port_map(encode_dut_port_name(dut_name, mapped_port), fanout_port)
 
     # Process Serial connections
 
     dev_serial_link = conn_graph_facts.get('device_serial_link', {})
 
-    for dut_host, serial_ports in dev_serial_link.items():
+    for dut_name, serial_ports_map in dev_serial_link.items():
 
-        duthost = duthosts[dut_host]
+        duthost = duthosts[dut_name]
 
         # Skip virtual testbed which has no fanout
         if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
-            logging.info(f"Skipping kvm platform {dut_host} for serial links")
+            logging.info(f"Skipping kvm platform {dut_name} for serial links")
             continue
 
         # Process each Serial port connection
-        for serial_port_num, link_info in serial_ports.items():
+        for host_port, link_info in serial_ports_map.items():
             fanout_host = str(link_info['peerdevice'])
             fanout_port = str(link_info['peerport'])
+            baud_rate = link_info.get('baud_rate', "9600")
+            flow_control = link_info.get('flow_control', "0") == "1"
 
-            # Create or get fanout object (reuses same function as Ethernet)
-            fanout = create_or_get_fanout(fanout_hosts, fanout_host, dut_host)
+            # Create or get fanout object
+            fanout = create_or_get_fanout(fanout_hosts, fanout_host, dut_name)
             if fanout is None:
                 continue
 
-            # Add Serial port mapping with Console prefix
-            serial_port_key = f"C0_{serial_port_num}"
-            fanout.add_port_map(encode_dut_port_name(dut_host, serial_port_key), fanout_port)
+            # Add Serial port mapping
+            fanout.add_serial_port_map(dut_name, host_port, fanout_port, baud_rate, flow_control)
 
-            logging.debug(f"Added serial port mapping: {dut_host} Console{serial_port_num} -> "
-                          f"{fanout_host}:{fanout_port} (baud={link_info.get('baud_rate', '9600')})")
+            logging.debug(
+                f"Added serial port mapping: {dut_name} Console{host_port} -> "
+                f"{fanout_host}:{fanout_port} (baud={link_info.get('baud_rate', '9600')})"
+            )
 
     logging.info(f"fanouthosts fixture initialized with {len(fanout_hosts)} fanout devices")
 


### PR DESCRIPTION
Backport of https://github.com/sonic-net/sonic-mgmt/pull/21726 to 202603.

### Description of PR

Add console loopback utility and improve type checking for serial port operations.

This PR adds utilities for managing serial port connections on console switches and improves type safety in the test framework.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [x] 202603

### Approach
#### What is the motivation for this PR?

Need utilities to test console switch functionality, specifically serial port loopback and bridging operations.

#### How did you do it?

1. Added `SonicHost` methods for serial port operations:
   - `set_loopback()` / `unset_loopback()` - Create/remove loopback on a single port
   - `bridge()` / `unbridge()` - Connect/disconnect two serial ports
   - `cleanup_all_console_sessions()` - Clean up all serial port sessions
2. Added `SerialPortMapping` dataclass in `FanoutHost` to store serial port configuration
3. Extended `fanouthosts` fixture to support serial connections from `device_serial_link` in connection graph
4. Added `ShellResult` TypedDict for better type checking of shell command results
5. Used exception-based error handling instead of return codes

#### How did you verify/test it?

Cherry-picked from merged upstream PR. Conflict resolution: kept `get_mgmt_ip()` from 202603 branch, added new console utility methods after it.

#### Any platform specific information?

Console switch must be SONiC-based with serial ports accessible via `/dev/C0-*` device paths.
