### PR TITLE
[202603] C8220TG: Adding new threshold values for Arctos platform. (#23477)

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -4,7 +4,8 @@
     "Mellanox-SN4600C": ["Mellanox-SN4600C-C64"],
     "Arista-7060X6": ["Arista-7060X6-64PE-B-C512S2", "Arista-7060X6-64PE-B-C448O16", "Arista-7060X6-16PE-384C-B-O128S2", "Arista-7060X6-64PE-B-O128"],
     "Mellanox-SN5640": ["Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512S2"],
-    "Arista-7260CX3": ["Arista-7260CX3-C64", "Arista-7260CX3-D108C8", "Arista-7260CX3-D108C10"]
+    "Arista-7260CX3": ["Arista-7260CX3-C64", "Arista-7260CX3-D108C8", "Arista-7260CX3-D108C10"],
+    "Cisco-C8220TG": ["Cisco-C8220TG-48A-O"]
   },
   "COMMON": [
     {
@@ -315,6 +316,25 @@
         }
       },
       "memory_check": "parse_docker_stats_output"
+    }
+  ],
+  "Cisco-C8220TG": [
+    {
+      "name": "monit",
+      "cmd": "sudo monit validate",
+      "memory_params": {
+        "memory_usage": {
+          "memory_increase_threshold": {
+            "type": "percentage_points",
+            "value": 10
+          },
+          "memory_high_threshold": {
+            "type": "percentage_points",
+            "value": 75
+          }
+        }
+      },
+      "memory_check": "parse_monit_validate_output"
     }
   ]
 }


### PR DESCRIPTION
What is the motivation for this PR?
The monit code in common teardown keeps raising redflag for memory usage of more than 70% in C8220TG platform during console test runs.

How did you do it?
I have added new threshold for memory usage check for C8220TG platform.

How did you verify/test it?
Ran it in my c0-LO dut, the failures below are not related to this PR.