### PR TITLE
[code sync] sonic-mgmt public 202511 → public 202603 (2026-04-01)

### DIFF
--- a/ansible/ceos_topo_converger.py
+++ b/ansible/ceos_topo_converger.py
@@ -265,6 +265,9 @@ class SonicTopoConverger:
 def converge_testbed(input_file: str, output_file: str) -> None:
     with open(input_file, "r", encoding="utf-8") as in_file:
         topo = yaml.safe_load(in_file)
+    if topo.get("topo_is_multi_vrf", False):
+        print("Topology already converged, skipping convergence.")
+        return
     converger = SonicTopoConverger(topo, output_file)
     converger.run()
 

--- a/ansible/ceos_topo_converger.py
+++ b/ansible/ceos_topo_converger.py
@@ -163,6 +163,9 @@ class SonicTopoConverger:
                         continue
                     eth_intf = f"Ethernet{eth_intf_index}"
                     vrf[eth_intf] = deepcopy(peer_intfs[intf])
+                    # Update lacp channel-group to match the new Port-Channel index
+                    if "lacp" in vrf[eth_intf] and "Port-Channel1" in peer_intfs:
+                        vrf[eth_intf]["lacp"] = intf_index
                     orig_intf_map[intf] = eth_intf
                     eth_intf_index += 1
 

--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -7215,3 +7215,1535 @@ sensors_checks:
       temp: [ ]
     psu_skips: { }
     sensor_skip_per_version: { }
+
+  x86_64-arista_7280r4_32qf_32df:
+    alarms:
+      fan:
+      - dps800-i2c-22-58/fan1/fan1_alarm
+      - dps800-i2c-22-58/fan1/fan1_fault
+      - dps800-i2c-22-58/fan2/fan2_alarm
+      - dps800-i2c-22-58/fan2/fan2_fault
+      - dps800-i2c-23-58/fan1/fan1_alarm
+      - dps800-i2c-23-58/fan1/fan1_fault
+      - dps800-i2c-23-58/fan2/fan2_alarm
+      - dps800-i2c-23-58/fan2/fan2_fault
+      - pali2_cpld-i2c-16-60/fan1/fan1_fault
+      - pali2_cpld-i2c-16-60/fan2/fan2_fault
+      - pali2_cpld-i2c-16-60/fan3/fan3_fault
+      - pali2_cpld-i2c-16-60/fan4/fan4_fault
+      power:
+      - dps800-i2c-22-58/iin/curr1_crit_alarm
+      - dps800-i2c-22-58/iin/curr1_max_alarm
+      - dps800-i2c-22-58/iout1/curr2_crit_alarm
+      - dps800-i2c-22-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-22-58/iout1/curr2_max_alarm
+      - dps800-i2c-22-58/pin/power1_alarm
+      - dps800-i2c-22-58/pout1/power2_cap_alarm
+      - dps800-i2c-22-58/pout1/power2_crit_alarm
+      - dps800-i2c-22-58/pout1/power2_max_alarm
+      - dps800-i2c-22-58/vin/in1_crit_alarm
+      - dps800-i2c-22-58/vin/in1_lcrit_alarm
+      - dps800-i2c-22-58/vin/in1_max_alarm
+      - dps800-i2c-22-58/vin/in1_min_alarm
+      - dps800-i2c-22-58/vout1/in3_crit_alarm
+      - dps800-i2c-22-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-22-58/vout1/in3_max_alarm
+      - dps800-i2c-22-58/vout1/in3_min_alarm
+      - dps800-i2c-23-58/iin/curr1_crit_alarm
+      - dps800-i2c-23-58/iin/curr1_max_alarm
+      - dps800-i2c-23-58/iout1/curr2_crit_alarm
+      - dps800-i2c-23-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-23-58/iout1/curr2_max_alarm
+      - dps800-i2c-23-58/pin/power1_alarm
+      - dps800-i2c-23-58/pout1/power2_cap_alarm
+      - dps800-i2c-23-58/pout1/power2_crit_alarm
+      - dps800-i2c-23-58/pout1/power2_max_alarm
+      - dps800-i2c-23-58/vin/in1_crit_alarm
+      - dps800-i2c-23-58/vin/in1_lcrit_alarm
+      - dps800-i2c-23-58/vin/in1_max_alarm
+      - dps800-i2c-23-58/vin/in1_min_alarm
+      - dps800-i2c-23-58/vout1/in3_crit_alarm
+      - dps800-i2c-23-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-23-58/vout1/in3_max_alarm
+      - dps800-i2c-23-58/vout1/in3_min_alarm
+      - isl68223-i2c-25-47/iin1/curr1_crit_alarm
+      - isl68223-i2c-25-47/iin1/curr1_max_alarm
+      - isl68223-i2c-25-47/iin2/curr2_crit_alarm
+      - isl68223-i2c-25-47/iin2/curr2_max_alarm
+      - isl68223-i2c-25-47/iout1/curr3_crit_alarm
+      - isl68223-i2c-25-47/iout1/curr3_max_alarm
+      - isl68223-i2c-25-47/iout2/curr4_crit_alarm
+      - isl68223-i2c-25-47/iout2/curr4_max_alarm
+      - isl68223-i2c-25-47/pin1/power1_alarm
+      - isl68223-i2c-25-47/pin2/power2_alarm
+      - isl68223-i2c-25-47/vin/in1_crit_alarm
+      - isl68223-i2c-25-47/vin/in1_lcrit_alarm
+      - isl68223-i2c-25-47/vin/in1_max_alarm
+      - isl68223-i2c-25-47/vin/in1_min_alarm
+      - isl68223-i2c-25-47/vout1/in3_crit_alarm
+      - isl68223-i2c-25-47/vout1/in3_lcrit_alarm
+      - isl68223-i2c-25-47/vout2/in4_crit_alarm
+      - isl68223-i2c-25-47/vout2/in4_lcrit_alarm
+      - isl68226-i2c-24-4c/iin1/curr1_crit_alarm
+      - isl68226-i2c-24-4c/iin1/curr1_max_alarm
+      - isl68226-i2c-24-4c/iin2/curr2_crit_alarm
+      - isl68226-i2c-24-4c/iin2/curr2_max_alarm
+      - isl68226-i2c-24-4c/iin3/curr3_crit_alarm
+      - isl68226-i2c-24-4c/iin3/curr3_max_alarm
+      - isl68226-i2c-24-4c/iout1/curr4_crit_alarm
+      - isl68226-i2c-24-4c/iout1/curr4_max_alarm
+      - isl68226-i2c-24-4c/iout2/curr5_crit_alarm
+      - isl68226-i2c-24-4c/iout2/curr5_max_alarm
+      - isl68226-i2c-24-4c/iout3/curr6_crit_alarm
+      - isl68226-i2c-24-4c/iout3/curr6_max_alarm
+      - isl68226-i2c-24-4c/pin1/power1_alarm
+      - isl68226-i2c-24-4c/pin2/power2_alarm
+      - isl68226-i2c-24-4c/pin3/power3_alarm
+      - isl68226-i2c-24-4c/vin/in1_crit_alarm
+      - isl68226-i2c-24-4c/vin/in1_lcrit_alarm
+      - isl68226-i2c-24-4c/vin/in1_max_alarm
+      - isl68226-i2c-24-4c/vin/in1_min_alarm
+      - isl68226-i2c-24-4c/vout1/in3_crit_alarm
+      - isl68226-i2c-24-4c/vout1/in3_lcrit_alarm
+      - isl68226-i2c-24-4c/vout2/in4_crit_alarm
+      - isl68226-i2c-24-4c/vout2/in4_lcrit_alarm
+      - isl68226-i2c-24-4c/vout3/in5_crit_alarm
+      - isl68226-i2c-24-4c/vout3/in5_lcrit_alarm
+      - isl68226-i2c-24-4f/iin1/curr1_crit_alarm
+      - isl68226-i2c-24-4f/iin1/curr1_max_alarm
+      - isl68226-i2c-24-4f/iin2/curr2_crit_alarm
+      - isl68226-i2c-24-4f/iin2/curr2_max_alarm
+      - isl68226-i2c-24-4f/iin3/curr3_crit_alarm
+      - isl68226-i2c-24-4f/iin3/curr3_max_alarm
+      - isl68226-i2c-24-4f/iout1/curr4_crit_alarm
+      - isl68226-i2c-24-4f/iout1/curr4_max_alarm
+      - isl68226-i2c-24-4f/iout2/curr5_crit_alarm
+      - isl68226-i2c-24-4f/iout2/curr5_max_alarm
+      - isl68226-i2c-24-4f/iout3/curr6_crit_alarm
+      - isl68226-i2c-24-4f/iout3/curr6_max_alarm
+      - isl68226-i2c-24-4f/pin1/power1_alarm
+      - isl68226-i2c-24-4f/pin2/power2_alarm
+      - isl68226-i2c-24-4f/pin3/power3_alarm
+      - isl68226-i2c-24-4f/vin/in1_crit_alarm
+      - isl68226-i2c-24-4f/vin/in1_lcrit_alarm
+      - isl68226-i2c-24-4f/vin/in1_max_alarm
+      - isl68226-i2c-24-4f/vin/in1_min_alarm
+      - isl68226-i2c-24-4f/vout1/in3_crit_alarm
+      - isl68226-i2c-24-4f/vout1/in3_lcrit_alarm
+      - isl68226-i2c-24-4f/vout2/in4_crit_alarm
+      - isl68226-i2c-24-4f/vout2/in4_lcrit_alarm
+      - isl68226-i2c-24-4f/vout3/in5_crit_alarm
+      - isl68226-i2c-24-4f/vout3/in5_lcrit_alarm
+      - isl68226-i2c-25-4c/iin1/curr1_crit_alarm
+      - isl68226-i2c-25-4c/iin1/curr1_max_alarm
+      - isl68226-i2c-25-4c/iin2/curr2_crit_alarm
+      - isl68226-i2c-25-4c/iin2/curr2_max_alarm
+      - isl68226-i2c-25-4c/iin3/curr3_crit_alarm
+      - isl68226-i2c-25-4c/iin3/curr3_max_alarm
+      - isl68226-i2c-25-4c/iout1/curr4_crit_alarm
+      - isl68226-i2c-25-4c/iout1/curr4_max_alarm
+      - isl68226-i2c-25-4c/iout2/curr5_crit_alarm
+      - isl68226-i2c-25-4c/iout2/curr5_max_alarm
+      - isl68226-i2c-25-4c/iout3/curr6_crit_alarm
+      - isl68226-i2c-25-4c/iout3/curr6_max_alarm
+      - isl68226-i2c-25-4c/pin1/power1_alarm
+      - isl68226-i2c-25-4c/pin2/power2_alarm
+      - isl68226-i2c-25-4c/pin3/power3_alarm
+      - isl68226-i2c-25-4c/vin/in1_crit_alarm
+      - isl68226-i2c-25-4c/vin/in1_lcrit_alarm
+      - isl68226-i2c-25-4c/vin/in1_max_alarm
+      - isl68226-i2c-25-4c/vin/in1_min_alarm
+      - isl68226-i2c-25-4c/vout1/in3_crit_alarm
+      - isl68226-i2c-25-4c/vout1/in3_lcrit_alarm
+      - isl68226-i2c-25-4c/vout2/in4_crit_alarm
+      - isl68226-i2c-25-4c/vout2/in4_lcrit_alarm
+      - isl68226-i2c-25-4c/vout3/in5_crit_alarm
+      - isl68226-i2c-25-4c/vout3/in5_lcrit_alarm
+      - raa228228-i2c-24-45/iin1/curr1_crit_alarm
+      - raa228228-i2c-24-45/iin1/curr1_max_alarm
+      - raa228228-i2c-24-45/iin2/curr2_crit_alarm
+      - raa228228-i2c-24-45/iin2/curr2_max_alarm
+      - raa228228-i2c-24-45/iout1/curr3_crit_alarm
+      - raa228228-i2c-24-45/iout1/curr3_max_alarm
+      - raa228228-i2c-24-45/iout2/curr4_crit_alarm
+      - raa228228-i2c-24-45/iout2/curr4_max_alarm
+      - raa228228-i2c-24-45/pin1/power1_alarm
+      - raa228228-i2c-24-45/pin2/power2_alarm
+      - raa228228-i2c-24-45/vin/in1_crit_alarm
+      - raa228228-i2c-24-45/vin/in1_lcrit_alarm
+      - raa228228-i2c-24-45/vin/in1_max_alarm
+      - raa228228-i2c-24-45/vin/in1_min_alarm
+      - raa228228-i2c-24-45/vout1/in3_crit_alarm
+      - raa228228-i2c-24-45/vout1/in3_lcrit_alarm
+      - raa228228-i2c-24-45/vout2/in4_crit_alarm
+      - raa228228-i2c-24-45/vout2/in4_lcrit_alarm
+      - raa228228-i2c-25-45/iin1/curr1_crit_alarm
+      - raa228228-i2c-25-45/iin1/curr1_max_alarm
+      - raa228228-i2c-25-45/iin2/curr2_crit_alarm
+      - raa228228-i2c-25-45/iin2/curr2_max_alarm
+      - raa228228-i2c-25-45/iout1/curr3_crit_alarm
+      - raa228228-i2c-25-45/iout1/curr3_max_alarm
+      - raa228228-i2c-25-45/iout2/curr4_crit_alarm
+      - raa228228-i2c-25-45/iout2/curr4_max_alarm
+      - raa228228-i2c-25-45/pin1/power1_alarm
+      - raa228228-i2c-25-45/pin2/power2_alarm
+      - raa228228-i2c-25-45/vin/in1_crit_alarm
+      - raa228228-i2c-25-45/vin/in1_lcrit_alarm
+      - raa228228-i2c-25-45/vin/in1_max_alarm
+      - raa228228-i2c-25-45/vin/in1_min_alarm
+      - raa228228-i2c-25-45/vout1/in3_crit_alarm
+      - raa228228-i2c-25-45/vout1/in3_lcrit_alarm
+      - raa228228-i2c-25-45/vout2/in4_crit_alarm
+      - raa228228-i2c-25-45/vout2/in4_lcrit_alarm
+      temp:
+      - amax31732-i2c-19-1c/temp1/temp1_crit_alarm
+      - amax31732-i2c-19-1c/temp1/temp1_lcrit_alarm
+      - amax31732-i2c-19-1c/temp1/temp1_max_alarm
+      - amax31732-i2c-19-1c/temp1/temp1_min_alarm
+      - amax31732-i2c-19-1c/temp2/temp2_crit_alarm
+      - amax31732-i2c-19-1c/temp2/temp2_fault
+      - amax31732-i2c-19-1c/temp2/temp2_lcrit_alarm
+      - amax31732-i2c-19-1c/temp2/temp2_max_alarm
+      - amax31732-i2c-19-1c/temp2/temp2_min_alarm
+      - amax31732-i2c-19-1c/temp3/temp3_crit_alarm
+      - amax31732-i2c-19-1c/temp3/temp3_fault
+      - amax31732-i2c-19-1c/temp3/temp3_lcrit_alarm
+      - amax31732-i2c-19-1c/temp3/temp3_max_alarm
+      - amax31732-i2c-19-1c/temp3/temp3_min_alarm
+      - amax31732-i2c-19-1c/temp4/temp4_crit_alarm
+      - amax31732-i2c-19-1c/temp4/temp4_fault
+      - amax31732-i2c-19-1c/temp4/temp4_lcrit_alarm
+      - amax31732-i2c-19-1c/temp4/temp4_max_alarm
+      - amax31732-i2c-19-1c/temp4/temp4_min_alarm
+      - amax31732-i2c-19-1c/temp5/temp5_crit_alarm
+      - amax31732-i2c-19-1c/temp5/temp5_fault
+      - amax31732-i2c-19-1c/temp5/temp5_lcrit_alarm
+      - amax31732-i2c-19-1c/temp5/temp5_max_alarm
+      - amax31732-i2c-19-1c/temp5/temp5_min_alarm
+      - dps800-i2c-22-58/temp1/temp1_crit_alarm
+      - dps800-i2c-22-58/temp1/temp1_lcrit_alarm
+      - dps800-i2c-22-58/temp1/temp1_max_alarm
+      - dps800-i2c-22-58/temp1/temp1_min_alarm
+      - dps800-i2c-22-58/temp2/temp2_crit_alarm
+      - dps800-i2c-22-58/temp2/temp2_lcrit_alarm
+      - dps800-i2c-22-58/temp2/temp2_max_alarm
+      - dps800-i2c-22-58/temp2/temp2_min_alarm
+      - dps800-i2c-22-58/temp3/temp3_crit_alarm
+      - dps800-i2c-22-58/temp3/temp3_lcrit_alarm
+      - dps800-i2c-22-58/temp3/temp3_max_alarm
+      - dps800-i2c-22-58/temp3/temp3_min_alarm
+      - dps800-i2c-23-58/temp1/temp1_crit_alarm
+      - dps800-i2c-23-58/temp1/temp1_lcrit_alarm
+      - dps800-i2c-23-58/temp1/temp1_max_alarm
+      - dps800-i2c-23-58/temp1/temp1_min_alarm
+      - dps800-i2c-23-58/temp2/temp2_crit_alarm
+      - dps800-i2c-23-58/temp2/temp2_lcrit_alarm
+      - dps800-i2c-23-58/temp2/temp2_max_alarm
+      - dps800-i2c-23-58/temp2/temp2_min_alarm
+      - dps800-i2c-23-58/temp3/temp3_crit_alarm
+      - dps800-i2c-23-58/temp3/temp3_lcrit_alarm
+      - dps800-i2c-23-58/temp3/temp3_max_alarm
+      - dps800-i2c-23-58/temp3/temp3_min_alarm
+      - isl68223-i2c-25-47/temp1/temp1_crit_alarm
+      - isl68223-i2c-25-47/temp1/temp1_lcrit_alarm
+      - isl68223-i2c-25-47/temp1/temp1_max_alarm
+      - isl68223-i2c-25-47/temp2/temp2_crit_alarm
+      - isl68223-i2c-25-47/temp2/temp2_lcrit_alarm
+      - isl68223-i2c-25-47/temp2/temp2_max_alarm
+      - isl68223-i2c-25-47/temp3/temp3_crit_alarm
+      - isl68223-i2c-25-47/temp3/temp3_lcrit_alarm
+      - isl68223-i2c-25-47/temp3/temp3_max_alarm
+      - isl68223-i2c-25-47/temp4/temp4_crit_alarm
+      - isl68223-i2c-25-47/temp4/temp4_lcrit_alarm
+      - isl68223-i2c-25-47/temp4/temp4_max_alarm
+      - isl68223-i2c-25-47/temp5/temp5_crit_alarm
+      - isl68223-i2c-25-47/temp5/temp5_lcrit_alarm
+      - isl68223-i2c-25-47/temp5/temp5_max_alarm
+      - isl68226-i2c-24-4c/temp1/temp1_crit_alarm
+      - isl68226-i2c-24-4c/temp1/temp1_lcrit_alarm
+      - isl68226-i2c-24-4c/temp1/temp1_max_alarm
+      - isl68226-i2c-24-4c/temp2/temp2_crit_alarm
+      - isl68226-i2c-24-4c/temp2/temp2_lcrit_alarm
+      - isl68226-i2c-24-4c/temp2/temp2_max_alarm
+      - isl68226-i2c-24-4c/temp3/temp3_crit_alarm
+      - isl68226-i2c-24-4c/temp3/temp3_lcrit_alarm
+      - isl68226-i2c-24-4c/temp3/temp3_max_alarm
+      - isl68226-i2c-24-4c/temp4/temp4_crit_alarm
+      - isl68226-i2c-24-4c/temp4/temp4_lcrit_alarm
+      - isl68226-i2c-24-4c/temp4/temp4_max_alarm
+      - isl68226-i2c-24-4c/temp5/temp5_crit_alarm
+      - isl68226-i2c-24-4c/temp5/temp5_lcrit_alarm
+      - isl68226-i2c-24-4c/temp5/temp5_max_alarm
+      - isl68226-i2c-24-4c/temp6/temp6_crit_alarm
+      - isl68226-i2c-24-4c/temp6/temp6_lcrit_alarm
+      - isl68226-i2c-24-4c/temp6/temp6_max_alarm
+      - isl68226-i2c-24-4c/temp7/temp7_crit_alarm
+      - isl68226-i2c-24-4c/temp7/temp7_lcrit_alarm
+      - isl68226-i2c-24-4c/temp7/temp7_max_alarm
+      - isl68226-i2c-24-4f/temp1/temp1_crit_alarm
+      - isl68226-i2c-24-4f/temp1/temp1_lcrit_alarm
+      - isl68226-i2c-24-4f/temp1/temp1_max_alarm
+      - isl68226-i2c-24-4f/temp2/temp2_crit_alarm
+      - isl68226-i2c-24-4f/temp2/temp2_lcrit_alarm
+      - isl68226-i2c-24-4f/temp2/temp2_max_alarm
+      - isl68226-i2c-24-4f/temp3/temp3_crit_alarm
+      - isl68226-i2c-24-4f/temp3/temp3_lcrit_alarm
+      - isl68226-i2c-24-4f/temp3/temp3_max_alarm
+      - isl68226-i2c-24-4f/temp4/temp4_crit_alarm
+      - isl68226-i2c-24-4f/temp4/temp4_lcrit_alarm
+      - isl68226-i2c-24-4f/temp4/temp4_max_alarm
+      - isl68226-i2c-24-4f/temp5/temp5_crit_alarm
+      - isl68226-i2c-24-4f/temp5/temp5_lcrit_alarm
+      - isl68226-i2c-24-4f/temp5/temp5_max_alarm
+      - isl68226-i2c-24-4f/temp6/temp6_crit_alarm
+      - isl68226-i2c-24-4f/temp6/temp6_lcrit_alarm
+      - isl68226-i2c-24-4f/temp6/temp6_max_alarm
+      - isl68226-i2c-24-4f/temp7/temp7_crit_alarm
+      - isl68226-i2c-24-4f/temp7/temp7_lcrit_alarm
+      - isl68226-i2c-24-4f/temp7/temp7_max_alarm
+      - isl68226-i2c-25-4c/temp1/temp1_crit_alarm
+      - isl68226-i2c-25-4c/temp1/temp1_lcrit_alarm
+      - isl68226-i2c-25-4c/temp1/temp1_max_alarm
+      - isl68226-i2c-25-4c/temp2/temp2_crit_alarm
+      - isl68226-i2c-25-4c/temp2/temp2_lcrit_alarm
+      - isl68226-i2c-25-4c/temp2/temp2_max_alarm
+      - isl68226-i2c-25-4c/temp3/temp3_crit_alarm
+      - isl68226-i2c-25-4c/temp3/temp3_lcrit_alarm
+      - isl68226-i2c-25-4c/temp3/temp3_max_alarm
+      - isl68226-i2c-25-4c/temp4/temp4_crit_alarm
+      - isl68226-i2c-25-4c/temp4/temp4_lcrit_alarm
+      - isl68226-i2c-25-4c/temp4/temp4_max_alarm
+      - isl68226-i2c-25-4c/temp5/temp5_crit_alarm
+      - isl68226-i2c-25-4c/temp5/temp5_lcrit_alarm
+      - isl68226-i2c-25-4c/temp5/temp5_max_alarm
+      - isl68226-i2c-25-4c/temp6/temp6_crit_alarm
+      - isl68226-i2c-25-4c/temp6/temp6_lcrit_alarm
+      - isl68226-i2c-25-4c/temp6/temp6_max_alarm
+      - isl68226-i2c-25-4c/temp7/temp7_crit_alarm
+      - isl68226-i2c-25-4c/temp7/temp7_lcrit_alarm
+      - isl68226-i2c-25-4c/temp7/temp7_max_alarm
+      - nvme-pci-0500/Composite/temp1_alarm
+      - raa228228-i2c-24-45/temp1/temp1_crit_alarm
+      - raa228228-i2c-24-45/temp1/temp1_lcrit_alarm
+      - raa228228-i2c-24-45/temp1/temp1_max_alarm
+      - raa228228-i2c-24-45/temp2/temp2_crit_alarm
+      - raa228228-i2c-24-45/temp2/temp2_lcrit_alarm
+      - raa228228-i2c-24-45/temp2/temp2_max_alarm
+      - raa228228-i2c-24-45/temp3/temp3_crit_alarm
+      - raa228228-i2c-24-45/temp3/temp3_lcrit_alarm
+      - raa228228-i2c-24-45/temp3/temp3_max_alarm
+      - raa228228-i2c-25-45/temp1/temp1_crit_alarm
+      - raa228228-i2c-25-45/temp1/temp1_lcrit_alarm
+      - raa228228-i2c-25-45/temp1/temp1_max_alarm
+      - raa228228-i2c-25-45/temp2/temp2_crit_alarm
+      - raa228228-i2c-25-45/temp2/temp2_lcrit_alarm
+      - raa228228-i2c-25-45/temp2/temp2_max_alarm
+      - raa228228-i2c-25-45/temp3/temp3_crit_alarm
+      - raa228228-i2c-25-45/temp3/temp3_lcrit_alarm
+      - raa228228-i2c-25-45/temp3/temp3_max_alarm
+
+    compares:
+      fan: [ ]
+      power: [ ]
+      temp:
+      - - amax31732-i2c-19-1c/temp1/temp1_input
+        - amax31732-i2c-19-1c/temp1/temp1_crit
+      - - amax31732-i2c-19-1c/temp2/temp2_input
+        - amax31732-i2c-19-1c/temp2/temp2_crit
+      - - amax31732-i2c-19-1c/temp3/temp3_input
+        - amax31732-i2c-19-1c/temp3/temp3_crit
+      - - amax31732-i2c-19-1c/temp4/temp4_input
+        - amax31732-i2c-19-1c/temp4/temp4_crit
+      - - amax31732-i2c-19-1c/temp5/temp5_input
+        - amax31732-i2c-19-1c/temp5/temp5_crit
+      - - dps800-i2c-22-58/temp1/temp1_input
+        - dps800-i2c-22-58/temp1/temp1_crit
+      - - dps800-i2c-22-58/temp2/temp2_input
+        - dps800-i2c-22-58/temp2/temp2_crit
+      - - dps800-i2c-22-58/temp3/temp3_input
+        - dps800-i2c-22-58/temp3/temp3_crit
+      - - dps800-i2c-23-58/temp1/temp1_input
+        - dps800-i2c-23-58/temp1/temp1_crit
+      - - dps800-i2c-23-58/temp2/temp2_input
+        - dps800-i2c-23-58/temp2/temp2_crit
+      - - dps800-i2c-23-58/temp3/temp3_input
+        - dps800-i2c-23-58/temp3/temp3_crit
+      - - isl68223-i2c-25-47/temp1/temp1_input
+        - isl68223-i2c-25-47/temp1/temp1_crit
+      - - isl68223-i2c-25-47/temp3/temp3_input
+        - isl68223-i2c-25-47/temp3/temp3_crit
+      - - isl68226-i2c-24-4c/temp1/temp1_input
+        - isl68226-i2c-24-4c/temp1/temp1_crit
+      - - isl68226-i2c-24-4c/temp2/temp2_input
+        - isl68226-i2c-24-4c/temp2/temp2_crit
+      - - isl68226-i2c-24-4c/temp3/temp3_input
+        - isl68226-i2c-24-4c/temp3/temp3_crit
+      - - isl68226-i2c-24-4c/temp4/temp4_input
+        - isl68226-i2c-24-4c/temp4/temp4_crit
+      - - isl68226-i2c-24-4f/temp1/temp1_input
+        - isl68226-i2c-24-4f/temp1/temp1_crit
+      - - isl68226-i2c-24-4f/temp2/temp2_input
+        - isl68226-i2c-24-4f/temp2/temp2_crit
+      - - isl68226-i2c-24-4f/temp3/temp3_input
+        - isl68226-i2c-24-4f/temp3/temp3_crit
+      - - isl68226-i2c-24-4f/temp4/temp4_input
+        - isl68226-i2c-24-4f/temp4/temp4_crit
+      - - isl68226-i2c-25-4c/temp1/temp1_input
+        - isl68226-i2c-25-4c/temp1/temp1_crit
+      - - isl68226-i2c-25-4c/temp2/temp2_input
+        - isl68226-i2c-25-4c/temp2/temp2_crit
+      - - isl68226-i2c-25-4c/temp3/temp3_input
+        - isl68226-i2c-25-4c/temp3/temp3_crit
+      - - isl68226-i2c-25-4c/temp4/temp4_input
+        - isl68226-i2c-25-4c/temp4/temp4_crit
+      - - nvme-pci-0500/Composite/temp1_input
+        - nvme-pci-0500/Composite/temp1_crit
+      - - raa228228-i2c-24-45/temp1/temp1_input
+        - raa228228-i2c-24-45/temp1/temp1_crit
+      - - raa228228-i2c-24-45/temp2/temp2_input
+        - raa228228-i2c-24-45/temp2/temp2_crit
+      - - raa228228-i2c-24-45/temp3/temp3_input
+        - raa228228-i2c-24-45/temp3/temp3_crit
+      - - raa228228-i2c-25-45/temp1/temp1_input
+        - raa228228-i2c-25-45/temp1/temp1_crit
+      - - raa228228-i2c-25-45/temp2/temp2_input
+        - raa228228-i2c-25-45/temp2/temp2_crit
+      - - raa228228-i2c-25-45/temp3/temp3_input
+        - raa228228-i2c-25-45/temp3/temp3_crit
+      - - tmp75-i2c-16-48/temp1/temp1_input
+        - tmp75-i2c-16-48/temp1/temp1_max
+      - - tmp75-i2c-19-48/temp1/temp1_input
+        - tmp75-i2c-19-48/temp1/temp1_max
+
+    non_zero:
+      fan:
+      - dps800-i2c-22-58/fan1/fan1_input
+      - dps800-i2c-22-58/fan2/fan2_input
+      - dps800-i2c-23-58/fan1/fan1_input
+      - dps800-i2c-23-58/fan2/fan2_input
+      - pali2_cpld-i2c-16-60/fan1/fan1_input
+      - pali2_cpld-i2c-16-60/fan2/fan2_input
+      - pali2_cpld-i2c-16-60/fan3/fan3_input
+      - pali2_cpld-i2c-16-60/fan4/fan4_input
+      power: [ ]
+      temp: [ ]
+
+    psu_skips:
+      dps800-i2c-22-58:
+        number: 1
+        side: left
+        skip_list:
+        - dps800-i2c-22-58
+      dps800-i2c-23-58:
+        number: 2
+        side: right
+        skip_list:
+        - dps800-i2c-23-58
+
+    sensor_skip_per_version: { }
+
+  x86_64-arista_7280r4k_32qf_32df:
+    alarms:
+      fan:
+      - dps800-i2c-22-58/fan1/fan1_alarm
+      - dps800-i2c-22-58/fan1/fan1_fault
+      - dps800-i2c-22-58/fan2/fan2_alarm
+      - dps800-i2c-22-58/fan2/fan2_fault
+      - dps800-i2c-23-58/fan1/fan1_alarm
+      - dps800-i2c-23-58/fan1/fan1_fault
+      - dps800-i2c-23-58/fan2/fan2_alarm
+      - dps800-i2c-23-58/fan2/fan2_fault
+      - pali2_cpld-i2c-16-60/fan1/fan1_fault
+      - pali2_cpld-i2c-16-60/fan2/fan2_fault
+      - pali2_cpld-i2c-16-60/fan3/fan3_fault
+      - pali2_cpld-i2c-16-60/fan4/fan4_fault
+      power:
+      - dps800-i2c-22-58/iin/curr1_crit_alarm
+      - dps800-i2c-22-58/iin/curr1_max_alarm
+      - dps800-i2c-22-58/iout1/curr2_crit_alarm
+      - dps800-i2c-22-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-22-58/iout1/curr2_max_alarm
+      - dps800-i2c-22-58/pin/power1_alarm
+      - dps800-i2c-22-58/pout1/power2_cap_alarm
+      - dps800-i2c-22-58/pout1/power2_crit_alarm
+      - dps800-i2c-22-58/pout1/power2_max_alarm
+      - dps800-i2c-22-58/vin/in1_crit_alarm
+      - dps800-i2c-22-58/vin/in1_lcrit_alarm
+      - dps800-i2c-22-58/vin/in1_max_alarm
+      - dps800-i2c-22-58/vin/in1_min_alarm
+      - dps800-i2c-22-58/vout1/in3_crit_alarm
+      - dps800-i2c-22-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-22-58/vout1/in3_max_alarm
+      - dps800-i2c-22-58/vout1/in3_min_alarm
+      - dps800-i2c-23-58/iin/curr1_crit_alarm
+      - dps800-i2c-23-58/iin/curr1_max_alarm
+      - dps800-i2c-23-58/iout1/curr2_crit_alarm
+      - dps800-i2c-23-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-23-58/iout1/curr2_max_alarm
+      - dps800-i2c-23-58/pin/power1_alarm
+      - dps800-i2c-23-58/pout1/power2_cap_alarm
+      - dps800-i2c-23-58/pout1/power2_crit_alarm
+      - dps800-i2c-23-58/pout1/power2_max_alarm
+      - dps800-i2c-23-58/vin/in1_crit_alarm
+      - dps800-i2c-23-58/vin/in1_lcrit_alarm
+      - dps800-i2c-23-58/vin/in1_max_alarm
+      - dps800-i2c-23-58/vin/in1_min_alarm
+      - dps800-i2c-23-58/vout1/in3_crit_alarm
+      - dps800-i2c-23-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-23-58/vout1/in3_max_alarm
+      - dps800-i2c-23-58/vout1/in3_min_alarm
+      - isl68223-i2c-25-47/iin1/curr1_crit_alarm
+      - isl68223-i2c-25-47/iin1/curr1_max_alarm
+      - isl68223-i2c-25-47/iin2/curr2_crit_alarm
+      - isl68223-i2c-25-47/iin2/curr2_max_alarm
+      - isl68223-i2c-25-47/iout1/curr3_crit_alarm
+      - isl68223-i2c-25-47/iout1/curr3_max_alarm
+      - isl68223-i2c-25-47/iout2/curr4_crit_alarm
+      - isl68223-i2c-25-47/iout2/curr4_max_alarm
+      - isl68223-i2c-25-47/pin1/power1_alarm
+      - isl68223-i2c-25-47/pin2/power2_alarm
+      - isl68223-i2c-25-47/vin/in1_crit_alarm
+      - isl68223-i2c-25-47/vin/in1_lcrit_alarm
+      - isl68223-i2c-25-47/vin/in1_max_alarm
+      - isl68223-i2c-25-47/vin/in1_min_alarm
+      - isl68223-i2c-25-47/vout1/in3_crit_alarm
+      - isl68223-i2c-25-47/vout1/in3_lcrit_alarm
+      - isl68223-i2c-25-47/vout2/in4_crit_alarm
+      - isl68223-i2c-25-47/vout2/in4_lcrit_alarm
+      - isl68226-i2c-24-4c/iin1/curr1_crit_alarm
+      - isl68226-i2c-24-4c/iin1/curr1_max_alarm
+      - isl68226-i2c-24-4c/iin2/curr2_crit_alarm
+      - isl68226-i2c-24-4c/iin2/curr2_max_alarm
+      - isl68226-i2c-24-4c/iin3/curr3_crit_alarm
+      - isl68226-i2c-24-4c/iin3/curr3_max_alarm
+      - isl68226-i2c-24-4c/iout1/curr4_crit_alarm
+      - isl68226-i2c-24-4c/iout1/curr4_max_alarm
+      - isl68226-i2c-24-4c/iout2/curr5_crit_alarm
+      - isl68226-i2c-24-4c/iout2/curr5_max_alarm
+      - isl68226-i2c-24-4c/iout3/curr6_crit_alarm
+      - isl68226-i2c-24-4c/iout3/curr6_max_alarm
+      - isl68226-i2c-24-4c/pin1/power1_alarm
+      - isl68226-i2c-24-4c/pin2/power2_alarm
+      - isl68226-i2c-24-4c/pin3/power3_alarm
+      - isl68226-i2c-24-4c/vin/in1_crit_alarm
+      - isl68226-i2c-24-4c/vin/in1_lcrit_alarm
+      - isl68226-i2c-24-4c/vin/in1_max_alarm
+      - isl68226-i2c-24-4c/vin/in1_min_alarm
+      - isl68226-i2c-24-4c/vout1/in3_crit_alarm
+      - isl68226-i2c-24-4c/vout1/in3_lcrit_alarm
+      - isl68226-i2c-24-4c/vout2/in4_crit_alarm
+      - isl68226-i2c-24-4c/vout2/in4_lcrit_alarm
+      - isl68226-i2c-24-4c/vout3/in5_crit_alarm
+      - isl68226-i2c-24-4c/vout3/in5_lcrit_alarm
+      - isl68226-i2c-24-4f/iin1/curr1_crit_alarm
+      - isl68226-i2c-24-4f/iin1/curr1_max_alarm
+      - isl68226-i2c-24-4f/iin2/curr2_crit_alarm
+      - isl68226-i2c-24-4f/iin2/curr2_max_alarm
+      - isl68226-i2c-24-4f/iin3/curr3_crit_alarm
+      - isl68226-i2c-24-4f/iin3/curr3_max_alarm
+      - isl68226-i2c-24-4f/iout1/curr4_crit_alarm
+      - isl68226-i2c-24-4f/iout1/curr4_max_alarm
+      - isl68226-i2c-24-4f/iout2/curr5_crit_alarm
+      - isl68226-i2c-24-4f/iout2/curr5_max_alarm
+      - isl68226-i2c-24-4f/iout3/curr6_crit_alarm
+      - isl68226-i2c-24-4f/iout3/curr6_max_alarm
+      - isl68226-i2c-24-4f/pin1/power1_alarm
+      - isl68226-i2c-24-4f/pin2/power2_alarm
+      - isl68226-i2c-24-4f/pin3/power3_alarm
+      - isl68226-i2c-24-4f/vin/in1_crit_alarm
+      - isl68226-i2c-24-4f/vin/in1_lcrit_alarm
+      - isl68226-i2c-24-4f/vin/in1_max_alarm
+      - isl68226-i2c-24-4f/vin/in1_min_alarm
+      - isl68226-i2c-24-4f/vout1/in3_crit_alarm
+      - isl68226-i2c-24-4f/vout1/in3_lcrit_alarm
+      - isl68226-i2c-24-4f/vout2/in4_crit_alarm
+      - isl68226-i2c-24-4f/vout2/in4_lcrit_alarm
+      - isl68226-i2c-24-4f/vout3/in5_crit_alarm
+      - isl68226-i2c-24-4f/vout3/in5_lcrit_alarm
+      - isl68226-i2c-25-4c/iin1/curr1_crit_alarm
+      - isl68226-i2c-25-4c/iin1/curr1_max_alarm
+      - isl68226-i2c-25-4c/iin2/curr2_crit_alarm
+      - isl68226-i2c-25-4c/iin2/curr2_max_alarm
+      - isl68226-i2c-25-4c/iin3/curr3_crit_alarm
+      - isl68226-i2c-25-4c/iin3/curr3_max_alarm
+      - isl68226-i2c-25-4c/iout1/curr4_crit_alarm
+      - isl68226-i2c-25-4c/iout1/curr4_max_alarm
+      - isl68226-i2c-25-4c/iout2/curr5_crit_alarm
+      - isl68226-i2c-25-4c/iout2/curr5_max_alarm
+      - isl68226-i2c-25-4c/iout3/curr6_crit_alarm
+      - isl68226-i2c-25-4c/iout3/curr6_max_alarm
+      - isl68226-i2c-25-4c/pin1/power1_alarm
+      - isl68226-i2c-25-4c/pin2/power2_alarm
+      - isl68226-i2c-25-4c/pin3/power3_alarm
+      - isl68226-i2c-25-4c/vin/in1_crit_alarm
+      - isl68226-i2c-25-4c/vin/in1_lcrit_alarm
+      - isl68226-i2c-25-4c/vin/in1_max_alarm
+      - isl68226-i2c-25-4c/vin/in1_min_alarm
+      - isl68226-i2c-25-4c/vout1/in3_crit_alarm
+      - isl68226-i2c-25-4c/vout1/in3_lcrit_alarm
+      - isl68226-i2c-25-4c/vout2/in4_crit_alarm
+      - isl68226-i2c-25-4c/vout2/in4_lcrit_alarm
+      - isl68226-i2c-25-4c/vout3/in5_crit_alarm
+      - isl68226-i2c-25-4c/vout3/in5_lcrit_alarm
+      - raa228228-i2c-24-45/iin1/curr1_crit_alarm
+      - raa228228-i2c-24-45/iin1/curr1_max_alarm
+      - raa228228-i2c-24-45/iin2/curr2_crit_alarm
+      - raa228228-i2c-24-45/iin2/curr2_max_alarm
+      - raa228228-i2c-24-45/iout1/curr3_crit_alarm
+      - raa228228-i2c-24-45/iout1/curr3_max_alarm
+      - raa228228-i2c-24-45/iout2/curr4_crit_alarm
+      - raa228228-i2c-24-45/iout2/curr4_max_alarm
+      - raa228228-i2c-24-45/pin1/power1_alarm
+      - raa228228-i2c-24-45/pin2/power2_alarm
+      - raa228228-i2c-24-45/vin/in1_crit_alarm
+      - raa228228-i2c-24-45/vin/in1_lcrit_alarm
+      - raa228228-i2c-24-45/vin/in1_max_alarm
+      - raa228228-i2c-24-45/vin/in1_min_alarm
+      - raa228228-i2c-24-45/vout1/in3_crit_alarm
+      - raa228228-i2c-24-45/vout1/in3_lcrit_alarm
+      - raa228228-i2c-24-45/vout2/in4_crit_alarm
+      - raa228228-i2c-24-45/vout2/in4_lcrit_alarm
+      - raa228228-i2c-25-45/iin1/curr1_crit_alarm
+      - raa228228-i2c-25-45/iin1/curr1_max_alarm
+      - raa228228-i2c-25-45/iin2/curr2_crit_alarm
+      - raa228228-i2c-25-45/iin2/curr2_max_alarm
+      - raa228228-i2c-25-45/iout1/curr3_crit_alarm
+      - raa228228-i2c-25-45/iout1/curr3_max_alarm
+      - raa228228-i2c-25-45/iout2/curr4_crit_alarm
+      - raa228228-i2c-25-45/iout2/curr4_max_alarm
+      - raa228228-i2c-25-45/pin1/power1_alarm
+      - raa228228-i2c-25-45/pin2/power2_alarm
+      - raa228228-i2c-25-45/vin/in1_crit_alarm
+      - raa228228-i2c-25-45/vin/in1_lcrit_alarm
+      - raa228228-i2c-25-45/vin/in1_max_alarm
+      - raa228228-i2c-25-45/vin/in1_min_alarm
+      - raa228228-i2c-25-45/vout1/in3_crit_alarm
+      - raa228228-i2c-25-45/vout1/in3_lcrit_alarm
+      - raa228228-i2c-25-45/vout2/in4_crit_alarm
+      - raa228228-i2c-25-45/vout2/in4_lcrit_alarm
+      temp:
+      - amax31732-i2c-19-1c/temp1/temp1_crit_alarm
+      - amax31732-i2c-19-1c/temp1/temp1_lcrit_alarm
+      - amax31732-i2c-19-1c/temp1/temp1_max_alarm
+      - amax31732-i2c-19-1c/temp1/temp1_min_alarm
+      - amax31732-i2c-19-1c/temp2/temp2_crit_alarm
+      - amax31732-i2c-19-1c/temp2/temp2_fault
+      - amax31732-i2c-19-1c/temp2/temp2_lcrit_alarm
+      - amax31732-i2c-19-1c/temp2/temp2_max_alarm
+      - amax31732-i2c-19-1c/temp2/temp2_min_alarm
+      - amax31732-i2c-19-1c/temp3/temp3_crit_alarm
+      - amax31732-i2c-19-1c/temp3/temp3_fault
+      - amax31732-i2c-19-1c/temp3/temp3_lcrit_alarm
+      - amax31732-i2c-19-1c/temp3/temp3_max_alarm
+      - amax31732-i2c-19-1c/temp3/temp3_min_alarm
+      - amax31732-i2c-19-1c/temp4/temp4_crit_alarm
+      - amax31732-i2c-19-1c/temp4/temp4_fault
+      - amax31732-i2c-19-1c/temp4/temp4_lcrit_alarm
+      - amax31732-i2c-19-1c/temp4/temp4_max_alarm
+      - amax31732-i2c-19-1c/temp4/temp4_min_alarm
+      - amax31732-i2c-19-1c/temp5/temp5_crit_alarm
+      - amax31732-i2c-19-1c/temp5/temp5_fault
+      - amax31732-i2c-19-1c/temp5/temp5_lcrit_alarm
+      - amax31732-i2c-19-1c/temp5/temp5_max_alarm
+      - amax31732-i2c-19-1c/temp5/temp5_min_alarm
+      - dps800-i2c-22-58/temp1/temp1_crit_alarm
+      - dps800-i2c-22-58/temp1/temp1_lcrit_alarm
+      - dps800-i2c-22-58/temp1/temp1_max_alarm
+      - dps800-i2c-22-58/temp1/temp1_min_alarm
+      - dps800-i2c-22-58/temp2/temp2_crit_alarm
+      - dps800-i2c-22-58/temp2/temp2_lcrit_alarm
+      - dps800-i2c-22-58/temp2/temp2_max_alarm
+      - dps800-i2c-22-58/temp2/temp2_min_alarm
+      - dps800-i2c-22-58/temp3/temp3_crit_alarm
+      - dps800-i2c-22-58/temp3/temp3_lcrit_alarm
+      - dps800-i2c-22-58/temp3/temp3_max_alarm
+      - dps800-i2c-22-58/temp3/temp3_min_alarm
+      - dps800-i2c-23-58/temp1/temp1_crit_alarm
+      - dps800-i2c-23-58/temp1/temp1_lcrit_alarm
+      - dps800-i2c-23-58/temp1/temp1_max_alarm
+      - dps800-i2c-23-58/temp1/temp1_min_alarm
+      - dps800-i2c-23-58/temp2/temp2_crit_alarm
+      - dps800-i2c-23-58/temp2/temp2_lcrit_alarm
+      - dps800-i2c-23-58/temp2/temp2_max_alarm
+      - dps800-i2c-23-58/temp2/temp2_min_alarm
+      - dps800-i2c-23-58/temp3/temp3_crit_alarm
+      - dps800-i2c-23-58/temp3/temp3_lcrit_alarm
+      - dps800-i2c-23-58/temp3/temp3_max_alarm
+      - dps800-i2c-23-58/temp3/temp3_min_alarm
+      - isl68223-i2c-25-47/temp1/temp1_crit_alarm
+      - isl68223-i2c-25-47/temp1/temp1_lcrit_alarm
+      - isl68223-i2c-25-47/temp1/temp1_max_alarm
+      - isl68223-i2c-25-47/temp2/temp2_crit_alarm
+      - isl68223-i2c-25-47/temp2/temp2_lcrit_alarm
+      - isl68223-i2c-25-47/temp2/temp2_max_alarm
+      - isl68223-i2c-25-47/temp3/temp3_crit_alarm
+      - isl68223-i2c-25-47/temp3/temp3_lcrit_alarm
+      - isl68223-i2c-25-47/temp3/temp3_max_alarm
+      - isl68223-i2c-25-47/temp4/temp4_crit_alarm
+      - isl68223-i2c-25-47/temp4/temp4_lcrit_alarm
+      - isl68223-i2c-25-47/temp4/temp4_max_alarm
+      - isl68223-i2c-25-47/temp5/temp5_crit_alarm
+      - isl68223-i2c-25-47/temp5/temp5_lcrit_alarm
+      - isl68223-i2c-25-47/temp5/temp5_max_alarm
+      - isl68226-i2c-24-4c/temp1/temp1_crit_alarm
+      - isl68226-i2c-24-4c/temp1/temp1_lcrit_alarm
+      - isl68226-i2c-24-4c/temp1/temp1_max_alarm
+      - isl68226-i2c-24-4c/temp2/temp2_crit_alarm
+      - isl68226-i2c-24-4c/temp2/temp2_lcrit_alarm
+      - isl68226-i2c-24-4c/temp2/temp2_max_alarm
+      - isl68226-i2c-24-4c/temp3/temp3_crit_alarm
+      - isl68226-i2c-24-4c/temp3/temp3_lcrit_alarm
+      - isl68226-i2c-24-4c/temp3/temp3_max_alarm
+      - isl68226-i2c-24-4c/temp4/temp4_crit_alarm
+      - isl68226-i2c-24-4c/temp4/temp4_lcrit_alarm
+      - isl68226-i2c-24-4c/temp4/temp4_max_alarm
+      - isl68226-i2c-24-4c/temp5/temp5_crit_alarm
+      - isl68226-i2c-24-4c/temp5/temp5_lcrit_alarm
+      - isl68226-i2c-24-4c/temp5/temp5_max_alarm
+      - isl68226-i2c-24-4c/temp6/temp6_crit_alarm
+      - isl68226-i2c-24-4c/temp6/temp6_lcrit_alarm
+      - isl68226-i2c-24-4c/temp6/temp6_max_alarm
+      - isl68226-i2c-24-4c/temp7/temp7_crit_alarm
+      - isl68226-i2c-24-4c/temp7/temp7_lcrit_alarm
+      - isl68226-i2c-24-4c/temp7/temp7_max_alarm
+      - isl68226-i2c-24-4f/temp1/temp1_crit_alarm
+      - isl68226-i2c-24-4f/temp1/temp1_lcrit_alarm
+      - isl68226-i2c-24-4f/temp1/temp1_max_alarm
+      - isl68226-i2c-24-4f/temp2/temp2_crit_alarm
+      - isl68226-i2c-24-4f/temp2/temp2_lcrit_alarm
+      - isl68226-i2c-24-4f/temp2/temp2_max_alarm
+      - isl68226-i2c-24-4f/temp3/temp3_crit_alarm
+      - isl68226-i2c-24-4f/temp3/temp3_lcrit_alarm
+      - isl68226-i2c-24-4f/temp3/temp3_max_alarm
+      - isl68226-i2c-24-4f/temp4/temp4_crit_alarm
+      - isl68226-i2c-24-4f/temp4/temp4_lcrit_alarm
+      - isl68226-i2c-24-4f/temp4/temp4_max_alarm
+      - isl68226-i2c-24-4f/temp5/temp5_crit_alarm
+      - isl68226-i2c-24-4f/temp5/temp5_lcrit_alarm
+      - isl68226-i2c-24-4f/temp5/temp5_max_alarm
+      - isl68226-i2c-24-4f/temp6/temp6_crit_alarm
+      - isl68226-i2c-24-4f/temp6/temp6_lcrit_alarm
+      - isl68226-i2c-24-4f/temp6/temp6_max_alarm
+      - isl68226-i2c-24-4f/temp7/temp7_crit_alarm
+      - isl68226-i2c-24-4f/temp7/temp7_lcrit_alarm
+      - isl68226-i2c-24-4f/temp7/temp7_max_alarm
+      - isl68226-i2c-25-4c/temp1/temp1_crit_alarm
+      - isl68226-i2c-25-4c/temp1/temp1_lcrit_alarm
+      - isl68226-i2c-25-4c/temp1/temp1_max_alarm
+      - isl68226-i2c-25-4c/temp2/temp2_crit_alarm
+      - isl68226-i2c-25-4c/temp2/temp2_lcrit_alarm
+      - isl68226-i2c-25-4c/temp2/temp2_max_alarm
+      - isl68226-i2c-25-4c/temp3/temp3_crit_alarm
+      - isl68226-i2c-25-4c/temp3/temp3_lcrit_alarm
+      - isl68226-i2c-25-4c/temp3/temp3_max_alarm
+      - isl68226-i2c-25-4c/temp4/temp4_crit_alarm
+      - isl68226-i2c-25-4c/temp4/temp4_lcrit_alarm
+      - isl68226-i2c-25-4c/temp4/temp4_max_alarm
+      - isl68226-i2c-25-4c/temp5/temp5_crit_alarm
+      - isl68226-i2c-25-4c/temp5/temp5_lcrit_alarm
+      - isl68226-i2c-25-4c/temp5/temp5_max_alarm
+      - isl68226-i2c-25-4c/temp6/temp6_crit_alarm
+      - isl68226-i2c-25-4c/temp6/temp6_lcrit_alarm
+      - isl68226-i2c-25-4c/temp6/temp6_max_alarm
+      - isl68226-i2c-25-4c/temp7/temp7_crit_alarm
+      - isl68226-i2c-25-4c/temp7/temp7_lcrit_alarm
+      - isl68226-i2c-25-4c/temp7/temp7_max_alarm
+      - nvme-pci-0500/Composite/temp1_alarm
+      - raa228228-i2c-24-45/temp1/temp1_crit_alarm
+      - raa228228-i2c-24-45/temp1/temp1_lcrit_alarm
+      - raa228228-i2c-24-45/temp1/temp1_max_alarm
+      - raa228228-i2c-24-45/temp2/temp2_crit_alarm
+      - raa228228-i2c-24-45/temp2/temp2_lcrit_alarm
+      - raa228228-i2c-24-45/temp2/temp2_max_alarm
+      - raa228228-i2c-24-45/temp3/temp3_crit_alarm
+      - raa228228-i2c-24-45/temp3/temp3_lcrit_alarm
+      - raa228228-i2c-24-45/temp3/temp3_max_alarm
+      - raa228228-i2c-25-45/temp1/temp1_crit_alarm
+      - raa228228-i2c-25-45/temp1/temp1_lcrit_alarm
+      - raa228228-i2c-25-45/temp1/temp1_max_alarm
+      - raa228228-i2c-25-45/temp2/temp2_crit_alarm
+      - raa228228-i2c-25-45/temp2/temp2_lcrit_alarm
+      - raa228228-i2c-25-45/temp2/temp2_max_alarm
+      - raa228228-i2c-25-45/temp3/temp3_crit_alarm
+      - raa228228-i2c-25-45/temp3/temp3_lcrit_alarm
+      - raa228228-i2c-25-45/temp3/temp3_max_alarm
+
+    compares:
+      fan: [ ]
+      power: [ ]
+      temp:
+      - - amax31732-i2c-19-1c/temp1/temp1_input
+        - amax31732-i2c-19-1c/temp1/temp1_crit
+      - - amax31732-i2c-19-1c/temp2/temp2_input
+        - amax31732-i2c-19-1c/temp2/temp2_crit
+      - - amax31732-i2c-19-1c/temp3/temp3_input
+        - amax31732-i2c-19-1c/temp3/temp3_crit
+      - - amax31732-i2c-19-1c/temp4/temp4_input
+        - amax31732-i2c-19-1c/temp4/temp4_crit
+      - - amax31732-i2c-19-1c/temp5/temp5_input
+        - amax31732-i2c-19-1c/temp5/temp5_crit
+      - - dps800-i2c-22-58/temp1/temp1_input
+        - dps800-i2c-22-58/temp1/temp1_crit
+      - - dps800-i2c-22-58/temp2/temp2_input
+        - dps800-i2c-22-58/temp2/temp2_crit
+      - - dps800-i2c-22-58/temp3/temp3_input
+        - dps800-i2c-22-58/temp3/temp3_crit
+      - - dps800-i2c-23-58/temp1/temp1_input
+        - dps800-i2c-23-58/temp1/temp1_crit
+      - - dps800-i2c-23-58/temp2/temp2_input
+        - dps800-i2c-23-58/temp2/temp2_crit
+      - - dps800-i2c-23-58/temp3/temp3_input
+        - dps800-i2c-23-58/temp3/temp3_crit
+      - - isl68223-i2c-25-47/temp1/temp1_input
+        - isl68223-i2c-25-47/temp1/temp1_crit
+      - - isl68223-i2c-25-47/temp3/temp3_input
+        - isl68223-i2c-25-47/temp3/temp3_crit
+      - - isl68226-i2c-24-4c/temp1/temp1_input
+        - isl68226-i2c-24-4c/temp1/temp1_crit
+      - - isl68226-i2c-24-4c/temp2/temp2_input
+        - isl68226-i2c-24-4c/temp2/temp2_crit
+      - - isl68226-i2c-24-4c/temp3/temp3_input
+        - isl68226-i2c-24-4c/temp3/temp3_crit
+      - - isl68226-i2c-24-4c/temp4/temp4_input
+        - isl68226-i2c-24-4c/temp4/temp4_crit
+      - - isl68226-i2c-24-4f/temp1/temp1_input
+        - isl68226-i2c-24-4f/temp1/temp1_crit
+      - - isl68226-i2c-24-4f/temp2/temp2_input
+        - isl68226-i2c-24-4f/temp2/temp2_crit
+      - - isl68226-i2c-24-4f/temp3/temp3_input
+        - isl68226-i2c-24-4f/temp3/temp3_crit
+      - - isl68226-i2c-24-4f/temp4/temp4_input
+        - isl68226-i2c-24-4f/temp4/temp4_crit
+      - - isl68226-i2c-25-4c/temp1/temp1_input
+        - isl68226-i2c-25-4c/temp1/temp1_crit
+      - - isl68226-i2c-25-4c/temp2/temp2_input
+        - isl68226-i2c-25-4c/temp2/temp2_crit
+      - - isl68226-i2c-25-4c/temp3/temp3_input
+        - isl68226-i2c-25-4c/temp3/temp3_crit
+      - - isl68226-i2c-25-4c/temp4/temp4_input
+        - isl68226-i2c-25-4c/temp4/temp4_crit
+      - - nvme-pci-0500/Composite/temp1_input
+        - nvme-pci-0500/Composite/temp1_crit
+      - - raa228228-i2c-24-45/temp1/temp1_input
+        - raa228228-i2c-24-45/temp1/temp1_crit
+      - - raa228228-i2c-24-45/temp2/temp2_input
+        - raa228228-i2c-24-45/temp2/temp2_crit
+      - - raa228228-i2c-24-45/temp3/temp3_input
+        - raa228228-i2c-24-45/temp3/temp3_crit
+      - - raa228228-i2c-25-45/temp1/temp1_input
+        - raa228228-i2c-25-45/temp1/temp1_crit
+      - - raa228228-i2c-25-45/temp2/temp2_input
+        - raa228228-i2c-25-45/temp2/temp2_crit
+      - - raa228228-i2c-25-45/temp3/temp3_input
+        - raa228228-i2c-25-45/temp3/temp3_crit
+      - - tmp75-i2c-16-48/temp1/temp1_input
+        - tmp75-i2c-16-48/temp1/temp1_max
+      - - tmp75-i2c-19-48/temp1/temp1_input
+        - tmp75-i2c-19-48/temp1/temp1_max
+
+    non_zero:
+      fan:
+      - dps800-i2c-22-58/fan1/fan1_input
+      - dps800-i2c-22-58/fan2/fan2_input
+      - dps800-i2c-23-58/fan1/fan1_input
+      - dps800-i2c-23-58/fan2/fan2_input
+      - pali2_cpld-i2c-16-60/fan1/fan1_input
+      - pali2_cpld-i2c-16-60/fan2/fan2_input
+      - pali2_cpld-i2c-16-60/fan3/fan3_input
+      - pali2_cpld-i2c-16-60/fan4/fan4_input
+      power: [ ]
+      temp: [ ]
+
+    psu_skips:
+      dps800-i2c-22-58:
+        number: 1
+        side: left
+        skip_list:
+        - dps800-i2c-22-58
+      dps800-i2c-23-58:
+        number: 2
+        side: right
+        skip_list:
+        - dps800-i2c-23-58
+
+    sensor_skip_per_version: { }
+
+  x86_64-arista_7280dr3a_36:
+    alarms:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_alarm
+      - dps800-i2c-21-58/fan1/fan1_fault
+      - dps800-i2c-21-58/fan2/fan2_alarm
+      - dps800-i2c-21-58/fan2/fan2_fault
+      - dps800-i2c-22-58/fan1/fan1_alarm
+      - dps800-i2c-22-58/fan1/fan1_fault
+      - dps800-i2c-22-58/fan2/fan2_alarm
+      - dps800-i2c-22-58/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan1/fan1_fault
+      - scd_fan_p3-pci-00c7/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan3/fan3_fault
+      - scd_fan_p3-pci-00c7/fan4/fan4_fault
+      power:
+      - dps800-i2c-21-58/iin/curr1_crit_alarm
+      - dps800-i2c-21-58/iin/curr1_max_alarm
+      - dps800-i2c-21-58/iout1/curr2_crit_alarm
+      - dps800-i2c-21-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-21-58/iout1/curr2_max_alarm
+      - dps800-i2c-21-58/pin/power1_alarm
+      - dps800-i2c-21-58/pout1/power2_cap_alarm
+      - dps800-i2c-21-58/pout1/power2_crit_alarm
+      - dps800-i2c-21-58/pout1/power2_max_alarm
+      - dps800-i2c-21-58/vin/in1_crit_alarm
+      - dps800-i2c-21-58/vin/in1_lcrit_alarm
+      - dps800-i2c-21-58/vin/in1_max_alarm
+      - dps800-i2c-21-58/vin/in1_min_alarm
+      - dps800-i2c-21-58/vout1/in3_crit_alarm
+      - dps800-i2c-21-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-21-58/vout1/in3_max_alarm
+      - dps800-i2c-21-58/vout1/in3_min_alarm
+      - dps800-i2c-22-58/iin/curr1_crit_alarm
+      - dps800-i2c-22-58/iin/curr1_max_alarm
+      - dps800-i2c-22-58/iout1/curr2_crit_alarm
+      - dps800-i2c-22-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-22-58/iout1/curr2_max_alarm
+      - dps800-i2c-22-58/pin/power1_alarm
+      - dps800-i2c-22-58/pout1/power2_cap_alarm
+      - dps800-i2c-22-58/pout1/power2_crit_alarm
+      - dps800-i2c-22-58/pout1/power2_max_alarm
+      - dps800-i2c-22-58/vin/in1_crit_alarm
+      - dps800-i2c-22-58/vin/in1_lcrit_alarm
+      - dps800-i2c-22-58/vin/in1_max_alarm
+      - dps800-i2c-22-58/vin/in1_min_alarm
+      - dps800-i2c-22-58/vout1/in3_crit_alarm
+      - dps800-i2c-22-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-22-58/vout1/in3_max_alarm
+      - dps800-i2c-22-58/vout1/in3_min_alarm
+      temp:
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_min_alarm
+      - max6658-i2c-9-4c/temp1/temp1_crit_alarm
+      - max6658-i2c-9-4c/temp1/temp1_max_alarm
+      - max6658-i2c-9-4c/temp1/temp1_min_alarm
+      - max6658-i2c-9-4c/temp2/temp2_crit_alarm
+      - max6658-i2c-9-4c/temp2/temp2_fault
+      - max6658-i2c-9-4c/temp2/temp2_max_alarm
+      - max6658-i2c-9-4c/temp2/temp2_min_alarm
+      - nvme-pci-0500/Composite/temp1_alarm
+      - tmp464-i2c-28-48/temp1/temp1_crit_alarm
+      - tmp464-i2c-28-48/temp1/temp1_max_alarm
+      - tmp464-i2c-28-48/temp2/temp2_crit_alarm
+      - tmp464-i2c-28-48/temp2/temp2_fault
+      - tmp464-i2c-28-48/temp2/temp2_max_alarm
+      - tmp464-i2c-28-48/temp3/temp3_crit_alarm
+      - tmp464-i2c-28-48/temp3/temp3_fault
+      - tmp464-i2c-28-48/temp3/temp3_max_alarm
+      - tmp464-i2c-28-48/temp4/temp4_crit_alarm
+      - tmp464-i2c-28-48/temp4/temp4_fault
+      - tmp464-i2c-28-48/temp4/temp4_max_alarm
+      - tmp464-i2c-28-48/temp5/temp5_crit_alarm
+      - tmp464-i2c-28-48/temp5/temp5_fault
+      - tmp464-i2c-28-48/temp5/temp5_max_alarm
+      - tmp464-i2c-28-48/temp6/temp6_crit_alarm
+      - tmp464-i2c-28-48/temp6/temp6_fault
+      - tmp464-i2c-28-48/temp6/temp6_max_alarm
+      - tmp464-i2c-28-48/temp7/temp7_crit_alarm
+      - tmp464-i2c-28-48/temp7/temp7_fault
+      - tmp464-i2c-28-48/temp7/temp7_max_alarm
+      - tmp464-i2c-28-48/temp8/temp8_crit_alarm
+      - tmp464-i2c-28-48/temp8/temp8_fault
+      - tmp464-i2c-28-48/temp8/temp8_max_alarm
+      - tmp464-i2c-28-48/temp9/temp9_crit_alarm
+      - tmp464-i2c-28-48/temp9/temp9_fault
+      - tmp464-i2c-28-48/temp9/temp9_max_alarm
+
+    compares:
+      fan: [ ]
+      power: [ ]
+      temp:
+      - - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_input
+        - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit
+      - - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_input
+        - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_input
+        - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit
+      - - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_input
+        - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit
+      - - max6658-i2c-9-4c/temp1/temp1_input
+        - max6658-i2c-9-4c/temp1/temp1_crit
+      - - max6658-i2c-9-4c/temp2/temp2_input
+        - max6658-i2c-9-4c/temp2/temp2_crit
+      - - nvme-pci-0500/Composite/temp1_input
+        - nvme-pci-0500/Composite/temp1_crit
+      - - tmp464-i2c-28-48/temp1/temp1_input
+        - tmp464-i2c-28-48/temp1/temp1_crit
+      - - tmp464-i2c-28-48/temp2/temp2_input
+        - tmp464-i2c-28-48/temp2/temp2_crit
+      - - tmp464-i2c-28-48/temp3/temp3_input
+        - tmp464-i2c-28-48/temp3/temp3_crit
+      - - tmp464-i2c-28-48/temp4/temp4_input
+        - tmp464-i2c-28-48/temp4/temp4_crit
+      - - tmp464-i2c-28-48/temp5/temp5_input
+        - tmp464-i2c-28-48/temp5/temp5_crit
+
+    non_zero:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_input
+      - dps800-i2c-21-58/fan2/fan2_input
+      - dps800-i2c-22-58/fan1/fan1_input
+      - dps800-i2c-22-58/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan1/fan1_input
+      - scd_fan_p3-pci-00c7/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan3/fan3_input
+      - scd_fan_p3-pci-00c7/fan4/fan4_input
+      power: [ ]
+      temp: [ ]
+
+    psu_skips:
+      dps800-i2c-21-58:
+        number: 1
+        side: left
+        skip_list:
+        - dps800-i2c-21-58
+      dps800-i2c-22-58:
+        number: 2
+        side: right
+        skip_list:
+        - dps800-i2c-22-58
+
+    sensor_skip_per_version: { }
+
+  x86_64-arista_7280dr3ak_36:
+    alarms:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_alarm
+      - dps800-i2c-21-58/fan1/fan1_fault
+      - dps800-i2c-21-58/fan2/fan2_alarm
+      - dps800-i2c-21-58/fan2/fan2_fault
+      - dps800-i2c-22-58/fan1/fan1_alarm
+      - dps800-i2c-22-58/fan1/fan1_fault
+      - dps800-i2c-22-58/fan2/fan2_alarm
+      - dps800-i2c-22-58/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan1/fan1_fault
+      - scd_fan_p3-pci-00c7/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan3/fan3_fault
+      - scd_fan_p3-pci-00c7/fan4/fan4_fault
+      power:
+      - dps800-i2c-21-58/iin/curr1_crit_alarm
+      - dps800-i2c-21-58/iin/curr1_max_alarm
+      - dps800-i2c-21-58/iout1/curr2_crit_alarm
+      - dps800-i2c-21-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-21-58/iout1/curr2_max_alarm
+      - dps800-i2c-21-58/pin/power1_alarm
+      - dps800-i2c-21-58/pout1/power2_cap_alarm
+      - dps800-i2c-21-58/pout1/power2_crit_alarm
+      - dps800-i2c-21-58/pout1/power2_max_alarm
+      - dps800-i2c-21-58/vin/in1_crit_alarm
+      - dps800-i2c-21-58/vin/in1_lcrit_alarm
+      - dps800-i2c-21-58/vin/in1_max_alarm
+      - dps800-i2c-21-58/vin/in1_min_alarm
+      - dps800-i2c-21-58/vout1/in3_crit_alarm
+      - dps800-i2c-21-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-21-58/vout1/in3_max_alarm
+      - dps800-i2c-21-58/vout1/in3_min_alarm
+      - dps800-i2c-22-58/iin/curr1_crit_alarm
+      - dps800-i2c-22-58/iin/curr1_max_alarm
+      - dps800-i2c-22-58/iout1/curr2_crit_alarm
+      - dps800-i2c-22-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-22-58/iout1/curr2_max_alarm
+      - dps800-i2c-22-58/pin/power1_alarm
+      - dps800-i2c-22-58/pout1/power2_cap_alarm
+      - dps800-i2c-22-58/pout1/power2_crit_alarm
+      - dps800-i2c-22-58/pout1/power2_max_alarm
+      - dps800-i2c-22-58/vin/in1_crit_alarm
+      - dps800-i2c-22-58/vin/in1_lcrit_alarm
+      - dps800-i2c-22-58/vin/in1_max_alarm
+      - dps800-i2c-22-58/vin/in1_min_alarm
+      - dps800-i2c-22-58/vout1/in3_crit_alarm
+      - dps800-i2c-22-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-22-58/vout1/in3_max_alarm
+      - dps800-i2c-22-58/vout1/in3_min_alarm
+      temp:
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_min_alarm
+      - max6658-i2c-9-4c/temp1/temp1_crit_alarm
+      - max6658-i2c-9-4c/temp1/temp1_max_alarm
+      - max6658-i2c-9-4c/temp1/temp1_min_alarm
+      - max6658-i2c-9-4c/temp2/temp2_crit_alarm
+      - max6658-i2c-9-4c/temp2/temp2_fault
+      - max6658-i2c-9-4c/temp2/temp2_max_alarm
+      - max6658-i2c-9-4c/temp2/temp2_min_alarm
+      - nvme-pci-0500/Composite/temp1_alarm
+      - tmp464-i2c-28-48/temp1/temp1_crit_alarm
+      - tmp464-i2c-28-48/temp1/temp1_max_alarm
+      - tmp464-i2c-28-48/temp2/temp2_crit_alarm
+      - tmp464-i2c-28-48/temp2/temp2_fault
+      - tmp464-i2c-28-48/temp2/temp2_max_alarm
+      - tmp464-i2c-28-48/temp3/temp3_crit_alarm
+      - tmp464-i2c-28-48/temp3/temp3_fault
+      - tmp464-i2c-28-48/temp3/temp3_max_alarm
+      - tmp464-i2c-28-48/temp4/temp4_crit_alarm
+      - tmp464-i2c-28-48/temp4/temp4_fault
+      - tmp464-i2c-28-48/temp4/temp4_max_alarm
+      - tmp464-i2c-28-48/temp5/temp5_crit_alarm
+      - tmp464-i2c-28-48/temp5/temp5_fault
+      - tmp464-i2c-28-48/temp5/temp5_max_alarm
+      - tmp464-i2c-28-48/temp6/temp6_crit_alarm
+      - tmp464-i2c-28-48/temp6/temp6_fault
+      - tmp464-i2c-28-48/temp6/temp6_max_alarm
+      - tmp464-i2c-28-48/temp7/temp7_crit_alarm
+      - tmp464-i2c-28-48/temp7/temp7_fault
+      - tmp464-i2c-28-48/temp7/temp7_max_alarm
+      - tmp464-i2c-28-48/temp8/temp8_crit_alarm
+      - tmp464-i2c-28-48/temp8/temp8_fault
+      - tmp464-i2c-28-48/temp8/temp8_max_alarm
+      - tmp464-i2c-28-48/temp9/temp9_crit_alarm
+      - tmp464-i2c-28-48/temp9/temp9_fault
+      - tmp464-i2c-28-48/temp9/temp9_max_alarm
+
+    compares:
+      fan: [ ]
+      power: [ ]
+      temp:
+      - - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_input
+        - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit
+      - - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_input
+        - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_input
+        - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit
+      - - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_input
+        - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit
+      - - max6658-i2c-9-4c/temp1/temp1_input
+        - max6658-i2c-9-4c/temp1/temp1_crit
+      - - max6658-i2c-9-4c/temp2/temp2_input
+        - max6658-i2c-9-4c/temp2/temp2_crit
+      - - nvme-pci-0500/Composite/temp1_input
+        - nvme-pci-0500/Composite/temp1_crit
+      - - tmp464-i2c-28-48/temp1/temp1_input
+        - tmp464-i2c-28-48/temp1/temp1_crit
+      - - tmp464-i2c-28-48/temp2/temp2_input
+        - tmp464-i2c-28-48/temp2/temp2_crit
+      - - tmp464-i2c-28-48/temp3/temp3_input
+        - tmp464-i2c-28-48/temp3/temp3_crit
+      - - tmp464-i2c-28-48/temp4/temp4_input
+        - tmp464-i2c-28-48/temp4/temp4_crit
+      - - tmp464-i2c-28-48/temp5/temp5_input
+        - tmp464-i2c-28-48/temp5/temp5_crit
+
+    non_zero:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_input
+      - dps800-i2c-21-58/fan2/fan2_input
+      - dps800-i2c-22-58/fan1/fan1_input
+      - dps800-i2c-22-58/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan1/fan1_input
+      - scd_fan_p3-pci-00c7/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan3/fan3_input
+      - scd_fan_p3-pci-00c7/fan4/fan4_input
+      power: [ ]
+      temp: [ ]
+
+    psu_skips:
+      dps800-i2c-21-58:
+        number: 1
+        side: left
+        skip_list:
+        - dps800-i2c-21-58
+      dps800-i2c-22-58:
+        number: 2
+        side: right
+        skip_list:
+        - dps800-i2c-22-58
+
+    sensor_skip_per_version: { }
+
+  x86_64-arista_7280dr3ak_36s:
+    alarms:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_alarm
+      - dps800-i2c-21-58/fan1/fan1_fault
+      - dps800-i2c-21-58/fan2/fan2_alarm
+      - dps800-i2c-21-58/fan2/fan2_fault
+      - dps800-i2c-22-58/fan1/fan1_alarm
+      - dps800-i2c-22-58/fan1/fan1_fault
+      - dps800-i2c-22-58/fan2/fan2_alarm
+      - dps800-i2c-22-58/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan1/fan1_fault
+      - scd_fan_p3-pci-00c7/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan3/fan3_fault
+      - scd_fan_p3-pci-00c7/fan4/fan4_fault
+      power:
+      - dps800-i2c-21-58/iin/curr1_crit_alarm
+      - dps800-i2c-21-58/iin/curr1_max_alarm
+      - dps800-i2c-21-58/iout1/curr2_crit_alarm
+      - dps800-i2c-21-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-21-58/iout1/curr2_max_alarm
+      - dps800-i2c-21-58/pin/power1_alarm
+      - dps800-i2c-21-58/pout1/power2_cap_alarm
+      - dps800-i2c-21-58/pout1/power2_crit_alarm
+      - dps800-i2c-21-58/pout1/power2_max_alarm
+      - dps800-i2c-21-58/vin/in1_crit_alarm
+      - dps800-i2c-21-58/vin/in1_lcrit_alarm
+      - dps800-i2c-21-58/vin/in1_max_alarm
+      - dps800-i2c-21-58/vin/in1_min_alarm
+      - dps800-i2c-21-58/vout1/in3_crit_alarm
+      - dps800-i2c-21-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-21-58/vout1/in3_max_alarm
+      - dps800-i2c-21-58/vout1/in3_min_alarm
+      - dps800-i2c-22-58/iin/curr1_crit_alarm
+      - dps800-i2c-22-58/iin/curr1_max_alarm
+      - dps800-i2c-22-58/iout1/curr2_crit_alarm
+      - dps800-i2c-22-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-22-58/iout1/curr2_max_alarm
+      - dps800-i2c-22-58/pin/power1_alarm
+      - dps800-i2c-22-58/pout1/power2_cap_alarm
+      - dps800-i2c-22-58/pout1/power2_crit_alarm
+      - dps800-i2c-22-58/pout1/power2_max_alarm
+      - dps800-i2c-22-58/vin/in1_crit_alarm
+      - dps800-i2c-22-58/vin/in1_lcrit_alarm
+      - dps800-i2c-22-58/vin/in1_max_alarm
+      - dps800-i2c-22-58/vin/in1_min_alarm
+      - dps800-i2c-22-58/vout1/in3_crit_alarm
+      - dps800-i2c-22-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-22-58/vout1/in3_max_alarm
+      - dps800-i2c-22-58/vout1/in3_min_alarm
+      temp:
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_min_alarm
+      - max6658-i2c-9-4c/temp1/temp1_crit_alarm
+      - max6658-i2c-9-4c/temp1/temp1_max_alarm
+      - max6658-i2c-9-4c/temp1/temp1_min_alarm
+      - max6658-i2c-9-4c/temp2/temp2_crit_alarm
+      - max6658-i2c-9-4c/temp2/temp2_fault
+      - max6658-i2c-9-4c/temp2/temp2_max_alarm
+      - max6658-i2c-9-4c/temp2/temp2_min_alarm
+      - nvme-pci-0500/Composite/temp1_alarm
+      - tmp464-i2c-28-48/temp1/temp1_crit_alarm
+      - tmp464-i2c-28-48/temp1/temp1_max_alarm
+      - tmp464-i2c-28-48/temp2/temp2_crit_alarm
+      - tmp464-i2c-28-48/temp2/temp2_fault
+      - tmp464-i2c-28-48/temp2/temp2_max_alarm
+      - tmp464-i2c-28-48/temp3/temp3_crit_alarm
+      - tmp464-i2c-28-48/temp3/temp3_fault
+      - tmp464-i2c-28-48/temp3/temp3_max_alarm
+      - tmp464-i2c-28-48/temp4/temp4_crit_alarm
+      - tmp464-i2c-28-48/temp4/temp4_fault
+      - tmp464-i2c-28-48/temp4/temp4_max_alarm
+      - tmp464-i2c-28-48/temp5/temp5_crit_alarm
+      - tmp464-i2c-28-48/temp5/temp5_fault
+      - tmp464-i2c-28-48/temp5/temp5_max_alarm
+      - tmp464-i2c-28-48/temp6/temp6_crit_alarm
+      - tmp464-i2c-28-48/temp6/temp6_fault
+      - tmp464-i2c-28-48/temp6/temp6_max_alarm
+      - tmp464-i2c-28-48/temp7/temp7_crit_alarm
+      - tmp464-i2c-28-48/temp7/temp7_fault
+      - tmp464-i2c-28-48/temp7/temp7_max_alarm
+      - tmp464-i2c-28-48/temp8/temp8_crit_alarm
+      - tmp464-i2c-28-48/temp8/temp8_fault
+      - tmp464-i2c-28-48/temp8/temp8_max_alarm
+      - tmp464-i2c-28-48/temp9/temp9_crit_alarm
+      - tmp464-i2c-28-48/temp9/temp9_fault
+      - tmp464-i2c-28-48/temp9/temp9_max_alarm
+
+    compares:
+      fan: [ ]
+      power: [ ]
+      temp:
+      - - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_input
+        - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit
+      - - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_input
+        - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_input
+        - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit
+      - - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_input
+        - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit
+      - - max6658-i2c-9-4c/temp1/temp1_input
+        - max6658-i2c-9-4c/temp1/temp1_crit
+      - - max6658-i2c-9-4c/temp2/temp2_input
+        - max6658-i2c-9-4c/temp2/temp2_crit
+      - - nvme-pci-0500/Composite/temp1_input
+        - nvme-pci-0500/Composite/temp1_crit
+      - - tmp464-i2c-28-48/temp1/temp1_input
+        - tmp464-i2c-28-48/temp1/temp1_crit
+      - - tmp464-i2c-28-48/temp2/temp2_input
+        - tmp464-i2c-28-48/temp2/temp2_crit
+      - - tmp464-i2c-28-48/temp3/temp3_input
+        - tmp464-i2c-28-48/temp3/temp3_crit
+      - - tmp464-i2c-28-48/temp4/temp4_input
+        - tmp464-i2c-28-48/temp4/temp4_crit
+      - - tmp464-i2c-28-48/temp5/temp5_input
+        - tmp464-i2c-28-48/temp5/temp5_crit
+
+    non_zero:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_input
+      - dps800-i2c-21-58/fan2/fan2_input
+      - dps800-i2c-22-58/fan1/fan1_input
+      - dps800-i2c-22-58/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan1/fan1_input
+      - scd_fan_p3-pci-00c7/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan3/fan3_input
+      - scd_fan_p3-pci-00c7/fan4/fan4_input
+      power: [ ]
+      temp: [ ]
+
+    psu_skips:
+      dps800-i2c-21-58:
+        number: 1
+        side: left
+        skip_list:
+        - dps800-i2c-21-58
+      dps800-i2c-22-58:
+        number: 2
+        side: right
+        skip_list:
+        - dps800-i2c-22-58
+
+    sensor_skip_per_version: { }
+
+  x86_64-arista_7280dr3am_36:
+    alarms:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_alarm
+      - dps800-i2c-21-58/fan1/fan1_fault
+      - dps800-i2c-21-58/fan2/fan2_alarm
+      - dps800-i2c-21-58/fan2/fan2_fault
+      - dps800-i2c-22-58/fan1/fan1_alarm
+      - dps800-i2c-22-58/fan1/fan1_fault
+      - dps800-i2c-22-58/fan2/fan2_alarm
+      - dps800-i2c-22-58/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan1/fan1_fault
+      - scd_fan_p3-pci-00c7/fan2/fan2_fault
+      - scd_fan_p3-pci-00c7/fan3/fan3_fault
+      - scd_fan_p3-pci-00c7/fan4/fan4_fault
+      power:
+      - dps800-i2c-21-58/iin/curr1_crit_alarm
+      - dps800-i2c-21-58/iin/curr1_max_alarm
+      - dps800-i2c-21-58/iout1/curr2_crit_alarm
+      - dps800-i2c-21-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-21-58/iout1/curr2_max_alarm
+      - dps800-i2c-21-58/pin/power1_alarm
+      - dps800-i2c-21-58/pout1/power2_cap_alarm
+      - dps800-i2c-21-58/pout1/power2_crit_alarm
+      - dps800-i2c-21-58/pout1/power2_max_alarm
+      - dps800-i2c-21-58/vin/in1_crit_alarm
+      - dps800-i2c-21-58/vin/in1_lcrit_alarm
+      - dps800-i2c-21-58/vin/in1_max_alarm
+      - dps800-i2c-21-58/vin/in1_min_alarm
+      - dps800-i2c-21-58/vout1/in3_crit_alarm
+      - dps800-i2c-21-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-21-58/vout1/in3_max_alarm
+      - dps800-i2c-21-58/vout1/in3_min_alarm
+      - dps800-i2c-22-58/iin/curr1_crit_alarm
+      - dps800-i2c-22-58/iin/curr1_max_alarm
+      - dps800-i2c-22-58/iout1/curr2_crit_alarm
+      - dps800-i2c-22-58/iout1/curr2_lcrit_alarm
+      - dps800-i2c-22-58/iout1/curr2_max_alarm
+      - dps800-i2c-22-58/pin/power1_alarm
+      - dps800-i2c-22-58/pout1/power2_cap_alarm
+      - dps800-i2c-22-58/pout1/power2_crit_alarm
+      - dps800-i2c-22-58/pout1/power2_max_alarm
+      - dps800-i2c-22-58/vin/in1_crit_alarm
+      - dps800-i2c-22-58/vin/in1_lcrit_alarm
+      - dps800-i2c-22-58/vin/in1_max_alarm
+      - dps800-i2c-22-58/vin/in1_min_alarm
+      - dps800-i2c-22-58/vout1/in3_crit_alarm
+      - dps800-i2c-22-58/vout1/in3_lcrit_alarm
+      - dps800-i2c-22-58/vout1/in3_max_alarm
+      - dps800-i2c-22-58/vout1/in3_min_alarm
+      temp:
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_max_alarm
+      - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_min_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_max_alarm
+      - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_min_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_min_alarm
+      - max6658-i2c-9-4c/temp1/temp1_crit_alarm
+      - max6658-i2c-9-4c/temp1/temp1_max_alarm
+      - max6658-i2c-9-4c/temp1/temp1_min_alarm
+      - max6658-i2c-9-4c/temp2/temp2_crit_alarm
+      - max6658-i2c-9-4c/temp2/temp2_fault
+      - max6658-i2c-9-4c/temp2/temp2_max_alarm
+      - max6658-i2c-9-4c/temp2/temp2_min_alarm
+      - nvme-pci-0500/Composite/temp1_alarm
+      - tmp464-i2c-28-48/temp1/temp1_crit_alarm
+      - tmp464-i2c-28-48/temp1/temp1_max_alarm
+      - tmp464-i2c-28-48/temp2/temp2_crit_alarm
+      - tmp464-i2c-28-48/temp2/temp2_fault
+      - tmp464-i2c-28-48/temp2/temp2_max_alarm
+      - tmp464-i2c-28-48/temp3/temp3_crit_alarm
+      - tmp464-i2c-28-48/temp3/temp3_fault
+      - tmp464-i2c-28-48/temp3/temp3_max_alarm
+      - tmp464-i2c-28-48/temp4/temp4_crit_alarm
+      - tmp464-i2c-28-48/temp4/temp4_fault
+      - tmp464-i2c-28-48/temp4/temp4_max_alarm
+      - tmp464-i2c-28-48/temp5/temp5_crit_alarm
+      - tmp464-i2c-28-48/temp5/temp5_fault
+      - tmp464-i2c-28-48/temp5/temp5_max_alarm
+      - tmp464-i2c-28-48/temp6/temp6_crit_alarm
+      - tmp464-i2c-28-48/temp6/temp6_fault
+      - tmp464-i2c-28-48/temp6/temp6_max_alarm
+      - tmp464-i2c-28-48/temp7/temp7_crit_alarm
+      - tmp464-i2c-28-48/temp7/temp7_fault
+      - tmp464-i2c-28-48/temp7/temp7_max_alarm
+      - tmp464-i2c-28-48/temp8/temp8_crit_alarm
+      - tmp464-i2c-28-48/temp8/temp8_fault
+      - tmp464-i2c-28-48/temp8/temp8_max_alarm
+      - tmp464-i2c-28-48/temp9/temp9_crit_alarm
+      - tmp464-i2c-28-48/temp9/temp9_fault
+      - tmp464-i2c-28-48/temp9/temp9_max_alarm
+
+    compares:
+      fan: [ ]
+      power: [ ]
+      temp:
+      - - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_input
+        - dps800-i2c-21-58/Power supply 1 inlet temp sensor/temp1_crit
+      - - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-21-58/Power supply 1 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_input
+        - dps800-i2c-21-58/Power supply 1 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_input
+        - dps800-i2c-22-58/Power supply 2 inlet temp sensor/temp1_crit
+      - - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_input
+        - dps800-i2c-22-58/Power supply 2 primary hotspot temp sensor/temp3_crit
+      - - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_input
+        - dps800-i2c-22-58/Power supply 2 secondary hotspot sensor/temp2_crit
+      - - max6658-i2c-9-4c/temp1/temp1_input
+        - max6658-i2c-9-4c/temp1/temp1_crit
+      - - max6658-i2c-9-4c/temp2/temp2_input
+        - max6658-i2c-9-4c/temp2/temp2_crit
+      - - nvme-pci-0500/Composite/temp1_input
+        - nvme-pci-0500/Composite/temp1_crit
+      - - tmp464-i2c-28-48/temp1/temp1_input
+        - tmp464-i2c-28-48/temp1/temp1_crit
+      - - tmp464-i2c-28-48/temp2/temp2_input
+        - tmp464-i2c-28-48/temp2/temp2_crit
+      - - tmp464-i2c-28-48/temp3/temp3_input
+        - tmp464-i2c-28-48/temp3/temp3_crit
+      - - tmp464-i2c-28-48/temp4/temp4_input
+        - tmp464-i2c-28-48/temp4/temp4_crit
+      - - tmp464-i2c-28-48/temp5/temp5_input
+        - tmp464-i2c-28-48/temp5/temp5_crit
+
+    non_zero:
+      fan:
+      - dps800-i2c-21-58/fan1/fan1_input
+      - dps800-i2c-21-58/fan2/fan2_input
+      - dps800-i2c-22-58/fan1/fan1_input
+      - dps800-i2c-22-58/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan1/fan1_input
+      - scd_fan_p3-pci-00c7/fan2/fan2_input
+      - scd_fan_p3-pci-00c7/fan3/fan3_input
+      - scd_fan_p3-pci-00c7/fan4/fan4_input
+      power: [ ]
+      temp: [ ]
+
+    psu_skips:
+      dps800-i2c-21-58:
+        number: 1
+        side: left
+        skip_list:
+        - dps800-i2c-21-58
+      dps800-i2c-22-58:
+        number: 2
+        side: right
+        skip_list:
+        - dps800-i2c-22-58
+
+    sensor_skip_per_version: { }

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -324,6 +324,37 @@ class DHCPTopoT1Test(PolicyTest):
         self.log("DHCPTopoT1Test")
         self.run_suite()
 
+    def check_constraints(self, send_count, recv_count, time_delta_ms, rx_pps):
+        """
+        Use packet-matched recv_count instead of unfiltered NN counter rx_pps.
+        The NN counter (AF_PACKET ETH_P_ALL) captures all traffic on the interface
+        including BGP keepalives, LLDP, and TCP ACKs that are unrelated to DHCP.
+        recv_count is matched against the exact DHCP packet template and correctly
+        verifies that DHCP is not being punted to CPU on T1 topology.
+        """
+        self.log("")
+        if self.is_smartswitch_light_mode:
+            self.log("Checking constraints (PolicyApplied - SmartSwitch):")
+            self.log(
+                "PPS_LIMIT_MIN (%d) <= rx_pps (%d) <= PPS_LIMIT_MAX (%d): %s" %
+                (int(self.PPS_LIMIT_MIN),
+                 int(rx_pps),
+                 int(self.PPS_LIMIT_MAX),
+                 str(self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX))
+            )
+            assert self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX, (
+                "Copp policer constraint check failed, Actual PPS: {} "
+                "Expected PPS range: {} - {}".format(
+                    rx_pps, self.PPS_LIMIT_MIN, self.PPS_LIMIT_MAX))
+        else:
+            self.log("Checking constraints (NoPolicyApplied - T1 DHCP):")
+            self.log(
+                "DHCP-matched recv_count (%d) should be 0 (DHCP not punted on T1)" % recv_count
+            )
+            assert recv_count == 0, (
+                "Copp policer constraint check failed, Expected 0 DHCP packets punted "
+                "to CPU on T1, but received {} packets".format(recv_count))
+
     def construct_packet(self, port_number):
         src_mac = self.my_mac[port_number]
 
@@ -449,6 +480,37 @@ class DHCP6TopoT1Test(PolicyTest):
     def runTest(self):
         self.log("DHCP6TopoT1Test")
         self.run_suite()
+
+    def check_constraints(self, send_count, recv_count, time_delta_ms, rx_pps):
+        """
+        Use packet-matched recv_count instead of unfiltered NN counter rx_pps.
+        The NN counter (AF_PACKET ETH_P_ALL) captures all traffic on the interface
+        including BGP keepalives, LLDP, and TCP ACKs that are unrelated to DHCP.
+        recv_count is matched against the exact DHCP packet template and correctly
+        verifies that DHCP is not being punted to CPU on T1 topology.
+        """
+        self.log("")
+        if self.is_smartswitch_light_mode:
+            self.log("Checking constraints (PolicyApplied - SmartSwitch):")
+            self.log(
+                "PPS_LIMIT_MIN (%d) <= rx_pps (%d) <= PPS_LIMIT_MAX (%d): %s" %
+                (int(self.PPS_LIMIT_MIN),
+                 int(rx_pps),
+                 int(self.PPS_LIMIT_MAX),
+                 str(self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX))
+            )
+            assert self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX, (
+                "Copp policer constraint check failed, Actual PPS: {} "
+                "Expected PPS range: {} - {}".format(
+                    rx_pps, self.PPS_LIMIT_MIN, self.PPS_LIMIT_MAX))
+        else:
+            self.log("Checking constraints (NoPolicyApplied - T1 DHCP):")
+            self.log(
+                "DHCP-matched recv_count (%d) should be 0 (DHCP not punted on T1)" % recv_count
+            )
+            assert recv_count == 0, (
+                "Copp policer constraint check failed, Expected 0 DHCP packets punted "
+                "to CPU on T1, but received {} packets".format(recv_count))
 
     def construct_packet(self, port_number):
         src_mac = self.my_mac[port_number]

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -460,3 +460,8 @@ r, ".*ERR swss#orchagent:.*SAI_API_QUEUE, status: SAI_STATUS_INVALID_PARAMETER.*
 # Ignore link-training failure status query errors during port state transitions
 # SAI cannot read LT registers while the port serdes is mid-transition
 r, ".* ERR swss\d*#orchagent:.*getPortLinkTrainingFailure: Failed to get LT failure status for .*"
+
+# https://github.com/sonic-net/sonic-mgmt/issues/19347
+r, ".* ERR auditd.*: queue to plugins is full - dropping event"
+r, ".* ERR auditd.*: message repeated .*: \[ queue to plugins is full - dropping event\]"
+r, ".* ERR auditd.*: auditd queue full reporting limit reached - ending dropped event notifications"

--- a/docs/testplan/dhcp_relay/DHCPv4-Relay-Test-Plan.md
+++ b/docs/testplan/dhcp_relay/DHCPv4-Relay-Test-Plan.md
@@ -265,10 +265,10 @@ This test plan covers comprehensive testing of DHCPv4 relay functionality in SON
 
 ### Key Helper Functions
 - `check_interface_status()`: Verify relay agent socket binding
-- `query_dhcpcom_relay_counter_result()`: Retrieve DHCP counters
-- `validate_dhcpcom_relay_counters()`: Validate counter accuracy
-- `start_dhcp_monitor_debug_counter()`: Enable debug counter mode
-- `init_dhcpcom_relay_counters()`: Reset counter values
+- `query_dhcpmon_counter_result()`: Retrieve DHCP counters from dhcpmon
+- `validate_dhcpmon_counters()`: Validate counter accuracy from dhcpmon
+- `restart_dhcpmon_in_debug()`: Enable dhcpmon debug mode
+- `init_dhcpmon_counters()`: Reset counter values from dhcpmon
 
 ### Fixtures
 - `ignore_expected_loganalyzer_exceptions`: Filter expected errors

--- a/setup-container.sh
+++ b/setup-container.sh
@@ -6,15 +6,12 @@ declare -r SCRIPT_DIR="$(dirname "${SCRIPT_PATH}")"
 
 declare -r DOCKER_REGISTRY="sonicdev-microsoft.azurecr.io:443"
 declare -r DOCKER_SONIC_MGMT="docker-sonic-mgmt:latest"
-declare -r LOCAL_IMAGE_NAME="docker-sonic-mgmt-$(echo "${USER}" | tr '[:upper:]' '[:lower:]')"
-declare -r LOCAL_IMAGE_TAG="master"
-declare -r LOCAL_IMAGE="${LOCAL_IMAGE_NAME}:${LOCAL_IMAGE_TAG}"
 
 declare -r ROOT_PASS="root"
 declare -r USER_PASS="12345"
 
 declare -r HOST_DGNAME="docker"
-declare -r HOST_DGID="$(getent group | grep docker | awk -F: '{print $3}')"
+declare -r HOST_DGID="$(getent group docker | awk -F: '{print $3}')"
 
 declare -r HOST_GID="$(id -g)"
 declare -r HOST_UID="$(id -u)"
@@ -49,6 +46,7 @@ PUBLISH_PORTS=""
 FORCE_REMOVAL="${NO_PARAM}"
 VERBOSE_LEVEL="${VERBOSE_MIN}"
 SILENT_HOOK="&> /dev/null"
+ENABLE_DEBUG=0
 
 # Sonic-mgmt remote debug feature
 DEBUG_PORT_START_RANGE=50000
@@ -108,8 +106,7 @@ function show_help_and_exit() {
     echo "  -i <image_id>        specify Docker image to use. This can be an image ID (hashed value) or an image name."
     echo "                       If no value is provided, defaults to the following images in the specified order:"
     echo "                         1. The local image named \"docker-sonic-mgmt\""
-    echo "                         2. The local image named \"sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt\""
-    echo "                         3. The remote image at \"sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt\""
+    echo "                         2. The remote image at \"sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest\""
     echo "  -d <directory>       specify directory inside container to bind mount to sonic-mgmt root (default: \"/var/src\")"
     echo "  -m <mount_point>     specify directory to bind mount to container"
     echo "  -p <port>            publish container port to the host"
@@ -132,18 +129,16 @@ function show_help_and_exit() {
 }
 
 function show_local_container_login() {
-    CONTAINER_EXEC_CMD="docker exec --user root \"${CONTAINER_NAME}\""
-    CONTAINER_INTF_CMD="bash -c \"ip -4 route ls | grep 'default' | grep -Po '(?<=dev )(\S+)'\""
-    CONTAINER_INTF="$(eval "${CONTAINER_EXEC_CMD} ${CONTAINER_INTF_CMD}")"
-    CONTAINER_IPV4_CMD="bash -c \"ip -4 addr show dev \"${CONTAINER_INTF}\" | grep 'inet' | awk '{print \\\$2}' | cut -d'/' -f1\""
-    CONTAINER_IPV4="$(eval "${CONTAINER_EXEC_CMD} ${CONTAINER_IPV4_CMD}")"
+    local CONTAINER_IPV4
+    CONTAINER_IPV4="$(docker exec --user root "${CONTAINER_NAME}" \
+        bash -c "ip -4 route get 1 | grep -Po '(?<=src )(\S+)'")"
 
     echo "******************************************************************************"
     echo "EXEC: docker exec --user ${USER} -ti ${CONTAINER_NAME} bash"
-    echo "SSH:  ssh -i ~/.ssh/id_rsa_docker_sonic_mgmt ${USER}@${CONTAINER_IPV4}"
+    echo "SSH:  ssh -i ~/.ssh/id_ed25519_docker_sonic_mgmt ${USER}@${CONTAINER_IPV4}"
     echo "******************************************************************************"
 
-    if [[ -n ${SELECTED_DEBUG_PORT} ]]; then
+    if [[ -n "${SELECTED_DEBUG_PORT}" ]]; then
         echo
         echo "*********************************[IMPORTANT]*********************************"
         echo "DEBUG PORT: $SELECTED_DEBUG_PORT"
@@ -156,14 +151,9 @@ function show_local_container_login() {
 
 function pull_sonic_mgmt_docker_image() {
     if [[ -z "${IMAGE_ID}" ]]; then
-        DOCKER_IMAGES_CMD="docker images --format \"{{.Repository}}:{{.Tag}}\""
-        DOCKER_PULL_CMD="docker pull \"${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}\""
-
-        if eval "${DOCKER_IMAGES_CMD}" | grep -q "^${DOCKER_SONIC_MGMT}:latest$"; then
+        if docker image inspect "${DOCKER_SONIC_MGMT}" &> /dev/null; then
             IMAGE_ID="${DOCKER_SONIC_MGMT}"
-        elif eval "${DOCKER_IMAGES_CMD}" | grep -q "^${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}:latest$"; then
-            IMAGE_ID="${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}"
-        elif log_info "pulling docker image from a registry ..." && eval "${DOCKER_PULL_CMD}"; then
+        elif log_info "pulling docker image from a registry ..." && docker pull "${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}"; then
             IMAGE_ID="${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}"
         else
             exit_failure "unable to find a usable default docker image, please specify one manually"
@@ -173,14 +163,15 @@ function pull_sonic_mgmt_docker_image() {
     fi
 }
 
-function setup_local_image() {
-    AUTHKEY_FILE="${HOME}/.ssh/authorized_keys"
-    PRIVKEY_FILE="${HOME}/.ssh/id_rsa_docker_sonic_mgmt"
-    PUBKEY_FILE="${HOME}/.ssh/id_rsa_docker_sonic_mgmt.pub"
+PRIVKEY_FILE="${HOME}/.ssh/id_ed25519_docker_sonic_mgmt"
+PUBKEY_FILE="${HOME}/.ssh/id_ed25519_docker_sonic_mgmt.pub"
+
+function generate_ssh_keys() {
+    local AUTHKEY_FILE="${HOME}/.ssh/authorized_keys"
 
     if [[ ! -f "${PRIVKEY_FILE}" ]]; then
         log_info "generate SSH key pair: $(basename "${PRIVKEY_FILE}")/$(basename "${PUBKEY_FILE}")"
-        ssh-keygen -t rsa -q -N "" -f "${PRIVKEY_FILE}" || \
+        ssh-keygen -t ed25519 -q -N "" -f "${PRIVKEY_FILE}" || \
         exit_failure "failed to generate SSH key pair: $(basename "${PRIVKEY_FILE}")/$(basename "${PUBKEY_FILE}")"
     fi
 
@@ -192,170 +183,127 @@ function setup_local_image() {
         grep -q "${SSH_PUBKEY}" "${AUTHKEY_FILE}" || echo "${SSH_PUBKEY}" >> "${AUTHKEY_FILE}"
     else
         echo "${SSH_PUBKEY}" > "${AUTHKEY_FILE}"
-        chmod 0644 "${AUTHKEY_FILE}"
+        chmod 0600 "${AUTHKEY_FILE}"
     fi
+}
 
-    TMP_DIR="$(mktemp -d)"
-    log_info "setup a temporary dir: ${TMP_DIR}"
+function configure_container_user() {
+    log_info "configuring user ${USER} inside container ..."
 
-    log_info "copy SSH key pair: $(basename "${PRIVKEY_FILE}")/$(basename "${PUBKEY_FILE}")"
-    eval "cp -fv \"${PRIVKEY_FILE}\" \"${TMP_DIR}/id_rsa\" ${SILENT_HOOK}"
-    eval "cp -fv \"${PUBKEY_FILE}\" \"${TMP_DIR}/id_rsa.pub\" ${SILENT_HOOK}"
+    # Write setup script to a temp file; host-side variables are substituted by the heredoc.
+    # Variables that must survive as literals inside the container (e.g. loop vars, sed anchors)
+    # are escaped with \$ so they reach the container shell unexpanded.
+    local TMP_SETUP
+    TMP_SETUP="$(mktemp)"
+    trap "rm -f '${TMP_SETUP}'" RETURN
+    cat > "${TMP_SETUP}" << SETUP_EOF
+#!/bin/bash
+set -e
 
-    log_info "prepare a Dockerfile template: ${TMP_DIR}/Dockerfile.j2"
-    cat <<'EOF' > "${TMP_DIR}/Dockerfile.j2"
-FROM {{ IMAGE_ID }}
+# Remove default ubuntu user if present (Ubuntu 24.04)
+getent passwd ubuntu && userdel -r ubuntu || true
 
-USER root
-
-# Remove possible default ubuntu user of Ubuntu 24.04
-RUN if getent passwd ubuntu; \
-then userdel -r ubuntu; \
-fi
-
-# Group configuration
-RUN if getent group {{ GROUP_NAME }}; \
-then groupmod -o -g {{ GROUP_ID }} {{ GROUP_NAME }}; \
-else groupadd -o -g {{ GROUP_ID }} {{ GROUP_NAME }}; \
+# Group configuration: reuse whichever group already owns the host GID, or create a new one.
+# This avoids groupmod/groupadd failures from duplicate GIDs (e.g. systemd-network sharing a GID).
+user_group=\$(getent group ${HOST_GID} | awk -F: '{print \$1}')
+if [ -z "\$user_group" ]; then
+    if getent group ${USER}; then
+        groupmod -g ${HOST_GID} ${USER}
+    else
+        groupadd -g ${HOST_GID} ${USER}
+    fi
+    user_group=${USER}
 fi
 
 # User configuration
-RUN if getent passwd {{ USER_NAME }}; \
-# Usermod will hang when user_id is large (https://github.com/moby/moby/issues/5419), and it can not work around this issue itself.
-# So, we first delete the user and use `useradd -l` to work around this issue.
-#then usermod -o -g {{ GROUP_ID }} -u {{ USER_ID }} -m -d /home/{{ USER_NAME }} {{ USER_NAME }}; \
-then userdel {{ USER_NAME }}; \
+# useradd -l works around https://github.com/moby/moby/issues/5419 for large UIDs
+if getent passwd ${USER}; then
+    userdel ${USER}
 fi
-RUN useradd -o -l -g {{ GROUP_ID }} -u {{ USER_ID }} -m -d /home/{{ USER_NAME }} -s /bin/bash {{ USER_NAME }};
+useradd -o -l -g "\$user_group" -u ${HOST_UID} -m -d /home/${USER} -s /bin/bash ${USER}
 
-# Docker configuration
-RUN if getent group {{ DGROUP_NAME }}; \
-then groupmod -o -g {{ DGROUP_ID }} {{ DGROUP_NAME }}; \
-else groupadd -o -g {{ DGROUP_ID }} {{ DGROUP_NAME }}; \
+# Docker socket access: find the group owning the host docker GID, or create it.
+# Using the existing group (regardless of name) is safe since socket access depends on GID only.
+docker_group=\$(getent group ${HOST_DGID} | awk -F: '{print \$1}')
+if [ -z "\$docker_group" ]; then
+    if getent group ${HOST_DGNAME}; then
+        groupmod -g ${HOST_DGID} ${HOST_DGNAME}
+    else
+        groupadd -g ${HOST_DGID} ${HOST_DGNAME}
+    fi
+    docker_group=${HOST_DGNAME}
 fi
 
-# Environment configuration, skip python virtual environments
-RUN if [ '{{ USER_NAME }}' != 'AzDevOps' ]; then \
-/bin/bash -O extglob -c 'cp -a -f /var/AzDevOps/!(env-*) /home/{{ USER_NAME }}/'; \
-for hidden_stuff in '.profile .local .ssh'; do \
-/bin/bash -c 'cp -a -f /var/AzDevOps/$hidden_stuff /home/{{ USER_NAME }}/ || true'; done \
+# Copy AzDevOps environment baseline (skip python virtual envs)
+if [ '${USER}' != 'AzDevOps' ]; then
+    /bin/bash -O extglob -c 'cp -a -f /var/AzDevOps/!(env-*) /home/${USER}/ 2>/dev/null || true'
+    for hidden_stuff in .profile .local .ssh; do
+        cp -a -f "/var/AzDevOps/\${hidden_stuff}" /home/${USER}/ 2>/dev/null || true
+    done
 fi
 
 # Permissions configuration
-RUN usermod -a -G sudo {{ USER_NAME }}
-RUN usermod -a -G {{ DGROUP_NAME }} {{ USER_NAME }}
-RUN echo '{{ USER_NAME }} ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/{{ USER_NAME }}
-RUN chmod 0440 /etc/sudoers.d/{{ USER_NAME }}
-RUN chown -R '{{ USER_ID }}:{{ GROUP_ID }}' /home/{{ USER_NAME }}
+usermod -a -G sudo ${USER}
+usermod -a -G "\$docker_group" ${USER}
+echo '${USER} ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/${USER}
+chmod 0440 /etc/sudoers.d/${USER}
+chown -R ${HOST_UID}:${HOST_GID} /home/${USER}
 
-# SSH/PASS configuration
-RUN sed -i -E 's/^#?PermitRootLogin.*$/PermitRootLogin yes/g' /etc/ssh/sshd_config
-RUN echo 'root:{{ ROOT_PASS }}' | chpasswd
-RUN echo '{{ USER_NAME }}:{{ USER_PASS }}' | chpasswd
+# SSH/password configuration
+sed -i -E 's/^#?PermitRootLogin.*\$/PermitRootLogin yes/g' /etc/ssh/sshd_config
+echo 'root:${ROOT_PASS}' | chpasswd
+echo '${USER}:${USER_PASS}' | chpasswd
 
-USER {{ USER_NAME }}
+# SSH key setup
+mkdir -p /home/${USER}/.ssh
+cat /tmp/ssh_pubkey_to_add >> /home/${USER}/.ssh/authorized_keys
+mv /tmp/id_ed25519 /home/${USER}/.ssh/id_ed25519
+mv /tmp/id_ed25519.pub /home/${USER}/.ssh/id_ed25519.pub
+chmod 0700 /home/${USER}/.ssh
+chmod 0600 /home/${USER}/.ssh/id_ed25519
+chmod 0644 /home/${USER}/.ssh/id_ed25519.pub
+chmod 0600 /home/${USER}/.ssh/authorized_keys
+chown -R ${HOST_UID}:${HOST_GID} /home/${USER}/.ssh
+SETUP_EOF
 
-ENV HOME=/home/{{ USER_NAME }}
-ENV USER={{ USER_NAME }}
+    docker cp "${TMP_SETUP}" "${CONTAINER_NAME}:/tmp/setup_user.sh"
+    docker cp "${PRIVKEY_FILE}" "${CONTAINER_NAME}:/tmp/id_ed25519"
+    docker cp "${PUBKEY_FILE}" "${CONTAINER_NAME}:/tmp/id_ed25519.pub"
+    echo "${SSH_PUBKEY}" | docker exec -i --user root "${CONTAINER_NAME}" tee /tmp/ssh_pubkey_to_add > /dev/null
+    rm -f "${TMP_SETUP}"
+    trap - RETURN
 
-# Passwordless SSH access
-COPY --chown={{ USER_ID }}:{{ GROUP_ID }} id_rsa id_rsa.pub ${HOME}/.ssh/
-RUN chmod 0700 ${HOME}/.ssh
-RUN chmod 0600 ${HOME}/.ssh/id_rsa
-RUN chmod 0644 ${HOME}/.ssh/id_rsa.pub
-RUN cat ${HOME}/.ssh/id_rsa.pub >> ${HOME}/.ssh/authorized_keys
-RUN chmod 0600 ${HOME}/.ssh/authorized_keys
+    eval "docker exec --user root \"${CONTAINER_NAME}\" bash /tmp/setup_user.sh ${SILENT_HOOK}" || \
+        exit_failure "failed to configure user in container"
 
-WORKDIR ${HOME}
-
-# Setup python3 virtual env if some conditions are met:
-# 1. pytest is not globally installed. If pytest is gloablly installed, this assumes that all the packages in
-#    the python3 virtual env are installed globally. No need to create python3 virtual env.
-# 2. The user is not AzDevOps. By default python3 virtual env is installed for AzDevOps user.
-#    No need to install it again when current user is AzDevOps.
-# 3. The python3 virtual env is not installed for AzDevOps. Then, it is not required for other users either.
-# As of 2025, python3 is installed globally in the docker-sonic-mgmt image. So, this step is not really required.
-# Adjust the conditions to fail faster to skip this step.
-RUN if [ -d /var/AzDevOps/env-python3 ] \
- && [ '{{ USER_NAME }}' != 'AzDevOps' ] \
- && ! pip3 list | grep -c pytest >/dev/null; then \
-/bin/bash -c 'python3 -m venv ${HOME}/env-python3'; \
-/bin/bash -c '${HOME}/env-python3/bin/pip install pip --upgrade'; \
-/bin/bash -c '${HOME}/env-python3/bin/pip install wheel'; \
-/bin/bash -c '${HOME}/env-python3/bin/pip install $(/var/AzDevOps/env-python3/bin/pip freeze | grep -vE "distro|PyGObject|python-apt|unattended-upgrades|dbus-python")'; \
-fi
-
-# Remote debug port setup
-{% if SONIC_MGMT_DEBUG_PORT %}
-ENV SONIC_MGMT_DEBUG_PORT={{ SONIC_MGMT_DEBUG_PORT }}
-{% endif %}
-EOF
-
-    log_info "prepare an environment file: ${TMP_DIR}/data.env"
-    cat <<EOF > "${TMP_DIR}/data.env"
-IMAGE_ID=${IMAGE_ID}
-DGROUP_NAME=${HOST_DGNAME}
-DGROUP_ID=${HOST_DGID}
-GROUP_ID=${HOST_GID}
-USER_ID=${HOST_UID}
-GROUP_NAME=${USER}
-USER_NAME=${USER}
-USER_PASS=${USER_PASS}
-ROOT_PASS=${ROOT_PASS}
-SONIC_MGMT_DEBUG_PORT=${SELECTED_DEBUG_PORT}
-EOF
-
-    log_info "generate a Dockerfile: ${TMP_DIR}/Dockerfile"
-    j2 -o "${TMP_DIR}/Dockerfile" "${TMP_DIR}/Dockerfile.j2" "${TMP_DIR}/data.env" || \
-    log_error "failed to generate a Dockerfile: ${TMP_DIR}/Dockerfile"
-
-    log_info "building docker image from ${TMP_DIR}: ${LOCAL_IMAGE} ..."
-    build_args=""
-    if [[ -n ${http_proxy} ]]; then
-        build_args="--build-arg http_proxy=${http_proxy}"
-    fi
-    if [[ -n ${https_proxy} ]]; then
-        build_args="${build_args} --build-arg https_proxy=${https_proxy}"
-    fi
-    eval "docker build -t \"${LOCAL_IMAGE}\" \"${TMP_DIR}\" ${SILENT_HOOK} ${build_args}" || \
-    log_error "failed to build docker image: ${LOCAL_IMAGE}"
-
-    log_info "cleanup a temporary dir: ${TMP_DIR}"
-    rm -rf "${TMP_DIR}"
-
-    if ! docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "^${LOCAL_IMAGE}$"; then
-        exit_failure "failed to build docker image: ${LOCAL_IMAGE}"
+    if [[ -n "${SELECTED_DEBUG_PORT}" ]]; then
+        eval "docker exec --user root \"${CONTAINER_NAME}\" \
+            bash -c \"echo 'export SONIC_MGMT_DEBUG_PORT=${SELECTED_DEBUG_PORT}' >> /home/${USER}/.profile\" \
+            ${SILENT_HOOK}"
     fi
 }
 
 function container_exists() {
-    container_id=`docker ps --all --filter name=^$CONTAINER_NAME\$ --format '{{.ID}}'`
-    count=`echo $container_id | wc -w`
-    return $count
+    local count
+    count=$(docker ps --all --filter "name=^${CONTAINER_NAME}$" --format '{{.ID}}' | wc -l)
+    [[ "$count" -gt 0 ]]
 }
 
 function get_existing_container() {
-    img_id=${IMAGE_ID}
-    if [ -z ${img_id} ]
-    then
-        img_id=${LOCAL_IMAGE}
-    fi
-    container_id=`docker container ls --all --filter=ancestor=${img_id} --format '{{.ID}}'`
-    count=`echo $container_id | wc -w`
+    local container_ids
+    mapfile -t container_ids < <(docker container ls --all --filter="ancestor=${IMAGE_ID}" --format '{{.ID}}')
+    local count=${#container_ids[@]}
     case $count in
         0)
             EXISTING_CONTAINER_NAME=""
             ;;
         1)
-            container_name=`docker inspect $container_id --format '{{.Name}}'`
-            if [[ $container_name == /* ]]
-            then
-                container_name="${container_name:1}"
-            fi
-            EXISTING_CONTAINER_NAME=${container_name}
+            local container_name
+            container_name=$(docker inspect "${container_ids[0]}" --format '{{.Name}}')
+            EXISTING_CONTAINER_NAME="${container_name#/}"
             ;;
         *)
-            echo "Multiple container IDs found: ${container_id}"
+            echo "Multiple container IDs found: ${container_ids[*]}"
             EXISTING_CONTAINER_NAME=""
             ;;
     esac
@@ -363,18 +311,18 @@ function get_existing_container() {
 
 function start_local_container() {
 
-    container_exists
-    local exists=$?
-    if [ $exists -eq 1 ]
+    if container_exists
     then
         log_info "starting existing container ${CONTAINER_NAME} ..."
-        docker start ${CONTAINER_NAME}
+        docker start "${CONTAINER_NAME}"
     else
         log_info "creating a container: ${CONTAINER_NAME} ..."
-        eval "docker run -d -t ${PUBLISH_PORTS} ${ENV_VARS} -h ${CONTAINER_NAME} \
+        eval "docker run --cap-add=SYS_PTRACE -d -t ${PUBLISH_PORTS} ${ENV_VARS} -h ${CONTAINER_NAME} \
         -v \"$(dirname "${SCRIPT_DIR}"):${LINK_DIR}:rslave\" ${MOUNT_POINTS} \
-        --name \"${CONTAINER_NAME}\" \"${LOCAL_IMAGE}\" /bin/bash ${SILENT_HOOK}" || \
+        --name \"${CONTAINER_NAME}\" \"${IMAGE_ID}\" /bin/bash ${SILENT_HOOK}" || \
         exit_failure "failed to start a container: ${CONTAINER_NAME}"
+
+        configure_container_user
     fi
 
     eval "docker exec --user root \"${CONTAINER_NAME}\" \
@@ -398,8 +346,7 @@ function parse_arguments() {
 
     if [[ -z "${CONTAINER_NAME}" ]]; then
         get_existing_container
-        if [ -z $EXISTING_CONTAINER_NAME ]
-        then
+        if [[ -z "${EXISTING_CONTAINER_NAME}" ]]; then
             exit_failure "container name is not set."
         else
             exit_failure "found existing container (\"docker start $EXISTING_CONTAINER_NAME\")"
@@ -515,16 +462,12 @@ if docker ps -a --format "{{.Names}}" | grep -q "^${CONTAINER_NAME}$"; then
         eval "docker rm -f \"${CONTAINER_NAME}\" ${SILENT_HOOK}"
     else
         show_local_container_login
-        exit_success "container is already exists: ${CONTAINER_NAME}"
+        exit_success "container already exists: ${CONTAINER_NAME}"
     fi
 fi
 
-if ! which j2 &> /dev/null; then
-    exit_failure "missing Jinja2 templates support: make sure j2cli package is installed"
-fi
-
 pull_sonic_mgmt_docker_image
-setup_local_image
+generate_ssh_keys
 start_local_container
 show_local_container_login
 

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -20,6 +20,7 @@ from tests.common.helpers.parallel import reset_ansible_local_tmp
 from tests.common.helpers.parallel import parallel_run
 from tests.common.utilities import wait_until
 from tests.common.utilities import is_ipv6_only_topology
+from tests.common.utilities import testbed_is_multi_vrf
 from tests.bgp.traffic_checker import get_traffic_shift_state
 from tests.bgp.constants import TS_NORMAL
 from tests.common.devices.eos import EosHost
@@ -673,7 +674,7 @@ def get_vm_name_list(tbinfo, vm_level='T2'):
     Get vm name, default return value would be T2 VM name
     """
     vm_name_list = []
-    if tbinfo.get('use_converged_peers', False):
+    if testbed_is_multi_vrf(tbinfo):
         vms = list(tbinfo['topo']['properties']['configuration'].keys())
     else:
         vms = list(tbinfo['topo']['properties']['topology']['VMs'].keys())

--- a/tests/common/connections/ssh_console_conn.py
+++ b/tests/common/connections/ssh_console_conn.py
@@ -161,7 +161,10 @@ class SSHConsoleConn(BaseConsoleConn):
                     msg = "Login failed: {}".format(self.host)
                     raise NetMikoAuthenticationException(msg)
 
-                self.write_channel(self.RETURN)
+                # Only send blank CR to wake up terminal when still waiting for username prompt;
+                # once username has been sent, stop sending CRs so no empty password arrives before 'Password:' prompt
+                if not user_sent:
+                    self.write_channel(self.RETURN)
                 time.sleep(0.5 * delay_factor)
                 i += 1
             except EOFError:

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -26,13 +26,13 @@ def restart_dhcp_service(duthost):
     pytest_assert(wait_until(120, 1, 10, _is_dhcp_relay_ready), "dhcp_relay is not ready after restarting")
 
 
-def init_dhcpcom_relay_counters(duthost):
+def init_dhcpmon_counters(duthost):
     command_output = duthost.shell("sudo sonic-clear dhcp_relay ipv4 counters")
     pytest_assert("Clear DHCPv4 relay counter done" == command_output["stdout"],
                   "dhcp_relay counters are not cleared successfully, output: {}".format(command_output["stdout"]))
 
 
-def query_dhcpcom_relay_counter_result(duthost, query_key):
+def query_dhcpmon_counter_result(duthost, query_key):
     '''
     Query the DHCPv4 counters from the COUNTERS_DB by the given key.
     The returned value is a dictionary and the counter values are converted to integers.
@@ -51,15 +51,15 @@ def query_dhcpcom_relay_counter_result(duthost, query_key):
         } for rx_or_tx, counters in shell_result.items()}
 
 
-def query_and_sum_dhcpcom_relay_counters(duthost, vlan_name, interface_name_list):
+def query_and_sum_dhcpmon_counters(duthost, vlan_name, interface_name_list):
     '''Query the DHCPv4 counters from the COUNTERS_DB and sum the counters for the given interface names.'''
     if interface_name_list is None or len(interface_name_list) == 0:
         # If no interface names are provided, return the counters for the VLAN interface only.
-        return query_dhcpcom_relay_counter_result(duthost, vlan_name)
+        return query_dhcpmon_counter_result(duthost, vlan_name)
     total_counters = {}
     # If interface names are provided, sum all of the provided interface names' counters
     for interface_name in interface_name_list:
-        internal_shell_result = query_dhcpcom_relay_counter_result(duthost, vlan_name + ":" + interface_name)
+        internal_shell_result = query_dhcpmon_counter_result(duthost, vlan_name + ":" + interface_name)
         for rx_or_tx, counters in internal_shell_result.items():
             total_value = total_counters.setdefault(rx_or_tx, {})
             for dhcp_type, counter_value in counters.items():
@@ -67,14 +67,14 @@ def query_and_sum_dhcpcom_relay_counters(duthost, vlan_name, interface_name_list
     return total_counters
 
 
-def compare_dhcpcom_relay_counters_with_warning(actual_counter, expected_counter, warning_msg, error_in_percentage=0.0):
-    compare_result = compare_dhcpcom_relay_counter_values(
+def compare_dhcp_counters_with_warning(actual_counter, expected_counter, warning_msg, error_in_percentage=0.0):
+    compare_result = compare_dhcp_counters(
         actual_counter, expected_counter, error_in_percentage)
     while msg := next(compare_result, False):
         logger.warning(warning_msg + ": " + str(msg))
 
 
-def compare_dhcpcom_relay_counter_values(dhcp_relay_counter, expected_counter, error_in_percentage=0.0):
+def compare_dhcp_counters(dhcp_relay_counter, expected_counter, error_in_percentage=0.0):
     """Compare the DHCP relay counter value with the expected counter."""
     for dir in SUPPORTED_DIR:
         for dhcp_type in SUPPORTED_DHCPV4_TYPE:
@@ -92,9 +92,9 @@ def compare_dhcpcom_relay_counter_values(dhcp_relay_counter, expected_counter, e
                           .format(dir, dhcp_type, actual_value, expected_value, error_in_percentage))
 
 
-def validate_dhcpcom_relay_counters(dhcp_relay, duthost, expected_uplink_counter,
-                                    expected_downlink_counter, error_in_percentage=0.0):
-    """Validate the dhcpcom relay counters"""
+def validate_dhcpmon_counters(dhcp_relay, duthost, expected_uplink_counter,
+                              expected_downlink_counter, error_in_percentage=0.0):
+    """Validate the dhcpmon relay counters"""
     logger.info("Expected uplink counters: {}, expected downlink counters: {}, error in percentage: {}%".format(
         expected_uplink_counter, expected_downlink_counter, error_in_percentage))
     downlink_vlan_iface = dhcp_relay['downlink_vlan_iface']['name']
@@ -115,15 +115,15 @@ def validate_dhcpcom_relay_counters(dhcp_relay, duthost, expected_uplink_counter
     for portchannel_name in uplink_portchannels_or_interfaces:
         if portchannel_name in portchannels.keys():
             uplink_interfaces.extend(portchannels[portchannel_name]['members'])
-            portchannel_counters = query_and_sum_dhcpcom_relay_counters(duthost,
-                                                                        downlink_vlan_iface,
-                                                                        [portchannel_name])
-            members_counters = query_and_sum_dhcpcom_relay_counters(duthost,
-                                                                    downlink_vlan_iface,
-                                                                    portchannels[portchannel_name]['members'])
+            portchannel_counters = query_and_sum_dhcpmon_counters(duthost,
+                                                                  downlink_vlan_iface,
+                                                                  [portchannel_name])
+            members_counters = query_and_sum_dhcpmon_counters(duthost,
+                                                              downlink_vlan_iface,
+                                                              portchannels[portchannel_name]['members'])
 
             # If the portchannel counters and its members' counters are not equal, yield a warning message
-            compare_dhcpcom_relay_counters_with_warning(
+            compare_dhcp_counters_with_warning(
                 portchannel_counters, members_counters,
                 compare_warning_msg.format(portchannel_name,
                                            portchannels[portchannel_name]['members'], duthost.hostname),
@@ -131,26 +131,26 @@ def validate_dhcpcom_relay_counters(dhcp_relay, duthost, expected_uplink_counter
         else:
             uplink_interfaces.append(portchannel_name)
 
-    vlan_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, [])
-    client_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, [client_iface])
-    uplink_portchannels_interfaces_counter = query_and_sum_dhcpcom_relay_counters(
+    vlan_interface_counter = query_and_sum_dhcpmon_counters(duthost, downlink_vlan_iface, [])
+    client_interface_counter = query_and_sum_dhcpmon_counters(duthost, downlink_vlan_iface, [client_iface])
+    uplink_portchannels_interfaces_counter = query_and_sum_dhcpmon_counters(
         duthost, downlink_vlan_iface, uplink_portchannels_or_interfaces
     )
-    uplink_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, uplink_interfaces)
+    uplink_interface_counter = query_and_sum_dhcpmon_counters(duthost, downlink_vlan_iface, uplink_interfaces)
 
-    compare_dhcpcom_relay_counters_with_warning(
+    compare_dhcp_counters_with_warning(
         vlan_interface_counter, client_interface_counter,
         compare_warning_msg.format(downlink_vlan_iface, client_iface, duthost.hostname),
         error_in_percentage)
-    compare_dhcpcom_relay_counters_with_warning(
+    compare_dhcp_counters_with_warning(
         uplink_portchannels_interfaces_counter, uplink_interface_counter,
         compare_warning_msg.format(uplink_portchannels_or_interfaces, uplink_interfaces, duthost.hostname),
         error_in_percentage)
-    compare_dhcpcom_relay_counters_with_warning(
+    compare_dhcp_counters_with_warning(
         client_interface_counter, expected_downlink_counter,
         compare_warning_msg.format(client_iface, "expected_downlink_counter", duthost.hostname),
         error_in_percentage)
-    compare_dhcpcom_relay_counters_with_warning(
+    compare_dhcp_counters_with_warning(
         uplink_interface_counter, expected_uplink_counter,
         compare_warning_msg.format(uplink_interfaces, "expected_uplink_counter", duthost.hostname),
         error_in_percentage)
@@ -199,7 +199,7 @@ def calculate_counters_per_pkts(pkts):
 
 def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_name_index_mapping,
                                            error_in_percentage=0.0):
-    """Validate the dhcpcom relay counters and packets consistence"""
+    """Validate the dhcpmon relay counters and packets consistence"""
     downlink_vlan_iface = dhcp_relay['downlink_vlan_iface']['name']
     # it can be portchannel or interface, it depends on the topology
     uplink_portchannels_or_interfaces = dhcp_relay['uplink_interfaces']
@@ -218,12 +218,12 @@ def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_
     for portchannel_name in uplink_portchannels_or_interfaces:
         if portchannel_name in portchannels.keys():
             uplink_interfaces.extend(portchannels[portchannel_name]['members'])
-            portchannel_counters = query_and_sum_dhcpcom_relay_counters(duthost,
-                                                                        downlink_vlan_iface,
-                                                                        [portchannel_name])
-            members_counters = query_and_sum_dhcpcom_relay_counters(duthost,
-                                                                    downlink_vlan_iface,
-                                                                    portchannels[portchannel_name]['members'])
+            portchannel_counters = query_and_sum_dhcpmon_counters(duthost,
+                                                                  downlink_vlan_iface,
+                                                                  [portchannel_name])
+            members_counters = query_and_sum_dhcpmon_counters(duthost,
+                                                              downlink_vlan_iface,
+                                                              portchannels[portchannel_name]['members'])
 
             # If the portchannel counters and its members' counters are not equal, yield a warning message
 
@@ -240,13 +240,13 @@ def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_
                                                                                {"RX": {}, "TX": {}}))
 
             # Compare the portchannel counters from dhcp relay counter and pkts
-            compare_dhcpcom_relay_counters_with_warning(
+            compare_dhcp_counters_with_warning(
                 portchannel_counters, portchannel_counter_from_pkts,
                 compare_warning_msg.format(portchannel_name, portchannel_name + " from pkts", duthost.hostname),
                 error_in_percentage)
 
             # Compare the members counters from dhcp relay counter and pkts
-            compare_dhcpcom_relay_counters_with_warning(
+            compare_dhcp_counters_with_warning(
                 members_counters, members_counter_from_pkts,
                 compare_warning_msg.format(portchannels[portchannel_name]['members'],
                                            str(portchannels[portchannel_name]['members']) + " from pkts",
@@ -254,7 +254,7 @@ def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_
                 error_in_percentage)
 
             # Compare the portchannel counters and its members' counters from dhcp relay counter
-            compare_dhcpcom_relay_counters_with_warning(
+            compare_dhcp_counters_with_warning(
                 portchannel_counters, members_counters,
                 compare_warning_msg.format(portchannel_name,
                                            portchannels[portchannel_name]['members'], duthost.hostname),
@@ -262,7 +262,7 @@ def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_
         else:
             uplink_interfaces.append(portchannel_name)
 
-    vlan_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, [])
+    vlan_interface_counter = query_and_sum_dhcpmon_counters(duthost, downlink_vlan_iface, [])
 
     # uplink_portchannels_interfaces means the item can be the portchannel or the interface
     # Example:
@@ -270,7 +270,7 @@ def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_
     #   ['PortChannel101', 'PortChannel103', 'PortChannel105', 'PortChannel106']
     #   If there is no portchannel, the uplink_portchannels_or_interfaces will be
     #   ['Ethernet48', 'Ethernet49', 'Ethernet50', 'Ethernet51']
-    uplink_portchannels_interfaces_counter = query_and_sum_dhcpcom_relay_counters(
+    uplink_portchannels_interfaces_counter = query_and_sum_dhcpmon_counters(
         duthost, downlink_vlan_iface, uplink_portchannels_or_interfaces
     )
 
@@ -284,7 +284,7 @@ def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_
     """
     # Query the counters for uplink portchannels interfaces such as:
     # ['Ethernet48', 'Ethernet49', 'Ethernet50', 'Ethernet51']
-    uplink_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, uplink_interfaces)
+    uplink_interface_counter = query_and_sum_dhcpmon_counters(duthost, downlink_vlan_iface, uplink_interfaces)
 
     vlan_interface_counter_from_pkts = all_pkt_counters.get(interface_name_index_mapping[downlink_vlan_iface],
                                                             {"RX": {}, "TX": {}})
@@ -308,36 +308,36 @@ def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_
                        all_pkt_counters.get(interface_name_index_mapping[iface], {"RX": {}, "TX": {}}))
 
     # Compare the vlan interface counters from dhcp relay counter and pkts
-    compare_dhcpcom_relay_counters_with_warning(
+    compare_dhcp_counters_with_warning(
         vlan_interface_counter, vlan_interface_counter_from_pkts,
         compare_warning_msg.format(downlink_vlan_iface, downlink_vlan_iface + " from pkts", duthost.hostname),
         error_in_percentage)
 
     # Compare the sum of uplink portchannels counters from dhcp relay counter and pkts
-    compare_dhcpcom_relay_counters_with_warning(
+    compare_dhcp_counters_with_warning(
         uplink_portchannels_interfaces_counter, uplink_portchannels_interfaces_counter_from_pkts,
         compare_warning_msg.format(uplink_portchannels_or_interfaces,
                                    str(uplink_portchannels_or_interfaces) + " from pkts", duthost.hostname),
         error_in_percentage)
 
     # Compare the uplink portchannel interfaces counter and uplink interface counter from dhcyp relay counter
-    compare_dhcpcom_relay_counters_with_warning(
+    compare_dhcp_counters_with_warning(
         uplink_portchannels_interfaces_counter, uplink_interface_counter,
         compare_warning_msg.format(uplink_portchannels_or_interfaces, uplink_interfaces, duthost.hostname),
         error_in_percentage)
 
     # Compare the uplink interface counters from dhcp relay counter and pkts
-    compare_dhcpcom_relay_counters_with_warning(
+    compare_dhcp_counters_with_warning(
         uplink_interface_counter, uplink_interface_counter_from_pkts,
         compare_warning_msg.format(uplink_interfaces, str(uplink_interfaces) + " from pkts", duthost.hostname),
         error_in_percentage)
 
     # Compare the vlan interface counters from dhcp relay counter and pkts
     for vlan_member in vlan_members:
-        vlan_member_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, [vlan_member])
+        vlan_member_counter = query_and_sum_dhcpmon_counters(duthost, downlink_vlan_iface, [vlan_member])
         vlan_member_counter_from_pkts = all_pkt_counters.get(interface_name_index_mapping[vlan_member],
                                                              {"RX": {}, "TX": {}})
-        compare_dhcpcom_relay_counters_with_warning(
+        compare_dhcp_counters_with_warning(
             vlan_member_counter, vlan_member_counter_from_pkts,
             compare_warning_msg.format(vlan_member, vlan_member + " from pkts", duthost.hostname),
             error_in_percentage)

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -881,6 +881,187 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_config_db_on_duts):
     return duthosts
 
 
+@pytest.fixture(scope="module")
+def duthosts_ipv4_mgmt_only(duthosts):
+    """Convert the DUTs mgmt-ip to IPv4 only
+
+    Since the change commands is distributed by IPv6 mgmt-ip,
+    the fixture will detect the IPv4 availability first,
+    only remove the IPv6 mgmt-ip when the IPv4 mgmt-ip is available,
+    and will re-establish the connection to the DUTs with IPv4 mgmt-ip.
+    """
+    config_db_file = "/etc/sonic/config_db.json"
+
+    # Sample MGMT_INTERFACE:
+    #     "MGMT_INTERFACE": {
+    #         "eth0|192.168.0.2/24": {
+    #             "forced_mgmt_routes": [
+    #                 "192.168.1.1/24"
+    #             ],
+    #             "gwaddr": "192.168.0.1"
+    #         },
+    #         "eth0|fc00:1234:5678:abcd::2/64": {
+    #             "gwaddr": "fc00:1234:5678:abcd::1",
+    #             "forced_mgmt_routes": [
+    #                 "fc00:1234:5678:abc1::1/64"
+    #             ]
+    #         }
+    #     }
+    #
+    # Sample SNMP_AGENT_ADDRESS_CONFIG:
+    #   "SNMP_AGENT_ADDRESS_CONFIG": {
+    #    "10.1.0.32|161|": {},
+    #    "10.250.0.101|161|": {},
+    #    "FC00:1::32|161|": {},
+    #    "fec0::ffff:afa:1|161|": {}
+    #    },                                         },
+
+    # duthost_name: config_db_modified
+    config_db_modified: Dict[str, bool] = {duthost.hostname: False
+                                           for duthost in duthosts.nodes}
+    # duthost_name: [ip_addr]
+    ipv4_address: Dict[str, List] = {duthost.hostname: []
+                                     for duthost in duthosts.nodes}
+    ipv6_address: Dict[str, List] = {duthost.hostname: []
+                                     for duthost in duthosts.nodes}
+    # Check IPv4 mgmt-ip is set and available, otherwise the DUT will lose control after v6 mgmt-ip is removed
+    for duthost in duthosts.nodes:
+        mgmt_interface = json.loads(duthost.shell(f"jq '.MGMT_INTERFACE' {config_db_file}",
+                                                  module_ignore_errors=True)["stdout"])
+        # Use list() to make a copy of mgmt_interface.keys() to avoid
+        # "RuntimeError: dictionary changed size during iteration" error
+        ssh_client = paramiko.SSHClient()
+        ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        has_available_ipv4_addr = False
+        for key in list(mgmt_interface):
+            ip_addr = key.split("|")[1]
+            ip_addr_without_mask = ip_addr.split('/')[0]
+            if ip_addr:
+                is_ipv4 = valid_ipv4(ip_addr_without_mask)
+                if is_ipv4:
+                    logger.info(f"Host[{duthost.hostname}] IPv4[{ip_addr}]")
+                    ipv4_address[duthost.hostname].append(ip_addr_without_mask)
+                    try:
+                        # Add a temporary debug log to see if the DUT is reachable via IPv4 mgmt-ip. Will remove later
+                        duthost_interface = duthost.shell("sudo ifconfig eth0")['stdout']
+                        logger.debug(f"Checking host[{duthost.hostname}] ifconfig eth0:[{duthost_interface}]")
+                        ssh_client.connect(ip_addr_without_mask,
+                                           username="WRONG_USER", password="WRONG_PWD", timeout=15)
+                    except AuthenticationException:
+                        logger.info(f"Host[{duthost.hostname}] IPv4[{ip_addr_without_mask}] mgmt-ip is available")
+                        has_available_ipv4_addr = True
+                    except BaseException as e:
+                        logger.info(f"Host[{duthost.hostname}] IPv4[{ip_addr_without_mask}] mgmt-ip is unavailable, "
+                                    f"exception[{type(e)}], msg[{str(e)}]")
+                    finally:
+                        ssh_client.close()
+
+        pt_assert(len(ipv4_address[duthost.hostname]) > 0,
+                  f"{duthost.hostname} doesn't have IPv4 Management IP address")
+        pt_assert(has_available_ipv4_addr,
+                  f"{duthost.hostname} doesn't have available IPv4 Management IP address")
+
+    # Remove IPv6 mgmt-ip
+    for duthost in duthosts.nodes:
+        mgmt_interface = json.loads(duthost.shell(f"jq '.MGMT_INTERFACE' {config_db_file}",
+                                                  module_ignore_errors=True)["stdout"])
+
+        # Use list() to make a copy of mgmt_interface.keys() to avoid
+        # "RuntimeError: dictionary changed size during iteration" error
+        for key in list(mgmt_interface):
+            ip_addr = key.split("|")[1]
+            ip_addr_without_mask = ip_addr.split('/')[0]
+            if ip_addr:
+                is_ipv6 = valid_ipv6(ip_addr_without_mask)
+                if is_ipv6:
+                    ipv6_address[duthost.hostname].append(ip_addr_without_mask)
+                    logger.info(f"Removing host[{duthost.hostname}] IPv6[{ip_addr}]")
+                    duthost.shell(f"""jq 'del(."MGMT_INTERFACE"."{key}")' {config_db_file} > temp.json"""
+                                  f"""&& mv temp.json {config_db_file}""", module_ignore_errors=True)
+                    config_db_modified[duthost.hostname] = True
+
+    # Save both IPv4 and IPv6 SNMP address for verification purpose.
+    snmp_ipv4_address: Dict[str, List] = {duthost.hostname: []
+                                          for duthost in duthosts.nodes}
+    snmp_ipv6_address: Dict[str, List] = {duthost.hostname: []
+                                          for duthost in duthosts.nodes}
+    for duthost in duthosts.nodes:
+        snmp_address = json.loads(duthost.shell(f"jq '.SNMP_AGENT_ADDRESS_CONFIG' {config_db_file}",
+                                                module_ignore_errors=True)["stdout"])
+        # In case device doesn't have SNMP_AGENT_CONFIG: this could happen if
+        # DUT is running old image.
+        if not snmp_address:
+            logger.info(f"No SNMP_AGENT_ADDRESS_CONFIG found in host[{duthost.hostname}] {config_db_file}, continue.")
+            continue
+        for key in list(snmp_address):
+            ip_addr = key.split("|")[0]
+            if ip_addr:
+                if valid_ipv6(ip_addr):
+                    snmp_ipv6_address[duthost.hostname].append(ip_addr)
+                    logger.info(f"Removing host[{duthost.hostname}] SNMP IPv6 address {ip_addr}")
+                    duthost.shell(f"""jq 'del(."SNMP_AGENT_ADDRESS_CONFIG"."{key}")' {config_db_file} > temp.json"""
+                                  f"""&& mv temp.json {config_db_file}""", module_ignore_errors=True)
+                    config_db_modified[duthost.hostname] = True
+                elif valid_ipv4(ip_addr):
+                    snmp_ipv4_address[duthost.hostname].append(ip_addr.lower())
+
+    # Do config_reload after processing BOTH SNMP and MGMT config
+    def config_reload_if_modified(dut):
+        if config_db_modified[dut.hostname]:
+            logger.info(f"config changed. Doing config reload for {dut.hostname}")
+            try:
+                config_reload(dut, safe_reload=True, wait_for_bgp=True)
+            except AnsibleConnectionFailure as e:
+                # IPV6 mgmt interface been deleted by config reload
+                # In latest SONiC, config reload command will exit after mgmt interface restart
+                # Then 'duthost' will lost IPV6 connection and throw exception
+                logger.warning(f'Exception after config reload: {e}')
+
+    with SafeThreadPoolExecutor(max_workers=8) as executor:
+        for duthost in duthosts.nodes:
+            executor.submit(config_reload_if_modified, duthost)
+
+    duthosts.reset()
+
+    def wait_for_processes_and_bgp(dut):
+        if config_db_modified[dut.hostname]:
+            # Wait until all critical processes are up,
+            # especially snmpd as it needs to be up for SNMP status verification
+            wait_critical_processes(dut)
+            if not dut.is_supervisor_node():
+                wait_bgp_sessions(dut)
+
+    with SafeThreadPoolExecutor(max_workers=8) as executor:
+        for duthost in duthosts.nodes:
+            executor.submit(wait_for_processes_and_bgp, duthost)
+
+    # Verify mgmt-interface status
+    mgmt_intf_name = "eth0"
+    for duthost in duthosts.nodes:
+        logger.info(f"Checking host[{duthost.hostname}] mgmt interface[{mgmt_intf_name}]")
+        mgmt_intf_ifconfig = duthost.shell(f"ifconfig {mgmt_intf_name}", module_ignore_errors=True)["stdout"]
+        assert_addr_in_output(addr_set=ipv4_address, hostname=duthost.hostname,
+                              expect_exists=True, cmd_output=mgmt_intf_ifconfig,
+                              cmd_desc="ifconfig")
+        assert_addr_in_output(addr_set=ipv6_address, hostname=duthost.hostname,
+                              expect_exists=False, cmd_output=mgmt_intf_ifconfig,
+                              cmd_desc="ifconfig")
+
+    # Verify SNMP address status
+    for duthost in duthosts.nodes:
+        logger.info(f"Checking host[{duthost.hostname}] SNMP status in netstat output")
+        snmp_netstat_output = duthost.shell("sudo netstat -tulnpW | grep snmpd",
+                                            module_ignore_errors=True)["stdout"]
+        assert_addr_in_output(addr_set=snmp_ipv4_address, hostname=duthost.hostname,
+                              expect_exists=True, cmd_output=snmp_netstat_output,
+                              cmd_desc="netstat")
+        assert_addr_in_output(addr_set=snmp_ipv6_address, hostname=duthost.hostname,
+                              expect_exists=False, cmd_output=snmp_netstat_output,
+                              cmd_desc="netstat")
+
+    return duthosts
+
+
 def assert_addr_in_output(addr_set: Dict[str, List], hostname: str,
                           expect_exists: bool, cmd_output: str, cmd_desc: str):
     """

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -270,6 +270,18 @@ bfd/test_bfd_traffic.py:
 #######################################
 #####            bgp              #####
 #######################################
+bgp/reliable_tsa/test_reliable_tsa_flaky.py:
+  skip:
+    reason: "reliable TSA is not supported on non-chassis"
+    conditions:
+      - "is_chassis==False"
+
+bgp/reliable_tsa/test_reliable_tsa_stable.py:
+  skip:
+    reason: "reliable TSA is not supported on non-chassis"
+    conditions:
+      - "is_chassis==False"
+
 bgp/test_bgp_allow_list.py:
   skip:
     reason: "Only supported on t1 topo. But Cisco 8111 or 8122 T1(compute ai) platform is not supported."

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2302,11 +2302,7 @@ generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
       - "hwsku in ['Cisco-8800-LC-48H-C48', 'Cisco-8122-O128S2', 'Cisco-8122-O64']"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "release in ['202211']"
-  xfail:
-    reason: "This test will be reworked following changes to GCU validators"
-    conditions_logical_operator: "OR"
-    conditions:
-      - "release in ['master', '202511'] and https://github.com/sonic-net/sonic-mgmt/issues/22333"
+      - "https://github.com/sonic-net/sonic-buildimage/issues/22295 and platform in ['x86_64-nvidia_sn5600-r0', 'x86_64-nvidia_sn5640-r0']"
 
 generic_config_updater/test_eth_interface.py::test_replace_fec:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -885,20 +885,20 @@ dhcp_relay:
     conditions:
       - "release in ['202412']"
 
-dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress:
+dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress:
   xfail:
     reason: "7215 has low performance, and can only take low stress (about 5 pps)"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
 
-dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress[discover]:
+dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress[discover]:
   xfail:
     reason: "Need to skip for discover test cases on dualtor"
     conditions:
       - "'dualtor' in topo_name"
       - "https://github.com/sonic-net/sonic-mgmt/issues/19230"
 
-dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress[request]:
+dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress[request]:
   xfail:
     reason: "Need to skip for request test cases on dualtor"
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5239,6 +5239,7 @@ zmq/test_gnmi_zmq.py:
     conditions_logical_operator: or
     conditions:
       - "'arista' in platform"
+      - "'dualtor' in topo_name"
       - "'isolated' in topo_name"
 
 zmq/test_gnmi_zmq.py::test_gnmi_zmq:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -382,6 +382,15 @@ platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_spe
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 #######################################
+#####   test_liquid_cooling_leakage.py   #####
+#######################################
+platform_tests/api/test_liquid_cooling_leakage.py:
+  skip:
+    reason: "Liquid cooling leakage tests not applicable to m0, mx, m1, c0 topologies"
+    conditions:
+      - "topo_type in ['m0', 'mx', 'm1', 'c0']"
+
+#######################################
 ##### api/test_module.py #####
 #######################################
 platform_tests/api/test_module.py:
@@ -1241,6 +1250,15 @@ platform_tests/test_kdump.py:
     reason: "Not supported on Nokia-7215 platform"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+
+#######################################
+#####   test_liquid_cooling_leakage_detection.py   #####
+#######################################
+platform_tests/test_liquid_cooling_leakage_detection.py:
+  skip:
+    reason: "Liquid cooling leakage detection tests not applicable to m0, mx, m1, c0 topologies"
+    conditions:
+      - "topo_type in ['m0', 'mx', 'm1', 'c0']"
 
 #######################################
 ####  test_memory_exhaustion.py   #####

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -221,11 +221,11 @@ def sanity_check_full(ptfhost, prepare_parallel_run, localhost, duthosts, reques
         return
 
     skip_sanity = False
-    skip_pre_sanity = False
+    skip_pre_sanity = True
     allow_recover = False
     recover_method = "adaptive"
     pre_check_items = copy.deepcopy(SUPPORTED_CHECKS)  # Default check items
-    post_check = False
+    post_check = True
     nbr_hosts = None
 
     customized_sanity_check = None
@@ -239,7 +239,7 @@ def sanity_check_full(ptfhost, prepare_parallel_run, localhost, duthosts, reques
         logger.info("Process marker {} in script. m.args={}, m.kwargs={}"
                     .format(customized_sanity_check.name, customized_sanity_check.args, customized_sanity_check.kwargs))
         skip_sanity = customized_sanity_check.kwargs.get("skip_sanity", False)
-        skip_pre_sanity = customized_sanity_check.kwargs.get("skip_pre_sanity", False)
+        skip_pre_sanity = customized_sanity_check.kwargs.get("skip_pre_sanity", True)
         allow_recover = customized_sanity_check.kwargs.get("allow_recover", False)
         recover_method = customized_sanity_check.kwargs.get("recover_method", "adaptive")
         if allow_recover and recover_method not in constants.RECOVER_METHODS:
@@ -252,7 +252,7 @@ def sanity_check_full(ptfhost, prepare_parallel_run, localhost, duthosts, reques
             customized_sanity_check.kwargs.get("check_items", []),
             SUPPORTED_CHECKS)
 
-        post_check = customized_sanity_check.kwargs.get("post_check", False)
+        post_check = customized_sanity_check.kwargs.get("post_check", True)
 
     if skip_sanity:
         logger.info("Skip sanity check according to configuration of test script.")
@@ -261,6 +261,9 @@ def sanity_check_full(ptfhost, prepare_parallel_run, localhost, duthosts, reques
 
     if request.config.option.skip_pre_sanity:
         skip_pre_sanity = True
+
+    if request.config.option.enable_pre_sanity:
+        skip_pre_sanity = False
 
     if request.config.option.allow_recover:
         allow_recover = True
@@ -271,6 +274,9 @@ def sanity_check_full(ptfhost, prepare_parallel_run, localhost, duthosts, reques
 
     if request.config.option.post_check:
         post_check = True
+
+    if request.config.option.skip_post_check:
+        post_check = False
 
     if not request.config.option.enable_macsec:
         pre_check_items.remove("check_neighbor_macsec_empty")

--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -126,6 +126,8 @@ def swap_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
 
     if duthost.facts.get("platform_asic") == 'broadcom-dnx':
         docker_syncd_name = docker_syncd_name + "-dnx"
+    elif duthost.facts.get("platform_asic") == "broadcom-legacy-th":
+        docker_syncd_name = docker_syncd_name + "-legacy-th"
 
     docker_rpc_image = docker_syncd_name + "-rpc"
 
@@ -191,6 +193,8 @@ def restore_default_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
 
     if duthost.facts.get("platform_asic") == 'broadcom-dnx':
         docker_syncd_name = docker_syncd_name + "-dnx"
+    elif duthost.facts.get("platform_asic") == "broadcom-legacy-th":
+        docker_syncd_name = docker_syncd_name + "-legacy-th"
 
     for asic in asics_list:
         asic.stop_service("swss")

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1743,3 +1743,10 @@ def group_interfaces_by_asic(duthost, interfaces: list) -> dict:
         namespace = duthost.get_port_asic_instance(interface).get_asic_namespace()
         asic_interface_map["-n {}".format(namespace)].append(interface)
     return dict(asic_interface_map)
+
+
+def testbed_is_multi_vrf(tbinfo):
+    val = tbinfo.get('use_converged_peers')
+    if val:
+        return str(val).lower() == 'true'
+    return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,12 +205,16 @@ def pytest_addoption(parser):
                      help="Skip sanity check")
     parser.addoption("--skip_pre_sanity", action="store_true", default=False,
                      help="Skip pre-test sanity check")
+    parser.addoption("--enable_pre_sanity", action="store_true", default=False,
+                     help="Enable pre-test sanity check (override default skip)")
     parser.addoption("--allow_recover", action="store_true", default=False,
                      help="Allow recovery attempt in sanity check in case of failure")
     parser.addoption("--check_items", action="store", default=False,
                      help="Change (add|remove) check items in the check list")
     parser.addoption("--post_check", action="store_true", default=False,
                      help="Perform post test sanity check if sanity check is enabled")
+    parser.addoption("--skip_post_check", action="store_true", default=False,
+                     help="Skip post-test sanity check (override default enable)")
     parser.addoption("--post_check_items", action="store", default=False,
                      help="Change (add|remove) post test check items based on pre test check items")
     parser.addoption("--recover_method", action="store", default="adaptive",

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -5,7 +5,7 @@ import re
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
-from tests.common.dhcp_relay_utils import init_dhcpcom_relay_counters, validate_dhcpcom_relay_counters, \
+from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmon_counters, \
                                           validate_counters_and_pkts_consistency
 from tests.common.utilities import wait_until, capture_and_check_packet_on_dut
 from tests.dhcp_relay.dhcp_relay_utils import check_dhcp_stress_status
@@ -42,7 +42,7 @@ def ignore_expected_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
 
 
 @pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
-def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
+def test_dhcpmon_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
                                        testing_config, setup_standby_ports_on_rand_unselected_tor,
                                        toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
                                        dhcp_type, clean_processes_after_stress_test,
@@ -61,10 +61,10 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
     for dhcp_relay in dut_dhcp_relay_data:
         client_port_id = dhcp_relay['client_iface']['port_idx']
 
-        init_dhcpcom_relay_counters(duthost)
+        init_dhcpmon_counters(duthost)
         if testing_mode == DUAL_TOR_MODE:
             standby_duthost = rand_unselected_dut
-            init_dhcpcom_relay_counters(standby_duthost)
+            init_dhcpmon_counters(standby_duthost)
 
         params = {
             "hostname": duthost.hostname,
@@ -99,8 +99,8 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
             validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_dict,
                                                    error_in_percentage=error_margin)
             if testing_mode == DUAL_TOR_MODE:
-                validate_dhcpcom_relay_counters(dhcp_relay, standby_duthost,
-                                                {}, {}, 0)
+                validate_dhcpmon_counters(dhcp_relay, standby_duthost,
+                                          {}, {}, 0)
 
         def get_ip_link_result(duthost):
             # Get the output of 'ip link' command and parse it to a dictionary of index: name
@@ -129,7 +129,7 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
         ):
             ptf_runner(ptfhost, "ptftests", "dhcp_relay_stress_test.DHCPStress{}Test".format(dhcp_type.capitalize()),
                        platform_dir="ptftests", params=params,
-                       log_file="/tmp/test_dhcpcom_relay_counters_stress.DHCPStressTest.log",
+                       log_file="/tmp/test_dhcpmon_relay_counters_stress.DHCPStressTest.log",
                        qlen=100000, is_python3=True, async_mode=True)
             check_dhcp_stress_status(duthost, packets_send_duration)
             pytest_assert(wait_until(600, 2, 0, _check_count_file_exists), "{} is missing".format(count_file))

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -4,7 +4,7 @@ import time
 import logging
 import re
 
-from tests.common.dhcp_relay_utils import init_dhcpcom_relay_counters, validate_dhcpcom_relay_counters
+from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmon_counters
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
@@ -127,7 +127,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data)
             assert "{}:67".format(iface) in output, "{} is not found in {}".format("{}:67".format(iface), output)
 
 
-def start_dhcp_monitor_debug_counter(duthost):
+def restart_dhcpmon_in_debug(duthost):
     program_name = "dhcpmon"
     program_pid_list = []
     program_list = duthost.shell("ps aux | grep {}".format(program_name))
@@ -210,8 +210,8 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                 dhcp_server_num = len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
                 if testing_mode == DUAL_TOR_MODE:
                     standby_duthost = rand_unselected_dut
-                    start_dhcp_monitor_debug_counter(standby_duthost)
-                    init_dhcpcom_relay_counters(standby_duthost)
+                    restart_dhcpmon_in_debug(standby_duthost)
+                    init_dhcpmon_counters(standby_duthost)
                     expected_standby_agg_counter_message = (
                         r".*dhcp_relay#dhcpmon\[[0-9]+\]: "
                         r"\[\s*Agg-%s\s*-[\sA-Za-z0-9]+\s*rx/tx\] "
@@ -220,8 +220,8 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                     loganalyzer_standby = LogAnalyzer(ansible_host=standby_duthost, marker_prefix="dhcpmon counter")
                     marker_standby = loganalyzer_standby.init()
                     loganalyzer_standby.expect_regex = [expected_standby_agg_counter_message]
-                start_dhcp_monitor_debug_counter(duthost)
-                init_dhcpcom_relay_counters(duthost)
+                restart_dhcpmon_in_debug(duthost)
+                init_dhcpmon_counters(duthost)
                 if testing_mode == DUAL_TOR_MODE:
                     expected_agg_counter_message = (
                         r".*dhcp_relay#dhcpmon\[[0-9]+\]: "
@@ -271,8 +271,8 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                 if testing_mode == DUAL_TOR_MODE:
                     loganalyzer_standby.analyze(marker_standby)
                     dhcp_relay_request_times = 1
-                    # If the testing mode is DUAL_TOR_MODE, standby tor's dhcpcom relay counters should all be 0
-                    validate_dhcpcom_relay_counters(dhcp_relay, standby_duthost, {}, {})
+                    # If the testing mode is DUAL_TOR_MODE, standby tor's dhcpmon relay counters should all be 0
+                    validate_dhcpmon_counters(dhcp_relay, standby_duthost, {}, {})
                 expected_downlink_counter = {
                     "RX": {"Unknown": 1, "Discover": 1, "Request": dhcp_relay_request_times, "Bootp": 1,
                            "Decline": 1, "Release": 1, "Inform": 1},
@@ -284,9 +284,9 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                            "Request": dhcp_server_sum * dhcp_relay_request_times, "Inform": dhcp_server_sum,
                            "Decline": dhcp_server_sum, "Release": dhcp_server_sum}
                 }
-                validate_dhcpcom_relay_counters(dhcp_relay, duthost,
-                                                expected_uplink_counter,
-                                                expected_downlink_counter)
+                validate_dhcpmon_counters(dhcp_relay, duthost,
+                                          expected_uplink_counter,
+                                          expected_downlink_counter)
     except LogAnalyzerError as err:
         logger.error("Unable to find expected log in syslog")
         raise err
@@ -318,8 +318,8 @@ def test_dhcp_relay_with_source_port_ip_in_relay_enabled(ptfhost, dut_dhcp_relay
                 dhcp_server_num = len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
                 if testing_mode == DUAL_TOR_MODE:
                     standby_duthost = rand_unselected_dut
-                    start_dhcp_monitor_debug_counter(standby_duthost)
-                    init_dhcpcom_relay_counters(standby_duthost)
+                    restart_dhcpmon_in_debug(standby_duthost)
+                    init_dhcpmon_counters(standby_duthost)
                     expected_standby_agg_counter_message = (
                         r".*dhcp_relay#dhcpmon\[[0-9]+\]: "
                         r"\[\s*Agg-%s\s*-[\sA-Za-z0-9]+\s*rx/tx\] "
@@ -328,8 +328,8 @@ def test_dhcp_relay_with_source_port_ip_in_relay_enabled(ptfhost, dut_dhcp_relay
                     loganalyzer_standby = LogAnalyzer(ansible_host=standby_duthost, marker_prefix="dhcpmon counter")
                     marker_standby = loganalyzer_standby.init()
                     loganalyzer_standby.expect_regex = [expected_standby_agg_counter_message]
-                start_dhcp_monitor_debug_counter(duthost)
-                init_dhcpcom_relay_counters(duthost)
+                restart_dhcpmon_in_debug(duthost)
+                init_dhcpmon_counters(duthost)
                 if testing_mode == DUAL_TOR_MODE:
                     expected_agg_counter_message = (
                         r".*dhcp_relay#dhcpmon\[[0-9]+\]: "
@@ -381,8 +381,8 @@ def test_dhcp_relay_with_source_port_ip_in_relay_enabled(ptfhost, dut_dhcp_relay
                 if testing_mode == DUAL_TOR_MODE:
                     loganalyzer_standby.analyze(marker_standby)
                     dhcp_relay_request_times = 1
-                    # If the testing mode is DUAL_TOR_MODE, standby tor's dhcpcom relay counters should all be 0
-                    validate_dhcpcom_relay_counters(dhcp_relay, standby_duthost, {}, {})
+                    # If the testing mode is DUAL_TOR_MODE, standby tor's dhcpmon relay counters should all be 0
+                    validate_dhcpmon_counters(dhcp_relay, standby_duthost, {}, {})
                 expected_downlink_counter = {
                     "RX": {"Unknown": 1, "Discover": 1, "Request": dhcp_relay_request_times, "Bootp": 1,
                            "Decline": 1, "Release": 1, "Inform": 1},
@@ -394,9 +394,9 @@ def test_dhcp_relay_with_source_port_ip_in_relay_enabled(ptfhost, dut_dhcp_relay
                            "Request": dhcp_server_sum * dhcp_relay_request_times, "Inform": dhcp_server_sum,
                            "Decline": dhcp_server_sum, "Release": dhcp_server_sum}
                 }
-                validate_dhcpcom_relay_counters(dhcp_relay, duthost,
-                                                expected_uplink_counter,
-                                                expected_downlink_counter)
+                validate_dhcpmon_counters(dhcp_relay, duthost,
+                                          expected_uplink_counter,
+                                          expected_downlink_counter)
     except LogAnalyzerError as err:
         logger.error("Unable to find expected log in syslog")
         raise err
@@ -605,10 +605,10 @@ def test_dhcp_relay_monitor_checksum_validation(ptfhost, dut_dhcp_relay_data, va
         for dhcp_relay in dut_dhcp_relay_data:
             if testing_mode == DUAL_TOR_MODE:
                 standby_duthost = rand_unselected_dut
-                start_dhcp_monitor_debug_counter(standby_duthost)
-                init_dhcpcom_relay_counters(standby_duthost)
-            start_dhcp_monitor_debug_counter(duthost)
-            init_dhcpcom_relay_counters(duthost)
+                restart_dhcpmon_in_debug(standby_duthost)
+                init_dhcpmon_counters(standby_duthost)
+            restart_dhcpmon_in_debug(duthost)
+            init_dhcpmon_counters(duthost)
             # Run the DHCP relay test on the PTF host
             ptf_runner(ptfhost,
                        "ptftests",
@@ -637,17 +637,17 @@ def test_dhcp_relay_monitor_checksum_validation(ptfhost, dut_dhcp_relay_data, va
                        is_python3=True)
             time.sleep(36)      # dhcpmon debug counter prints every 18 seconds
             if testing_mode == DUAL_TOR_MODE:
-                # If the testing mode is DUAL_TOR_MODE, standby tor's dhcpcom relay counters should all be 0
-                validate_dhcpcom_relay_counters(dhcp_relay, standby_duthost, {}, {})
+                # If the testing mode is DUAL_TOR_MODE, standby tor's dhcpmon relay counters should all be 0
+                validate_dhcpmon_counters(dhcp_relay, standby_duthost, {}, {})
             expected_downlink_counter = {
                 "RX": {"Malformed": 4}
             }
             expected_uplink_counter = {
                 "RX": {"Malformed": 3}
             }
-            validate_dhcpcom_relay_counters(dhcp_relay, duthost,
-                                            expected_uplink_counter,
-                                            expected_downlink_counter)
+            validate_dhcpmon_counters(dhcp_relay, duthost,
+                                      expected_uplink_counter,
+                                      expected_downlink_counter)
     except LogAnalyzerError as err:
         logger.error("Unable to find expected log in syslog")
         raise err

--- a/tests/dut_console/test_idle_timeout.py
+++ b/tests/dut_console/test_idle_timeout.py
@@ -15,8 +15,8 @@ pytestmark = [
 ]
 
 
-def test_timeout(duthost_console, duthosts, enum_supervisor_dut_hostname):
-    duthost = duthosts[enum_supervisor_dut_hostname]
+def test_timeout(duthost_console, duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     logger.info("Get default session idle timeout")
     default_tmout = duthost_console.send_command('echo $TMOUT').strip().splitlines()[0].strip()
     pytest_assert(default_tmout == DEFAULT_TMOUT, "default timeout on dut is not {} seconds".format(DEFAULT_TMOUT))

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -687,10 +687,11 @@ def verify_mirror_packets_on_recircle_port(self, ptfadapter, setup, mirror_sessi
     # Number of packets to send
     packet_count = {"iteration-1": 10, "iteration-2": 50, "iteration-3": 100}
     for iteration, count in list(packet_count.items()):
+        pkts_sent = 0
         clear_queue_counters(duthost, asic_ns)
         for i in range(1, count + 1):
             logging.info("Sending packet {} to DUT for {}".format(i, iteration))
-            self.send_and_check_mirror_packets(
+            pkts_sent += self.send_and_check_mirror_packets(
                 setup,
                 mirror_session,
                 ptfadapter,
@@ -707,7 +708,7 @@ def verify_mirror_packets_on_recircle_port(self, ptfadapter, setup, mirror_sessi
         # Make sure mirrored packets are sent via specific queue configured
         for q in range(1, 8):
             if str(q) == queue:
-                assert wait_until(30, 1, 0, check_queue_counters, duthost, asic_ns, recircle_port, q, count), \
+                assert wait_until(30, 1, 0, check_queue_counters, duthost, asic_ns, recircle_port, q, pkts_sent), \
                     "Recircle port {} queue{} counter value is not same as packets sent".format(recircle_port, q)
             else:
                 assert (get_queue_counters(duthost, asic_ns, recircle_port, q) == 0)
@@ -1157,6 +1158,7 @@ class BaseEverflowTest(object):
                 src_port_metadata_map[dest_ports[0]] = (None, 2)
 
         # Loop through Source Port Set and send traffic on each source port of the set
+        num_pkts_sent = 0
         for src_port in src_port_set:
             expected_mirror_packet = BaseEverflowTest.get_expected_mirror_packet(mirror_session,
                                                                                  setup,
@@ -1171,6 +1173,7 @@ class BaseEverflowTest(object):
             if src_port_metadata_map[src_port][0]:
                 mirror_packet_sent[packet.Ether].dst = src_port_metadata_map[src_port][0]
             ptfadapter.dataplane.flush()
+            num_pkts_sent += 1
             testutils.send(ptfadapter, src_port, mirror_packet_sent)
 
             if expect_recv:
@@ -1181,7 +1184,7 @@ class BaseEverflowTest(object):
 
                 if isinstance(result, bool):
                     logging.info("Using dummy testutils to skip traffic test, skip following checks")
-                    return
+                    return num_pkts_sent
 
                 _, received_packet = result
                 logging.info("Received packet: %s", packet.Ether(received_packet).summary())
@@ -1230,6 +1233,8 @@ class BaseEverflowTest(object):
                               "Mirror payload does not match received packet")
             else:
                 testutils.verify_no_packet_any(ptfadapter, expected_mirror_packet, dest_ports)
+
+        return num_pkts_sent
 
     @staticmethod
     def copy_and_pad(pkt, asic_type, platform_asic, hwsku, multi_binding_acl=False):

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -486,6 +486,90 @@ def validate_mirror_session_up(duthost, session_name):
     return False
 
 
+def validate_acl_rule_rids(duthost):
+    """
+    Validate that the ACL rule RIDs are not empty.
+    For multi-ASIC DUTs, validates ACL rule RIDs in each frontend ASIC's ASIC_DB.
+
+    Args:
+        duthost: DUT host object
+
+    Returns:
+        bool: True if all ACL rule RIDs are valid in all frontend ASICs, False otherwise
+    """
+    # Get all frontend ASIC instances
+    if duthost.is_multi_asic:
+        asic_instances = [duthost.asic_instance(asic_id) for asic_id in duthost.get_frontend_asic_ids()]
+    else:
+        asic_instances = [duthost]
+
+    # Validate ACL rule RIDs in each ASIC
+    for asic in asic_instances:
+        asicdb = AsicDbCli(asic)
+        acl_entry_table = asicdb.dump("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        entry_vids = []
+        for key, value in acl_entry_table.items():
+            if 'SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS' in value['value'] or \
+               'SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_EGRESS' in value['value']:
+                # Extract OID from key format "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY:oid:0x8000000000abe"
+                oid = key.split(":")[-1] if "oid:" in key else None
+                if oid is not None:
+                    entry_vids.append(oid)
+
+        # Validate VIDs for this ASIC
+        if entry_vids:
+            vidtorid_table = asicdb.dump("VIDTORID")["VIDTORID"]["value"]
+            for vid in entry_vids:
+                vid = "oid:" + vid
+                if vid not in vidtorid_table or vidtorid_table[vid] is None:
+                    logging.error("ACL entry VID {} not found or has None RID in ASIC {}".format(
+                        vid, asic.asic_index if duthost.is_multi_asic else "single"))
+                    return False
+    return True
+
+
+def validate_acl_rules_in_asic_db(duthost):
+    """
+    Validate that the number of ACL rules in ASIC DB is the same as the number of ACL rules in CONFIG DB.
+    Also check that the ACL rule RIDs are not empty.
+    For multi-ASIC DUTs, validates ACL rules in each frontend ASIC's ASIC_DB and CONFIG_DB.
+
+    Args:
+        duthost: DUT host object
+
+    Returns:
+        bool: True if ACL rules count matches and RIDs are valid in all frontend ASICs, False otherwise
+    """
+    # Get all frontend ASIC instances
+    if duthost.is_multi_asic:
+        asic_instances = [duthost.asic_instance(asic_id) for asic_id in duthost.get_frontend_asic_ids()]
+    else:
+        asic_instances = [duthost]
+
+    # Validate ACL rules in each ASIC
+    for asic in asic_instances:
+        # Get namespace-specific command prefix
+        if duthost.is_multi_asic:
+            namespace = asic.get_asic_namespace()
+            config_cmd = "sonic-db-cli -n {} CONFIG_DB KEYS *ACL_RULE*".format(namespace)
+            asic_cmd = "sonic-db-cli -n {} ASIC_DB KEYS *SAI_OBJECT_TYPE_ACL_ENTRY*".format(namespace)
+        else:
+            config_cmd = "sonic-db-cli CONFIG_DB KEYS *ACL_RULE*"
+            asic_cmd = "sonic-db-cli ASIC_DB KEYS *SAI_OBJECT_TYPE_ACL_ENTRY*"
+
+        config_rules = asic.shell(config_cmd)['stdout_lines']
+        asic_rules = asic.shell(asic_cmd)['stdout_lines']
+
+        if len(config_rules) != len(asic_rules):
+            logging.error("ACL rules count mismatch in ASIC {}: CONFIG_DB={}, ASIC_DB={}".format(
+                asic.asic_index if duthost.is_multi_asic else "single",
+                len(config_rules), len(asic_rules)))
+            return False
+
+    # Validate ACL rule RIDs across all ASICs
+    return validate_acl_rule_rids(duthost)
+
+
 # TODO: This should be refactored to some common area of sonic-mgmt.
 def add_route(duthost, prefix, nexthop, namespace):
     """

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -282,6 +282,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             logger=logger
         )
 
+
+
     def test_everflow_basic_forwarding(self, setup_info, setup_mirror_session,              # noqa F811
                                        dest_port_type, ptfadapter, tbinfo, mux_config,      # noqa F811
                                        toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
@@ -310,7 +312,10 @@ class EverflowIPv4Tests(BaseEverflowTest):
         everflow_utils.add_route(remote_dut, session_prefixes[0], peer_ip,
                                  setup_info[dest_port_type]["remote_namespace"])
 
-        time.sleep(15)
+        pytest_assert(
+            wait_until(120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[0])
+        )
+        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
 
         # Verify that mirrored traffic is sent along the route we installed
         rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
@@ -355,7 +360,11 @@ class EverflowIPv4Tests(BaseEverflowTest):
         peer_ip = everflow_utils.get_neighbor_info(remote_dut, tx_port, tbinfo, ip_version=erspan_ip_ver)
         everflow_utils.add_route(remote_dut, session_prefixes[1], peer_ip,
                                  setup_info[dest_port_type]["remote_namespace"])
-        time.sleep(15)
+        pytest_assert(
+            wait_until(
+                120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[1]
+            )
+        )
 
         # Verify that mirrored traffic uses the new route
         tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][1]
@@ -374,7 +383,12 @@ class EverflowIPv4Tests(BaseEverflowTest):
         # Remove the better route.
         everflow_utils.remove_route(remote_dut, session_prefixes[1], peer_ip,
                                     setup_info[dest_port_type]["remote_namespace"])
-        time.sleep(15)
+        pytest_assert(
+            wait_until(
+                120, 10, 0,
+                lambda: not everflow_utils.validate_asic_route(remote_dut, session_prefixes[1])
+            )
+        )
 
         # Verify that mirrored traffic switches back to the original route
         tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
@@ -411,7 +425,10 @@ class EverflowIPv4Tests(BaseEverflowTest):
             else setup_mirror_session["session_prefixes_ipv6"]
         everflow_utils.add_route(remote_dut, session_prefixes[0], peer_ip,
                                  setup_info[dest_port_type]["remote_namespace"])
-        time.sleep(15)
+        pytest_assert(
+            wait_until(120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[0])
+        )
+        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
 
         # Verify that mirrored traffic is sent along the route we installed
         rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
@@ -490,7 +507,10 @@ class EverflowIPv4Tests(BaseEverflowTest):
             else setup_mirror_session["session_prefixes_ipv6"]
         everflow_utils.add_route(remote_dut, session_prefixes[0], peer_ip_0,
                                  setup_info[dest_port_type]["remote_namespace"])
-        time.sleep(15)
+        pytest_assert(
+            wait_until(120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[0])
+        )
+        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
 
         tx_port = setup_info[dest_port_type]["dest_port"][1]
         peer_ip_1 = everflow_utils.get_neighbor_info(remote_dut, tx_port, tbinfo, ip_version=erspan_ip_ver)
@@ -601,7 +621,10 @@ class EverflowIPv4Tests(BaseEverflowTest):
             else setup_mirror_session["session_prefixes_ipv6"]
         everflow_utils.add_route(remote_dut, session_prefixes[0], peer_ip_0,
                                  setup_info[dest_port_type]["remote_namespace"])
-        time.sleep(15)
+        pytest_assert(
+            wait_until(120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[0])
+        )
+        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
 
         # Verify that mirrored traffic is sent along the route we installed
         rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
@@ -795,6 +818,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                        config_method,
                                        rules=EVERFLOW_DSCP_RULES)
 
+            pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
+
             # Run test with expected CIR/CBS in packets/sec and tolerance %
             partial_ptf_runner(setup_info,
                                dest_port_type,
@@ -847,7 +872,10 @@ class EverflowIPv4Tests(BaseEverflowTest):
         everflow_utils.add_route(remote_dut, session_prefixes[0], peer_ip,
                                  setup_info[dest_port_type]["remote_namespace"])
 
-        time.sleep(15)
+        pytest_assert(
+            wait_until(120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[0])
+        )
+        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, everflow_dut))
 
         # Verify that mirrored traffic is sent along the route we installed
         rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
@@ -954,7 +982,11 @@ class EverflowIPv4Tests(BaseEverflowTest):
             peer_ip = everflow_utils.get_neighbor_info(remote_dut, tx_port, tbinfo, ip_version=erspan_ip_ver)
             everflow_utils.add_route(remote_dut, session_prefixes[1], peer_ip,
                                      setup_info[dest_port_type]["remote_namespace"])
-            time.sleep(15)
+            pytest_assert(
+                wait_until(
+                    120, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[1]
+                )
+            )
             background_traffic(run_count=1)
             # Verify that mirrored traffic uses the new route
             tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][1]
@@ -973,7 +1005,12 @@ class EverflowIPv4Tests(BaseEverflowTest):
             # Remove the better route.
             everflow_utils.remove_route(remote_dut, session_prefixes[1], peer_ip,
                                         setup_info[dest_port_type]["remote_namespace"])
-            time.sleep(15)
+            pytest_assert(
+                wait_until(
+                    120, 10, 0,
+                    lambda: not everflow_utils.validate_asic_route(remote_dut, session_prefixes[1])
+                )
+            )
             background_traffic(run_count=1)
             # Verify that mirrored traffic switches back to the original route
             tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
@@ -1082,7 +1119,13 @@ class EverflowIPv4Tests(BaseEverflowTest):
         everflow_utils.add_route(remote_dut, setup_mirror_session["session_prefixes"][0], peer_ip,
                                  setup_info[dest_port_type]["remote_namespace"])
 
-        time.sleep(15)
+        pytest_assert(
+            wait_until(
+                120, 10, 0,
+                everflow_utils.validate_asic_route, remote_dut, setup_mirror_session["session_prefixes"][0]
+            )
+        )
+        pytest_assert(wait_until(120, 10, 0, everflow_utils.validate_acl_rules_in_asic_db, remote_dut))
 
         # Verify that mirrored traffic is sent along the route we installed
         rx_port_ptf_id = setup_info[dest_port_type]["src_port_ptf_id"]
@@ -1116,6 +1159,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             remote_dut.shell(remote_dut.get_vtysh_cmd_for_namespace(
                 "vtysh -c \"configure terminal\" -c \"ip nht resolve-via-default\"",
                 setup_info[dest_port_type]["remote_namespace"]))
+            everflow_utils.remove_route(remote_dut, setup_mirror_session["session_prefixes"][0],
+                                        peer_ip, setup_info[dest_port_type]["remote_namespace"])
 
     def _run_everflow_test_scenarios(self, ptfadapter, setup, mux_config, mirror_session, duthost, rx_port,  # noqa F811
                                      tx_ports, direction, expect_recv=True, valid_across_namespace=True,

--- a/tests/generic_config_updater/test_bgp_prefix.py
+++ b/tests/generic_config_updater/test_bgp_prefix.py
@@ -174,8 +174,8 @@ def bgp_prefix_tc1_xfail(duthost, community_table, namespace=None):
             delete_tmpfile(duthost, tmpfile)
 
 
-def check_bgp_prefix_config(duthost, community, cli_namespace_prefix):
-    """ Check bgp prefix config
+def check_bgp_prefix_config_replace(duthost, community, cli_namespace_prefix):
+    """ Check bgp prefix config for replace op
     """
     try:
         bgp_config = show_bgp_running_config(duthost, cli_namespace_prefix)
@@ -222,11 +222,31 @@ def bgp_prefix_tc1_replace(duthost, community, community_table, cli_namespace_pr
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost, output)
 
-        pytest_assert(wait_until(60, 5, 0, check_bgp_prefix_config, duthost, community, cli_namespace_prefix),
+        pytest_assert(wait_until(60, 5, 0, check_bgp_prefix_config_replace, duthost, community, cli_namespace_prefix),
                       "BGP prefix configuration not updated successfully")
 
     finally:
         delete_tmpfile(duthost, tmpfile)
+
+
+def check_bgp_prefix_config_remove(duthost, community, cli_namespace_prefix):
+    """ Check bgp prefix config for remove op
+    """
+    try:
+        bgp_config = show_bgp_running_config(duthost, cli_namespace_prefix)
+        ipv4_removed = not re.search(PREFIXES_V4_RE.format(community, PREFIXES_V4_DUMMY), bgp_config)
+        ipv6_removed = not re.search(PREFIXES_V6_RE.format(community, PREFIXES_V6_DUMMY), bgp_config)
+
+        if ipv4_removed and ipv6_removed:
+            logger.info("BGP prefix configuration updated successfully")
+            return True
+        else:
+            logger.error(f"BGP prefix configuration not ready yet - IPv4: ipv4_removed={ipv4_removed}, "
+                         f"IPv6: ipv6_removed={ipv6_removed}, ")
+            return False
+    except Exception as e:
+        logger.error(f"Error checking bgp prefix configuration: {e}")
+        return False
 
 
 def bgp_prefix_tc1_remove(duthost, community, cli_namespace_prefix, namespace=None):
@@ -248,15 +268,8 @@ def bgp_prefix_tc1_remove(duthost, community, cli_namespace_prefix, namespace=No
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         expect_op_success(duthost, output)
 
-        bgp_config = show_bgp_running_config(duthost, cli_namespace_prefix)
-        pytest_assert(
-            not re.search(PREFIXES_V4_RE.format(community, PREFIXES_V4_DUMMY), bgp_config),
-            "Failed to remove bgp prefix v4 config."
-        )
-        pytest_assert(
-            not re.search(PREFIXES_V6_RE.format(community, PREFIXES_V6_DUMMY), bgp_config),
-            "Failed to remove bgp prefix v6 config."
-        )
+        pytest_assert(wait_until(60, 5, 0, check_bgp_prefix_config_remove, duthost, community, cli_namespace_prefix),
+                      "BGP prefix configuration not updated successfully")
 
     finally:
         delete_tmpfile(duthost, tmpfile)

--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -8,11 +8,10 @@ import pytest
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import verify_orchagent_running_or_assert
-from tests.common.gu_utils import apply_patch, expect_op_success, expect_op_failure
+from tests.common.gu_utils import apply_patch, expect_op_success
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import format_json_patch_for_multiasic
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
-from tests.common.gu_utils import is_valid_platform_and_version
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -143,6 +142,61 @@ def get_wred_profiles(duthost, cli_namespace_prefix):
     return [w for w in wred_profiles.split('\n') if w]
 
 
+# Determines how the value of each field should change to satisfy different constraints (explained below).
+def determine_delta_values(ecn_data, fields):
+    # Extra care should be taken when changing "green_min_threshold" and "green_max_threshold". "green_min_threshold"
+    # must always be less than or equal to "green_max_threshold". Also, "green_max_threshold" must be less than
+    # the available buffer pool size. Note that some platforms (e.g., Mellanox) round-up the value of
+    # "green_max_threshold" if it is not provided as a multiple of a certain number in the config. The rounded-up
+    # value must still be less than the buffer pool size. So to avoid potential issues, we never attempt to increase
+    # "green_max_threshold".
+    delta = {"green_min_threshold": 0, "green_max_threshold": 0, "green_drop_probability": 0}
+
+    min_threshold = int(ecn_data["green_min_threshold"])
+    max_threshold = int(ecn_data["green_max_threshold"])
+    assert 0 <= min_threshold <= max_threshold, \
+        f"Invalid thresholds: green_min_threshold={min_threshold}, green_max_threshold={max_threshold}"
+    if "green_min_threshold" in fields and "green_max_threshold" in fields:
+        # Both fields are being updated.
+        if min_threshold > 0:
+            delta["green_min_threshold"] = -1
+            delta["green_max_threshold"] = -1
+        else:  # min_threshold == 0
+            if max_threshold - min_threshold >= 2:
+                delta["green_min_threshold"] = 1
+                delta["green_max_threshold"] = -1
+            elif max_threshold > min_threshold:  # min_threshold == 0, max_threshold == 1
+                delta["green_min_threshold"] = 0
+                delta["green_max_threshold"] = -1
+            else:  # min_threshold == max_threshold == 0
+                delta["green_min_threshold"] = 0
+                delta["green_max_threshold"] = 0
+    elif "green_max_threshold" in fields:
+        # Only "green_max_threshold" is being updated.
+        if max_threshold > min_threshold:
+            delta["green_max_threshold"] = -1
+        else:  # max_threshold == min_threshold
+            delta["green_max_threshold"] = 0
+    elif "green_min_threshold" in fields:
+        # Only "green_min_threshold" is being updated.
+        if min_threshold > 0:
+            delta["green_min_threshold"] = -1
+        else:  # min_threshold == 0
+            if min_threshold < max_threshold:
+                delta["green_min_threshold"] = 1
+            else:
+                delta["green_min_threshold"] = 0
+
+    if "green_drop_probability" in fields:
+        probability = int(ecn_data["green_drop_probability"])
+        assert 0 <= probability <= 100, f"Invalid green_drop_probability value: {probability}"
+        if 0 <= probability < 99:
+            delta["green_drop_probability"] = 1
+        else:  # probability == 100 or probability == 99
+            delta["green_drop_probability"] = -1
+    return delta
+
+
 @pytest.mark.parametrize("configdb_field", ["green_min_threshold", "green_max_threshold", "green_drop_probability",
                          "green_min_threshold,green_max_threshold,green_drop_probability"])
 @pytest.mark.parametrize("operation", ["replace"])
@@ -166,20 +220,14 @@ def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, opera
         ecn_data = duthost.shell("sonic-db-cli {} CONFIG_DB hgetall 'WRED_PROFILE|{}'"
                                  .format(cli_namespace_prefix, wred_profile))['stdout']
         ecn_data = ast.literal_eval(ecn_data)
+        delta = determine_delta_values(ecn_data, fields)
+        if all(delta[f] == 0 for f in fields):
+            logger.info(f"Skipping WRED profile {wred_profile}: all deltas are 0, no real value change possible.")
+            continue
         new_values[wred_profile] = {}
         for field in fields:
             value = int(ecn_data[field])
-            if "probability" in field:
-                if 0 <= value < 99:
-                    value += 1
-                elif value >= 99:
-                    value -= 1
-                else:
-                    raise ValueError("Invalid probability value: {}".format(value))
-            elif "min" in field:
-                value -= 1
-            else:
-                value += 1
+            value += delta[field]
             new_values[wred_profile][field] = value
 
             logger.info("value to be added to json patch: {}, operation: {}, field: {}"
@@ -190,14 +238,14 @@ def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, opera
                                "path": f"/WRED_PROFILE/{wred_profile}/{field}",
                                "value": "{}".format(value)})
 
+    if not json_patch:
+        pytest.skip("All WRED profiles have zero deltas for the requested fields, skipping test.")
+
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
                                                  is_asic_specific=True, asic_namespaces=[namespace])
     try:
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
-        if is_valid_platform_and_version(duthost, "WRED_PROFILE", "ECN tuning", operation):
-            expect_op_success(duthost, output)
-            ensure_application_of_updated_config(duthost, fields, new_values, cli_namespace_prefix)
-        else:
-            expect_op_failure(output)
+        expect_op_success(duthost, output)
+        ensure_application_of_updated_config(duthost, fields, new_values, cli_namespace_prefix)
     finally:
         delete_tmpfile(duthost, tmpfile)

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 from tests.common.devices.base import AnsibleHostBase
 from tests.common.platform.device_utils import fanout_switch_port_lookup
-from tests.common.utilities import wait, wait_until
+from tests.common.utilities import testbed_is_multi_vrf, wait, wait_until
 from netaddr import IPAddress
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.sonic_db import SonicDbCli
@@ -115,7 +115,7 @@ def setup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo):
     physical_interfaces = [item for item in up_ports if item not in portchannel_members]
 
     multi_vrf_info = None
-    if tbinfo.get('use_converged_peers', False):
+    if testbed_is_multi_vrf(tbinfo):
         multi_vrf_info = deepcopy(tbinfo['topo']['properties']['convergence_data'])
 
     setup_info = {

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -108,7 +108,9 @@ def get_lldpctl_output(duthost):
 def get_show_lldp_table_output(duthost):
     lines = duthost.shell("show lldp table")["stdout"].split("\n")[3:-2]
     interface_list = [line.split()[0] for line in lines]
-    return interface_list
+    # Deduplicate: in dualtor topology, uplink ports may have multiple
+    # LLDP neighbors (T1 switch + fanout), causing duplicate interface entries
+    return list(dict.fromkeys(interface_list))
 
 
 def get_lldp_data(duthost, db_instance):
@@ -123,7 +125,7 @@ def check_lldp_table_keys(duthost, db_instance):
     # Check if LLDP_ENTRY_TABLE keys match show lldp table output
     lldp_entry_keys = get_lldp_entry_keys(db_instance)
     show_lldp_table_int_list = get_show_lldp_table_output(duthost)
-    return sorted(lldp_entry_keys) == sorted(show_lldp_table_int_list)
+    return set(lldp_entry_keys) == set(show_lldp_table_int_list)
 
 
 def _shutdown_startup_interface(duthost, interface, asic_str=""):
@@ -192,9 +194,14 @@ def assert_lldp_interfaces(
     """
     Assert that LLDP_ENTRY_TABLE keys match show lldp table output and lldpctl output
     """
+    db_set = set(lldp_entry_keys)
+    cli_set = set(show_lldp_table_int_list)
     pytest_assert(
-        sorted(lldp_entry_keys) == sorted(show_lldp_table_int_list),
-        "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output",
+        db_set == cli_set,
+        "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output. "
+        "In DB but not in CLI: {}. In CLI but not in DB: {}".format(
+            db_set - cli_set, cli_set - db_set
+        ),
     )
 
     # Verify LLDP_ENTRY_TABLE keys match lldpctl interface indexes

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2449,15 +2449,24 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # & may give inconsistent test results
             # Adding COUNTER_MARGIN to provide room to 2 pkt incase, extra traffic received
             for cntr in ingress_counters:
-                if (platform_asic and
-                        platform_asic in ["broadcom-dnx", "marvell-teralynx"]):
-                    qos_test_assert(
-                        self, recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN,
-                        'unexpectedly RX drop counter increase, {}'.format(test_stage))
-                else:
-                    qos_test_assert(
-                        self, recv_counters[cntr] == recv_counters_base[cntr],
-                        'unexpectedly RX drop counter increase, {}'.format(test_stage))
+                dnx_asics = ["broadcom-dnx", "marvell-teralynx"]
+                counter_margin = COUNTER_MARGIN if (
+                    platform_asic and platform_asic in dnx_asics) else 0
+                # Check if ingress drop is caused by environmental non-unicast noise
+                if not ignore_ingress_drop_caused_by_nonunicast_noise(
+                        self.src_client, port_list['src'][src_port_id],
+                        recv_counters, recv_counters_base, cntr,
+                        counter_margin=counter_margin):
+                    # Legitimate ingress drop, should fail test
+                    if (platform_asic and
+                            platform_asic in ["broadcom-dnx", "marvell-teralynx"]):
+                        qos_test_assert(
+                            self, recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN,
+                            'unexpectedly RX drop counter increase, {}'.format(test_stage))
+                    else:
+                        qos_test_assert(
+                            self, recv_counters[cntr] == recv_counters_base[cntr],
+                            'unexpectedly RX drop counter increase, {}'.format(test_stage))
             # xmit port no egress drop
             for cntr in egress_counters:
                 qos_test_assert(

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -659,13 +659,14 @@ class TestAgentId():
 class TestReboot():
 
     def testRebootSflowEnable(self, sflowbase_config, config_sflow_agent, duthost,
-                              localhost, partial_ptf_runner, ptfhost):
+                              force_active_tor, localhost, partial_ptf_runner, ptfhost):
         duthost.command("config sflow polling-interval 80")
         verify_show_sflow(duthost, status='up', polling_int=80)
         duthost.command('sudo config save -y')
         reboot(duthost, localhost)
         assert wait_until(
             300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        force_active_tor(duthost, "all")
         assert wait_until(60, 5, 0, verify_sflow_config_apply, duthost)
         verify_show_sflow(duthost, status='up', collector=[
                           'collector0', 'collector1'], polling_int=80)
@@ -684,7 +685,8 @@ class TestReboot():
             polling_int=80,
             active_collectors="['collector0','collector1']")
 
-    def testRebootSflowDisable(self, sflowbase_config, duthost, localhost, partial_ptf_runner, ptfhost):
+    def testRebootSflowDisable(self, sflowbase_config, duthost, force_active_tor,
+                               localhost, partial_ptf_runner, ptfhost):
         config_sflow(duthost, sflow_status='disable')
         verify_show_sflow(duthost, status='down')
         partial_ptf_runner(
@@ -694,6 +696,7 @@ class TestReboot():
         reboot(duthost, localhost)
         assert wait_until(
             300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        force_active_tor(duthost, "all")
         verify_show_sflow(duthost, status='down')
         for intf in var['sflow_ports']:
             var['sflow_ports'][intf]['ifindex'] = get_ifindex(duthost, intf)

--- a/tests/telemetry/test_telemetry_poll.py
+++ b/tests/telemetry/test_telemetry_poll.py
@@ -143,7 +143,7 @@ def test_poll_mode_delete(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
                               xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
-                              max_sync_count=6, update_count=0, timeout=30, namespace=namespace)
+                              max_sync_count=15, update_count=0, timeout=30, namespace=namespace)
 
     def callback(show_gnmi_out):
         result = str(show_gnmi_out)

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -24,7 +24,8 @@ pytestmark = [
     pytest.mark.pretest,
     pytest.mark.topology('util', 'any'),
     pytest.mark.disable_loganalyzer,
-    pytest.mark.skip_check_dut_health
+    pytest.mark.skip_check_dut_health,
+    pytest.mark.sanity_check(skip_pre_sanity=False)
 ]
 
 


### PR DESCRIPTION
```n* 447cd292d - [sonic-mgmt][dualtor] Fix sflow/test_sflow.py reboot testcase failures (#23474) (2026-04-01 20:35:16 +0530) [vkjammala-arista]
* 187df7489 - Add non-unicast noise filter to missed check points in PFCtest and LossyQueueTest (#23378) (#23516) (2026-04-01 19:30:21 +0800) [mssonicbld]
* 08c269d77 - [gcu][ecn] Fix test_ecn_config_updates after GCU WRED validator removal (#23502) (2026-04-01 17:27:50 +0800) [Zhaohui Sun]
* e2e694897 - Skip test_gnmi_zmq on dualtor (#22992) (#23509) (2026-04-01 16:02:32 +0800) [mssonicbld]
* 27c1546ac - [LA] Add LA ignore for 'auditd queue full reporting limit reached' message (#19491) (#23399) (2026-04-01 14:12:16 +0800) [mssonicbld]
* 9638e39dc - Fix `Ethernet-Rec0` counter expectation in Everflow Test (#21942) (#23480) (2026-04-01 14:12:11 +0800) [mssonicbld]
* 4097f92a6 - copp: fix DHCPTopoT1Test false failure from background traffic (#23403) (#23503) (2026-04-01 14:12:01 +0800) [mssonicbld]
* 9a5c1cbcb - Add `wait_until` to `bgp_prefix_tc1_remove` (#22240) (#23482) (2026-04-01 11:51:09 +0800) [mssonicbld]
* 1310012af - Add Arista 7280DR3A* and 7280R4K* SKUs in sku-sensors-data.yml (#22477) (#23483) (2026-04-01 11:51:06 +0800) [mssonicbld]
* 0b320006a - Skip liquid cooling leakage tests on m0, mx, m1, c0 topologies (#23462) (#23473) (2026-04-01 07:01:42 +0800) [mssonicbld]
* c18c3f27f - [202511] Backport #21817 to 202511 (#23349) (2026-03-31 09:40:05 -0700) [Ashutosh Agrawal]
* 27492ef69 - Validate ACL rules and routes in test_everflow_testbed before traffic tests [202511 backport] (#23427) (2026-03-31 09:36:50 -0700) [Venu]
* dee53ff6c - [202511] Skip reliable_tsa tests on single-asic voq systems (#23444) (2026-03-31 12:35:54 -0400) [arista-nwolfe]
* 4b7e16cff - Fix syncd swap image name for broadcom-legacy-th (7060) platform (#23449) (#23469) (2026-03-31 22:09:33 +0800) [mssonicbld]
* cd330bee0 - The value of "use_converged_peers" for testbed multi-vrf can now be a boolean, string, or missing. Add a new utility to (#22472) (#23451) (2026-03-31 19:27:50 +0800) [mssonicbld]
* e34a1a733 - Fix LACP channel-group assignment in ceos_topo_converger for converged peers (#22527) (#23454) (2026-03-31 19:27:47 +0800) [mssonicbld]
* e64b30c64 - Make ceos_topo_converger idempotent for already-converged topologies (#22528) (#23455) (2026-03-31 19:27:43 +0800) [mssonicbld]
* 4db0051eb - Sync setup-container.sh from master branch (#23414) (2026-03-31 18:48:22 +0800) [Xin Wang - Bot]
* 514b9d802 - Change sanity check defaults: skip pre-sanity, enable post-sanity (#23260) (#23433) (2026-03-31 05:10:48 +0800) [mssonicbld]
* 94cd5ec5a - [dut_console] Fix fixture conflict in test_idle_timeout (#23201) (#23434) (2026-03-31 03:34:11 +0800) [mssonicbld]
* 0bde744e0 - [lldp] Fix LLDP_ENTRY_TABLE key comparison for dualtor topology (#23193) (#23435) (2026-03-31 03:34:08 +0800) [mssonicbld]
* a23bad30c - Increasing max sync count (#23384) (#23436) (2026-03-31 03:34:05 +0800) [mssonicbld]
* 02a178a9b - [MVRF] All 3 Test cases under TestReboot class are failing. (#19883) (#23386) (2026-03-31 01:29:33 +0800) [mssonicbld]
* 717d93977 - fix(console): skip extra newline after username in login_stage_2() (#23295) (#23362) (2026-03-30 17:56:29 +0800) [mssonicbld]
```n