### PR TITLE
[202506] Backport sonic mgmt tests from upstream/master

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/vxlan_ecmp_ptftest.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan_ecmp_ptftest.py
@@ -1,0 +1,280 @@
+# ptftests/vxlan_ecmp_ptftest.py
+from datetime import datetime
+import time
+import json
+import os
+import scapy.all as scapy
+import ptf
+import logging
+from ptf.mask import Mask
+from ptf.base_tests import BaseTest
+from ptf.testutils import (
+    simple_tcp_packet,
+    simple_vxlan_packet,
+    send_packet,
+    test_params_get,
+    dp_poll
+)
+
+logger = logging.getLogger(__name__)
+
+
+class VxlanEcmpTest(BaseTest):
+    """
+    Generic VXLAN ECMP PTF test:
+      - Takes 'endpoints', 'dst_ip', 'src_ip', 'dut_vtep', 'router_mac', 'num_packets'
+      - Sends packets toward DUT
+      - Captures VXLAN packets and verifies each endpoint is used
+    """
+
+    def setUp(self):
+        self.dataplane = ptf.dataplane_instance
+        params = test_params_get()
+        if "params_file" in params:
+            with open(params["params_file"], "r") as f:
+                params = json.load(f)
+
+        if "endpoints_file" in params and os.path.exists(params["endpoints_file"]):
+            with open(params["endpoints_file"], "r") as f:
+                self.endpoints = json.load(f)
+        else:
+            self.endpoints = params.get("endpoints", [])
+
+        if "macs_file" in params and os.path.exists(params["macs_file"]):
+            with open(params["macs_file"], "r") as f:
+                self.mac_list = json.load(f)
+        else:
+            self.mac_list = params.get("mac_address", [])
+
+        self.dst_ip = params.get("dst_ip")
+        self.src_ip = params.get("ptf_src_ip")
+        self.dut_vtep = params.get("dut_vtep")
+        self.router_mac = params.get("router_mac")
+        self.num_packets = int(params.get("num_packets", 6))
+        self.vxlan_port = int(params.get("vxlan_port", 4789))
+        self.send_port = int(params.get("ptf_ingress_port", 0))
+        self.mac_vni_verify = params.get("mac_vni_verify", "") == "yes"
+        self.vni = params.get("vni")
+        self.deleted_endpoints = params.get("deleted_endpoints", [])
+        self.modified_mac_index = params.get("modified_mac_index")
+        self.modified_mac_value = params.get("modified_mac_value")
+        self.random_mac = "00:aa:bb:cc:dd:ee"
+        self.tcp_sport = 1234
+        self.tcp_dport = 5000
+        self.batch_size = 200
+
+        self.dataplane.flush()
+
+        self.all_ports = [p for (d, p) in self.dataplane.ports.keys() if d == 0]
+        logger.info(f"Discovered {len(self.all_ports)} PTF ports: {self.all_ports}")
+
+        logger.info("=== VXLAN ECMP PTF Test Setup ===")
+        logger.info(f"Endpoints: {len(self.endpoints)}")
+        logger.info(f"Destination IP: {self.dst_ip}, Source IP: {self.src_ip}")
+        logger.info(f"DUT VTEP: {self.dut_vtep}, Router MAC: {self.router_mac}")
+        logger.info(f"Packets to send: {self.num_packets}, Ingress port: {self.send_port}")
+        logger.info(f"VXLAN UDP Port: {self.vxlan_port}")
+        logger.info("=================================")
+
+    def _next_port(self, key="sport"):
+        """Simple port generator for varying TCP ports."""
+        if key == "sport":
+            self.tcp_sport = (self.tcp_sport + 1) % 65535 or 1234
+            return self.tcp_sport
+        else:
+            self.tcp_dport = (self.tcp_dport + 1) % 65535 or 5000
+            return self.tcp_dport
+
+    def _build_expected_for_index(self, idx, inner_pkt):
+        """
+        Build a masked VXLAN expected packet for endpoint[idx] with mac_list[idx].
+        """
+        endpoint = self.endpoints[idx]
+        programmed_mac = self.mac_list[idx]
+
+        # inner expected frame
+        inner_exp = inner_pkt.copy()
+        inner_exp[scapy.Ether].src = self.router_mac
+        inner_exp[scapy.Ether].dst = programmed_mac
+        inner_exp[scapy.IP].ttl = inner_exp[scapy.IP].ttl - 1
+
+        # outer VXLAN header
+        encap = simple_vxlan_packet(
+            eth_src=self.router_mac,
+            eth_dst=self.random_mac,
+            ip_src=self.dut_vtep,
+            ip_dst=endpoint,
+            ip_id=0,
+            ip_ttl=128,
+            udp_sport=12345,
+            udp_dport=self.vxlan_port,
+            with_udp_chksum=False,
+            vxlan_vni=self.vni,
+            inner_frame=inner_exp,
+        )
+        encap[scapy.IP].flags = 0x2
+
+        m = Mask(encap)
+        m.set_ignore_extra_bytes()
+        m.set_do_not_care_scapy(scapy.Ether, "src")
+        m.set_do_not_care_scapy(scapy.Ether, "dst")
+        m.set_do_not_care_scapy(scapy.IP, "ttl")
+        m.set_do_not_care_scapy(scapy.IP, "id")
+        m.set_do_not_care_scapy(scapy.IP, "chksum")
+        m.set_do_not_care_scapy(scapy.UDP, "sport")
+
+        return m
+
+    def verify_mac_vni_encap(self):
+        logger.info("=== MAC+VNI multi-endpoint ECMP validation ===")
+        src_mac = self.dataplane.get_mac(0, self.send_port)
+        endpoint_hits = {ep: 0 for ep in self.endpoints}
+        mismatch_count = 0
+        if self.modified_mac_index is not None:
+            self.mac_list[self.modified_mac_index] = self.modified_mac_value
+
+        for _ in range(self.num_packets):
+            sport = self._next_port("sport")
+            dport = self._next_port("dport")
+
+            inner = simple_tcp_packet(
+                eth_dst=self.router_mac,
+                eth_src=src_mac,
+                ip_dst=self.dst_ip,
+                ip_src=self.src_ip,
+                ip_id=105,
+                ip_ttl=64,
+                tcp_sport=sport,
+                tcp_dport=dport,
+                pktlen=100,
+            )
+
+            send_packet(self, self.send_port, inner)
+
+            # Poll for VXLAN packets
+            poll_start = datetime.now()
+            poll_timeout = 2
+            while (datetime.now() - poll_start).total_seconds() < poll_timeout:
+                res = dp_poll(self, timeout=2)
+                if not isinstance(res, self.dataplane.PollSuccess):
+                    continue
+
+                pkt = scapy.Ether(res.packet)
+                if scapy.IP not in pkt or scapy.UDP not in pkt:
+                    continue
+                if pkt[scapy.UDP].dport != self.vxlan_port:
+                    continue
+                outer_dst = pkt[scapy.IP].dst
+                if outer_dst not in self.endpoints:
+                    logger.error(f"Received VXLAN pkt to unexpected endpoint {outer_dst}")
+                    continue
+
+                idx = self.endpoints.index(outer_dst)
+                exp = self._build_expected_for_index(idx, inner)
+
+                if exp.pkt_match(pkt):
+                    endpoint_hits[outer_dst] += 1
+                    break
+                else:
+                    mismatch_count += 1
+                    logger.error(
+                        f"Packet mismatch for endpoint={outer_dst}, mac={self.mac_list[idx]}."
+                        f"\n\nExpected:\n{exp}\n\nReceived:\n{pkt}\n\n"
+                    )
+
+        logger.info(f"MAC+VNI Multi-endpoint validation counts: {endpoint_hits}")
+        if mismatch_count > 0:
+            raise AssertionError(f"{mismatch_count} packet(s) did NOT match expected MAC/VNI encapsulation")
+        used = [ep for ep, c in endpoint_hits.items() if c > 0]
+        if len(used) == 0:
+            raise AssertionError("NO endpoints used VXLAN not working")
+        if len(used) < len(self.endpoints):
+            missing = set(self.endpoints) - set(used)
+            raise AssertionError(f"Missing endpoint hits: {missing}")
+
+        logger.info("MAC+VNI multi-endpoint ECMP validation PASSED.")
+
+    def runTest(self):
+        if self.mac_vni_verify:
+            self.verify_mac_vni_encap()
+            return
+        counts = {}
+        src_mac = self.dataplane.get_mac(0, self.send_port)
+
+        total_sent = 0
+        logger.info(f"Starting VXLAN ECMP test: {self.num_packets} packets total, {self.batch_size} per batch")
+        logger.info(f"Source {self.src_ip} → Destination {self.dst_ip}, ingress port {self.send_port}")
+
+        # --- Send & capture in batches ---
+        while total_sent < self.num_packets:
+            send_now = min(self.batch_size, self.num_packets - total_sent)
+            logger.info(f"--- Sending batch {total_sent + 1} to {total_sent + send_now} ---")
+
+            # Send packets for this batch
+            for _ in range(send_now):
+                sport = self._next_port("sport")
+                dport = self._next_port("dport")
+                pkt = simple_tcp_packet(
+                    eth_dst=self.router_mac,
+                    eth_src=src_mac,
+                    ip_dst=self.dst_ip,
+                    ip_src=self.src_ip,
+                    ip_id=105,
+                    ip_ttl=64,
+                    tcp_sport=sport,
+                    tcp_dport=dport,
+                    pktlen=100,
+                )
+                send_packet(self, self.send_port, pkt)
+
+            total_sent += send_now
+            logger.info(f"Batch sent ({total_sent}/{self.num_packets}). Polling for VXLAN packets...")
+
+            # Poll for VXLAN packets from this batch
+            poll_start = datetime.now()
+            poll_timeout = 8  # seconds per batch
+            while (datetime.now() - poll_start).total_seconds() < poll_timeout:
+                res = dp_poll(self, timeout=2)
+                if not isinstance(res, self.dataplane.PollSuccess):
+                    continue
+
+                ether = scapy.Ether(res.packet)
+                if scapy.IP in ether and scapy.UDP in ether and ether[scapy.UDP].dport == self.vxlan_port:
+                    vtep_dst = ether[scapy.IP].dst
+                    if vtep_dst in self.endpoints:
+                        counts[vtep_dst] = counts.get(vtep_dst, 0) + 1
+                    if vtep_dst in self.deleted_endpoints:
+                        raise AssertionError(f"Received packet for deleted endpoint {vtep_dst}")
+
+            logger.info(f"Completed batch {total_sent}/{self.num_packets}.")
+            time.sleep(0.3)  # small pause before next burst
+
+        # --- Post-send validation ---
+        total_received = sum(counts.values())
+        logger.info(f"VXLAN packets received: {total_received} / {self.num_packets}")
+        logger.info(f"Endpoints hit: {len(counts)} / {len(self.endpoints)}")
+        logger.info(f"Count per endpoint : {counts}")
+
+        # --- Validation ---
+        if total_received == 0:
+            raise AssertionError("No VXLAN packets captured (tunnel not active or misconfigured)")
+
+        if total_received < self.num_packets:
+            drop_pct = 100.0 * (self.num_packets - total_received) / self.num_packets
+            raise AssertionError(
+                f"Packet loss detected: sent={self.num_packets}, received={total_received} ({drop_pct:.2f}% loss)"
+            )
+
+        missing = set(self.endpoints) - set(counts.keys())
+        if missing:
+            logger.error(f"Missing endpoints ({len(missing)}): {sorted(list(missing))[:10]} ...")
+            raise AssertionError(f"Endpoints not used in ECMP: {len(missing)}")
+
+        logger.info(
+            f"VXLAN ECMP test passed: all {len(self.endpoints)} endpoints hit, "
+            f"{total_received}/{self.num_packets} packets received, no loss."
+        )
+
+    def tearDown(self):
+        self.dataplane.flush()
+        logger.info("Dataplane flushed VXLAN ECMP test complete")

--- a/ansible/roles/test/files/ptftests/py3/vxlan_traffic_scale.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan_traffic_scale.py
@@ -1,0 +1,231 @@
+import json
+import ptf
+from ptf.base_tests import BaseTest
+from ptf.mask import Mask
+import logging
+import ptf.packet as scapy
+from ptf.testutils import (
+    simple_tcp_packet,
+    simple_vxlan_packet,
+    verify_packet_any_port,
+    send_packet,
+    test_params_get,
+)
+
+
+class VXLANScaleTest(BaseTest):
+    """
+    Scaled VXLAN route verification test.
+    Builds TCP packets per sampled /32 route per VNET and verifies
+    VXLAN-encapsulated packets egress on any of the expected uplink ports.
+    """
+
+    def setUp(self):
+        self.dataplane = ptf.dataplane_instance
+        self.test_params = test_params_get()
+
+        self.dut_vtep = self.test_params["dut_vtep"]
+        self.vnet_base = int(self.test_params["vnet_base"])
+        self.num_vnets = int(self.test_params["num_vnets"])
+        self.routes_per_vnet = int(self.test_params["routes_per_vnet"])
+        self.samples_per_vnet = int(self.test_params.get("samples_per_vnet", -1))
+        self.vnet_ptf_map = self.test_params["vnet_ptf_map"]
+        self.mac_vni_per_vnet = self.test_params.get("mac_vni_per_vnet", "")
+        self.routes_per_vni = self.test_params.get("vni_batch_size", 1000)
+        self.routes_to_test_file_paths = self.test_params.get("routes_to_test_file_paths", {})
+
+        if self.samples_per_vnet < 0:
+            self.samples_per_vnet = self.routes_per_vnet
+
+        self.routes_to_test = {}
+        for vnet_name, mappings in self.vnet_ptf_map.items():
+            with open(self.routes_to_test_file_paths[vnet_name], "r") as f:
+                self.routes_to_test[vnet_name] = json.load(f)
+
+        # egress interfaces can be list or single int (for backward compat)
+        egress_param = self.test_params.get("egress_ptf_if", [])
+        if isinstance(egress_param, str):
+            # Could be comma-separated list passed as string
+            self.egress_ptf_if = [int(x) for x in egress_param.split(",") if x.strip()]
+        elif isinstance(egress_param, list):
+            self.egress_ptf_if = [int(x) for x in egress_param]
+        else:
+            self.egress_ptf_if = [int(egress_param)]
+
+        self.router_mac = self.test_params.get("router_mac")
+        self.mac_switch = self.test_params.get("mac_switch")
+        self.random_mac = "00:aa:bb:cc:dd:ee"
+        self.tcp_sport = 1234
+        self.tcp_dport = 5000
+        self.vxlan_port = self.test_params['vxlan_port']
+        self.udp_sport = 49366
+
+        self.logger = logging.getLogger("VXLANScaleTest")
+        self.logger.setLevel(logging.INFO)
+
+        self.logger.info(
+            f"VXLANScaleTest params: vnets={self.num_vnets}, routes_per_vnet={self.routes_per_vnet}, "
+            f"samples_per_vnet={self.samples_per_vnet}, egress_ptf_if={self.egress_ptf_if}"
+        )
+
+    def _next_port(self, key="sport"):
+        """Simple port generator for varying TCP ports."""
+        if key == "sport":
+            self.tcp_sport = (self.tcp_sport + 1) % 65535 or 1234
+            return self.tcp_sport
+        else:
+            self.tcp_dport = (self.tcp_dport + 1) % 65535 or 5000
+            return self.tcp_dport
+
+    def build_masked_encap(self, inner_exp_pkt, vni, endpoint):
+        """
+        Construct VXLAN-encapsulated expected packet and apply mask.
+        """
+        encap_pkt = simple_vxlan_packet(
+            eth_src=self.router_mac,
+            eth_dst=self.random_mac,
+            ip_id=0,
+            ip_src=self.dut_vtep,
+            ip_dst=endpoint,
+            ip_ttl=128,
+            udp_sport=self.udp_sport,
+            udp_dport=self.vxlan_port,
+            with_udp_chksum=False,
+            vxlan_vni=vni,
+            inner_frame=inner_exp_pkt,
+        )
+        encap_pkt[scapy.IP].flags = 0x2
+
+        m = Mask(encap_pkt)
+        m.set_ignore_extra_bytes()
+        # don't care about dynamic fields
+        m.set_do_not_care_scapy(scapy.Ether, "src")
+        m.set_do_not_care_scapy(scapy.Ether, "dst")
+        m.set_do_not_care_scapy(scapy.IP, "ttl")
+        m.set_do_not_care_scapy(scapy.IP, "chksum")
+        m.set_do_not_care_scapy(scapy.IP, "id")
+        m.set_do_not_care_scapy(scapy.UDP, "sport")
+        return m
+
+    def _build_packets_for_test(self, ingress_port, dst_ip, src_ip, programmed_mac, vni, endpoint):
+        """
+        Returns: (inner_packet, masked_expected_encap)
+        """
+
+        src_mac = self.dataplane.get_mac(0, ingress_port)
+
+        # Base inner packet
+        inner = simple_tcp_packet(
+            eth_dst=self.router_mac,
+            eth_src=src_mac,
+            ip_dst=dst_ip,
+            ip_src=src_ip,
+            ip_id=105,
+            ip_ttl=64,
+            tcp_sport=self._next_port("sport"),
+            tcp_dport=self._next_port("dport"),
+            pktlen=100,
+        )
+
+        # Expected inner after DUT rewrite
+        inner_exp = inner.copy()
+        inner_exp[scapy.Ether].src = self.router_mac
+        inner_exp[scapy.Ether].dst = programmed_mac
+        inner_exp[scapy.IP].ttl = 63
+
+        # Masked expected encap
+        masked = self.build_masked_encap(inner_exp, vni, endpoint)
+        return inner, masked
+
+    def _send_and_verify(self, vnet_name, ingress_port, inner_pkt, exp_pkt, failures, log_prefix):
+        try:
+            send_packet(self, ingress_port, inner_pkt)
+            verify_packet_any_port(self, exp_pkt, self.egress_ptf_if, timeout=3)
+            self.logger.info(f"[{log_prefix}] {vnet_name} PASSED")
+        except Exception as e:
+            failures[vnet_name] += 1
+            self.logger.error(
+                f"[{log_prefix} FAIL] {vnet_name}: ingress={ingress_port}, error={repr(e)}"
+            )
+
+    def run_mac_vni_per_vnet_test(self):
+        self.logger.info("=== Running deterministic MAC+VNI validation ===")
+
+        failures = {v: 0 for v in self.vnet_ptf_map}
+
+        for vnet_name, mapping in self.vnet_ptf_map.items():
+            vnet_id = mapping["vnet_id"]
+            ingress = int(mapping["ptf_ifindex"])
+
+            for idx in range(self.samples_per_vnet):
+                dst_ip = self.routes_to_test[vnet_name][idx]["route"]
+                src_ip = f"201.0.{vnet_id}.101"
+
+                mac = self.routes_to_test[vnet_name][idx]["mac_address"]
+                vni = self.routes_to_test[vnet_name][idx]["vni"]
+                endpoint = self.routes_to_test[vnet_name][idx]["endpoint"]
+
+                inner, exp = self._build_packets_for_test(
+                    ingress, dst_ip, src_ip, mac, vni, endpoint
+                )
+
+                self._send_and_verify(vnet_name, ingress, inner, exp,
+                                      failures, "MAC+VNI")
+
+        # Summary
+        total = sum(failures.values())
+        for n, f in failures.items():
+            self.logger.info(f"{n}: {f} failures")
+
+        if total > 0:
+            self.fail(f"MAC+VNI validation failed ({total} failures).")
+
+    def run_endpoint_test(self):
+        # Track failures per VNET
+        failures = {vnet_name: 0 for vnet_name in self.vnet_ptf_map}
+
+        for vnet_name, mapping in self.vnet_ptf_map.items():
+            vnet_id = mapping["vnet_id"]
+            vni = self.vnet_base + vnet_id
+            ingress_port = int(mapping["ptf_ifindex"])
+            ptf_intf_name = mapping["ptf_intf"]
+            dut_intf_name = mapping["dut_intf"]
+
+            self.logger.info(
+                f"Testing {vnet_name}: ingress={ptf_intf_name} (index {ingress_port}), "
+                f"DUT intf={dut_intf_name}, VNI={vni}"
+            )
+
+            for i in range(self.samples_per_vnet):
+                dst_ip = self.routes_to_test[vnet_name][i]["route"]
+                ip_src = f"201.0.{vnet_id}.101"
+
+                endpoint = self.routes_to_test[vnet_name][i]["endpoint"]
+
+                inner, masked = self._build_packets_for_test(
+                    ingress_port, dst_ip, ip_src, self.mac_switch, vni, endpoint
+                )
+
+                self._send_and_verify(vnet_name, ingress_port, inner, masked,
+                                      failures, "SCALE")
+
+        # ---- Summary ----
+        self.logger.info("---- VXLAN Scale Test Failure Summary ----")
+        for vnet_name, count in failures.items():
+            self.logger.info(f"{vnet_name}: {count} failures")
+
+        total_failures = sum(failures.values())
+        self.logger.info(f"TOTAL FAILURES: {total_failures}")
+
+        if total_failures > 0:
+            self.fail(f"VXLAN verification failed with {total_failures} packet misses")
+        else:
+            self.logger.info("VXLANScaleTest completed successfully.")
+
+    def runTest(self):
+        self.logger.info("Starting VXLAN scale TCP verification test...")
+        self.dataplane.flush()
+        if self.mac_vni_per_vnet:
+            return self.run_mac_vni_per_vnet_test()
+        else:
+            return self.run_endpoint_test()

--- a/tests/acl/test_src_mac_rewrite.py
+++ b/tests/acl/test_src_mac_rewrite.py
@@ -1,0 +1,816 @@
+"""
+Tests ACL to modify inner source MAC in VXLAN packets in SONiC.
+
+This test suite validates the INNER_SRC_MAC_REWRITE_ACTION functionality
+for ACL rules that can rewrite the inner source MAC address of VXLAN-encapsulated packets.
+"""
+
+import os
+import logging
+import pytest
+import json
+from datetime import datetime
+from scapy.all import Ether, IP, UDP
+from tests.common.helpers.assertions import pytest_assert
+from ptf import testutils
+from ptf.testutils import dp_poll, send_packet
+from tests.common.vxlan_ecmp_utils import Ecmp_Utils
+from tests.common.config_reload import config_reload
+from tests.common.utilities import wait_until
+
+ecmp_utils = Ecmp_Utils()
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('t0'),  # Only run on T0 testbed
+    pytest.mark.disable_loganalyzer,  # Disable automatic loganalyzer, since we use it for the test
+    pytest.mark.device_type('physical'),
+    pytest.mark.asic('cisco-8000')  # Only run on Cisco-8000 ASICs that support INNER_SRC_MAC_REWRITE_ACTION
+]
+
+# Test configuration constants
+ACL_COUNTERS_UPDATE_INTERVAL = 10
+BASE_DIR = os.path.dirname(os.path.realpath(__file__))
+FILES_DIR = os.path.join(BASE_DIR, "files")
+ACL_REMOVE_RULES_FILE = "acl_rules_del.json"
+ACL_RULES_FILE = 'acl_config.json'
+TMP_DIR = '/tmp'
+CONFIG_DB_PATH = "/etc/sonic/config_db.json"
+
+# VXLAN/VNET configuration constants
+PTF_VTEP_IP = "100.0.1.10"  # PTF VTEP endpoint IP
+DUT_VTEP_IP = "10.1.0.32"   # DUT VTEP IP
+VXLAN_UDP_PORT = 4789       # Standard VXLAN UDP port
+VXLAN_VNI = 10000           # VXLAN Network Identifier
+RANDOM_MAC = "00:aa:bb:cc:dd:ee"  # Random MAC for outer Ethernet dst
+
+ACL_TABLE_NAME = "INNER_SRC_MAC_REWRITE_TABLE"
+ACL_TABLE_TYPE = "INNER_SRC_MAC_REWRITE_TYPE"
+
+
+def generate_mac_address(index):
+    base_mac = "00:aa:bb:cc:dd"
+    last_octet = f"{(index % 256):02x}"
+    return f"{base_mac}:{last_octet}"
+
+
+@pytest.fixture(name="setUp", scope="module")
+def fixture_setUp(rand_selected_dut, tbinfo, ptfadapter):
+    data = {}
+
+    # Basic setup
+    data['duthost'] = rand_selected_dut
+    data['tbinfo'] = tbinfo
+    data['ptfadapter'] = ptfadapter
+
+    # Get minigraph facts
+    mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
+    data['mg_facts'] = mg_facts
+
+    # Extract Loopback0 IP
+    loopback0_ips = mg_facts["minigraph_lo_interfaces"]
+    loopback_src_ip = None
+    for intf in loopback0_ips:
+        if intf["name"] == "Loopback0":
+            loopback_src_ip = intf["addr"]
+            break
+
+    if not loopback_src_ip:
+        pytest.fail("Could not find Loopback0 IP address")
+
+    data['loopback_src_ip'] = loopback_src_ip
+
+    # Get CONFIG_DB facts for more robust port selection
+    cfg_facts = rand_selected_dut.get_running_config_facts()
+
+    # Get topology info for PTF port availability
+    topo = tbinfo['topo']['properties']['topology']
+    ptf_ports_available_in_topo = topo.get('ptf_map_disabled', {}).keys() if 'ptf_map_disabled' in topo else []
+    if not ptf_ports_available_in_topo:
+        # If ptf_map_disabled not available, use all PTF indices from minigraph
+        ptf_ports_available_in_topo = list(mg_facts["minigraph_ptf_indices"].values())
+
+    # Get port configuration using CONFIG_DB approach
+    pc_members = cfg_facts.get("PORTCHANNEL_MEMBER", {})
+    port_indexes = mg_facts["minigraph_ptf_indices"]
+
+    # Extract available PTF ports from PortChannel members
+    egress_ptf_if = []
+    for pc_name, members_dict in pc_members.items():
+        for member in members_dict.keys():
+            if member in port_indexes:
+                ptf_index = port_indexes[member]
+                if ptf_index in ptf_ports_available_in_topo:
+                    egress_ptf_if.append(ptf_index)
+
+    if not egress_ptf_if:
+        pytest.fail("No PortChannel member PTF ports found")
+
+    # Use first available port as send port, all ports as receive ports
+    send_ptf_port = egress_ptf_if[0]
+    expected_ptf_ports = egress_ptf_if
+
+    # Find the interface name and PortChannel for the send port
+    send_port_name = None
+    selected_pc = None
+    for pc_name, members_dict in pc_members.items():
+        for member in members_dict.keys():
+            if member in port_indexes and port_indexes[member] == send_ptf_port:
+                send_port_name = member
+                selected_pc = pc_name
+                break
+        if send_port_name:
+            break
+
+    if not send_port_name or not selected_pc:
+        pytest.fail("Could not determine send port interface name or PortChannel")
+
+    data['ptf_port_1'] = send_ptf_port
+    data['ptf_port_2'] = expected_ptf_ports
+    data['test_port_1'] = send_port_name
+    data['test_port_2'] = selected_pc
+
+    # Get bindable ports for ACL table
+    eth_ports_set = set(
+        iface["name"] for iface in mg_facts["minigraph_interfaces"]
+        if iface["name"].startswith("Ethernet")
+    )
+
+    bind_ports = []
+    for pc_name, pc_data in mg_facts.get("minigraph_portchannels", {}).items():
+        members = pc_data.get("members", [])
+        bind_ports.append(pc_name)
+        eth_ports_set -= set(members)
+
+    bind_ports.extend(sorted(eth_ports_set))
+    data['bind_ports'] = bind_ports
+
+    # Test scenarios using consistent configuration
+    data['test_scenarios'] = {
+        'single_ip_test': {
+            'original_mac': generate_mac_address(1),
+            'first_modified_mac': generate_mac_address(2),
+            'second_modified_mac': generate_mac_address(3)
+        },
+        'range_test': {
+            'original_mac': generate_mac_address(4),
+            'first_modified_mac': generate_mac_address(5),
+            'second_modified_mac': generate_mac_address(6)
+        }
+    }
+
+    # VXLAN/VNET configuration values
+    data['vxlan_tunnel_name'] = "tunnel_v4"
+    data['ptf_vtep_ip'] = PTF_VTEP_IP
+    data['dut_vtep_ip'] = DUT_VTEP_IP
+
+    # MAC addresses for packet crafting
+    data['outer_src_mac'] = ptfadapter.dataplane.get_mac(0, send_ptf_port)
+    data['outer_dst_mac'] = rand_selected_dut.facts['router_mac']
+
+    # Create configuration backup before making any changes
+    backup_config(rand_selected_dut)
+
+    # Configure VXLAN/VNET infrastructure once for all test scenarios
+    create_vxlan_vnet_config(
+        duthost=rand_selected_dut,
+        tunnel_name=data['vxlan_tunnel_name'],
+        src_ip=data['loopback_src_ip'],
+        portchannel_name=selected_pc,
+        router_mac=rand_selected_dut.facts['router_mac']
+    )
+
+    def _check_vnet_route(duthost):
+        output = duthost.shell("show vnet route all")["stdout"]
+        return "150.0.3.1/32" in output and "Vnet1" in output
+
+    # Wait for configuration to be applied
+    if not wait_until(30, 5, 5, _check_vnet_route, rand_selected_dut):
+        pytest.fail("VNET route not found in 'show vnet route all'")
+
+    return data
+
+
+@pytest.fixture(name="tearDown", scope="module", autouse=True)
+def fixture_tearDown(setUp):
+    yield  # This allows tests to run first
+
+    try:
+        duthost = setUp['duthost']
+        vxlan_tunnel_name = setUp['vxlan_tunnel_name']
+        cleanup_test_configuration(duthost, vxlan_tunnel_name)
+        logger.info("Module tearDown completed successfully")
+    except Exception as e:
+        logger.error(f"Module tearDown failed: {e}")
+        # Don't raise the exception since tests may have passed
+
+
+def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_INTERVAL):
+    def _check_acl_counter_updated(dut, tbl, rule, prev):
+        result = dut.show_and_parse('aclshow -a')
+        for entry in result:
+            if entry.get('table name') == tbl and entry.get('rule name') == rule:
+                return int(entry.get('packets count', 0)) > prev
+        return False
+
+    # Wait for orchagent to update the ACL counters
+    if timeout > 0:
+        wait_until(timeout, 2, 0, _check_acl_counter_updated, duthost, table_name, rule_name, 0)
+    result = duthost.show_and_parse('aclshow -a')
+
+    if not result:
+        pytest.fail("Failed to retrieve ACL counter for {}|{}".format(table_name, rule_name))
+
+    for rule in result:
+        if table_name == rule.get('table name') and rule_name == rule.get('rule name'):
+            pkt_count = rule.get('packets count', '0')
+            try:
+                return int(pkt_count)
+            except ValueError:
+                logger.warning(f"ACL counter for {table_name}|{rule_name} is not integer: '{pkt_count}', returning 0")
+                return 0
+
+    pytest.fail("ACL rule {} not found in table {}".format(rule_name, table_name))
+
+
+def setup_acl_table_type(duthost, acl_type_name=ACL_TABLE_TYPE):
+    acl_table_type_data = {
+        "ACL_TABLE_TYPE": {
+            acl_type_name: {
+                "BIND_POINTS": [
+                    "PORT",
+                    "PORTCHANNEL"
+                ],
+                "MATCHES": [
+                    "INNER_SRC_IP",
+                    "TUNNEL_VNI"
+                ],
+                "ACTIONS": [
+                    "COUNTER",
+                    "INNER_SRC_MAC_REWRITE_ACTION"
+                ]
+            }
+        }
+    }
+
+    acl_type_json = json.dumps(acl_table_type_data, indent=4)
+    acl_type_file = os.path.join(TMP_DIR, f"{acl_type_name.lower()}_acl_type.json")
+
+    logger.info("Writing ACL table type definition to %s:\n%s", acl_type_file, acl_type_json)
+    duthost.copy(content=acl_type_json, dest=acl_type_file)
+
+    logger.info("Loading ACL table type definition using config load")
+    duthost.shell(f"config load -y {acl_type_file}")
+
+    def _check_acl_table_type_in_config_db(duthost, type_name):
+        result = duthost.shell(f'redis-cli -n 4 KEYS "ACL_TABLE_TYPE|{type_name}"')["stdout"]
+        return type_name in result
+
+    pytest_assert(wait_until(30, 5, 2, _check_acl_table_type_in_config_db, duthost, acl_type_name),
+                  f"ACL table type {acl_type_name} not found in CONFIG_DB after loading")
+
+
+def setup_acl_table(duthost, ports):
+    logger.info(f"Cleaning up any existing ACL table named {ACL_TABLE_NAME}")
+    duthost.shell(f"config acl remove table {ACL_TABLE_NAME}", module_ignore_errors=True)
+
+    cmd = "config acl add table {} {} -s {} -p {}".format(
+        ACL_TABLE_NAME,
+        ACL_TABLE_TYPE,
+        "egress",
+        ",".join(ports)
+    )
+
+    logger.info(f"Creating ACL table {ACL_TABLE_NAME} with ports: {ports}")
+    duthost.shell(cmd)
+
+    def _check_acl_table_present(duthost, table_name):
+        result = duthost.shell(f'redis-cli -n 4 KEYS "ACL_TABLE|{table_name}"')["stdout"]
+        return table_name in result
+
+    pytest_assert(wait_until(30, 5, 2, _check_acl_table_present, duthost, ACL_TABLE_NAME),
+                  f"ACL table {ACL_TABLE_NAME} not found in CONFIG_DB after creation")
+
+    # === Show ACL Table Verification ===
+    logger.info("Verifying ACL table state using 'show acl table'")
+    result = duthost.shell("show acl table", module_ignore_errors=True)
+    output = result.get("stdout", "")
+    logger.info("Output of 'show acl table':\n%s", output)
+
+    if ACL_TABLE_NAME not in output:
+        pytest.fail(f"ACL table {ACL_TABLE_NAME} not found in 'show acl table' output")
+
+    for line in output.splitlines():
+        if ACL_TABLE_NAME in line:
+            if "pending" in line.lower():
+                pytest.fail(f"ACL table {ACL_TABLE_NAME} is in 'Pending creation' state")
+            elif "created" in line.lower() or "egress" in line.lower():
+                logger.info(f"ACL table {ACL_TABLE_NAME} is successfully created and active")
+                break
+    else:
+        pytest.fail(f"Unable to determine valid state for ACL table {ACL_TABLE_NAME}")
+
+    logger.info(f"ACL table {ACL_TABLE_NAME} validation completed successfully")
+
+
+def remove_acl_table(duthost):
+    logger.info(f"Removing ACL table {ACL_TABLE_NAME}")
+    cmd = f"config acl remove table {ACL_TABLE_NAME}"
+    result = duthost.shell(cmd, module_ignore_errors=True)
+
+    if result["rc"] != 0:
+        logger.warning(f"Failed to remove ACL table via config command. Output:\n{result.get('stdout', '')}")
+        pytest.fail(f"Failed to remove ACL table {ACL_TABLE_NAME}")
+
+    def _check_acl_table_absent(duthost, table_name):
+        result = duthost.shell(f'redis-cli -n 6 KEYS "ACL_TABLE_TABLE:{table_name}"')["stdout"]
+        return table_name not in result
+
+    pytest_assert(wait_until(30, 5, 2, _check_acl_table_absent, duthost, ACL_TABLE_NAME),
+                  f"ACL table {ACL_TABLE_NAME} still present in STATE_DB after removal")
+
+    logger.info(f"Verifying ACL table {ACL_TABLE_NAME} was removed from STATE_DB")
+    db_cmd = f"redis-cli -n 6 KEYS 'ACL_TABLE_TABLE:{ACL_TABLE_NAME}'"
+    keys_output = duthost.shell(db_cmd)["stdout_lines"]
+
+    if any(keys_output):
+        logger.error(f"ACL table {ACL_TABLE_NAME} still present in STATE_DB: {keys_output}")
+        pytest.fail(f"ACL table {ACL_TABLE_NAME} was not removed from STATE_DB")
+    else:
+        logger.info(f"ACL table {ACL_TABLE_NAME} successfully removed from STATE_DB")
+
+
+def setup_acl_rules(duthost, inner_src_ip, vni, new_src_mac):
+    """
+    Set up initial ACL rules. Uses 'config load -y' for initial setup
+    since it may need to create table types and tables first.
+    """
+
+    acl_rule = {
+        "ACL_RULE": {
+            f"{ACL_TABLE_NAME}|rule_1": {
+                "priority": "1005",
+                "TUNNEL_VNI": vni,
+                "INNER_SRC_IP": inner_src_ip,
+                "INNER_SRC_MAC_REWRITE_ACTION": new_src_mac
+            }
+        }
+    }
+    # Convert to JSON string
+    acl_rule_json = json.dumps(acl_rule, indent=4)
+    dest_path = os.path.join(TMP_DIR, ACL_RULES_FILE)
+
+    logger.info("Writing ACL rule to %s:\n%s", dest_path, acl_rule_json)
+    duthost.copy(content=acl_rule_json, dest=dest_path)
+
+    logger.info("Loading ACL rule from %s", dest_path)
+    load_result = duthost.shell(f"config load -y {dest_path}", module_ignore_errors=True)
+    logger.info("Config load result: rc=%s, stdout=%s", load_result.get("rc", "unknown"), load_result.get("stdout", ""))
+
+    if load_result.get("rc", 0) != 0:
+        logger.error("Config load failed: %s", load_result.get("stderr", ""))
+        pytest.fail("Failed to load ACL rule configuration")
+
+    def _check_acl_rule_active(duthost, table_name, rule_name):
+        result = duthost.shell(
+            f'redis-cli -n 6 KEYS "ACL_RULE_TABLE|{table_name}|{rule_name}"'
+        )["stdout"]
+        return rule_name in result
+
+    logger.info("Waiting for ACL rule to be applied...")
+    pytest_assert(wait_until(30, 5, 2, _check_acl_rule_active, duthost, ACL_TABLE_NAME, "rule_1"),
+                  "ACL rule not found in STATE_DB after loading")
+
+    # Check CONFIG_DB for the rule
+    logger.info("Checking if rule was added to CONFIG_DB...")
+    rule_config_cmd = f'redis-cli -n 4 HGETALL "ACL_RULE|{ACL_TABLE_NAME}|rule_1"'
+    rule_config_result = duthost.shell(rule_config_cmd)["stdout"]
+    logger.info("ACL rule in CONFIG_DB:\n%s", rule_config_result)
+
+    # === Show ACL Rule Verification ===
+    logger.info("Verifying ACL rule state using 'show acl rule'")
+    rule_result = duthost.shell("show acl rule", module_ignore_errors=True)
+    rule_output = rule_result.get("stdout", "")
+    logger.info("Output of 'show acl rule':\n%s", rule_output)
+
+    # Check that the rule shows up and is Active
+    if ACL_TABLE_NAME not in rule_output or "rule_1" not in rule_output:
+        pytest.fail(f"ACL rule for table {ACL_TABLE_NAME} and rule rule_1 not found in 'show acl rule' output")
+
+    if "Active" not in rule_output:
+        pytest.fail(f"ACL rule for table {ACL_TABLE_NAME} is not showing as Active in 'show acl rule' output")
+
+    logger.info(f"ACL rule for table {ACL_TABLE_NAME} is successfully created and shows as Active")
+
+    # === STATE_DB Verification ===
+    logger.info("Verifying ACL rule propagation to STATE_DB...")
+    state_db_key = f"ACL_RULE_TABLE|{ACL_TABLE_NAME}|rule_1"
+    state_db_cmd = f"redis-cli -n 6 HGETALL \"{state_db_key}\""
+    state_db_output = duthost.shell(state_db_cmd)["stdout"]
+
+    logger.info("STATE_DB entry for ACL rule:\n%s", state_db_output)
+
+    # Check if the rule is active in STATE_DB (this indicates successful propagation)
+    if "status" in state_db_output and "Active" in state_db_output:
+        logger.info("ACL rule is active in STATE_DB, indicating successful propagation")
+        # Also verify the CONFIG_DB has the correct MAC to confirm the setup
+        rule_key = f"ACL_RULE|{ACL_TABLE_NAME}|rule_1"
+        config_verification = duthost.shell(f'redis-cli -n 4 HGET "{rule_key}" INNER_SRC_MAC_REWRITE_ACTION')["stdout"]
+        pytest_assert(config_verification.strip() == new_src_mac,
+                      f"CONFIG_DB does not have expected MAC {new_src_mac}, got: {config_verification.strip()}")
+        logger.info(f"STATE_DB validation successful - rule is active with MAC {new_src_mac}")
+
+    logger.info("ACL rule STATE_DB verification completed")
+
+
+def modify_acl_rule(duthost, inner_src_ip, vni, new_src_mac):
+    logger.info("Modifying ACL rule with new MAC: %s", new_src_mac)
+
+    # First check what's currently in CONFIG_DB
+    logger.info("Checking current CONFIG_DB ACL rules...")
+    current_rules = duthost.shell('redis-cli -n 4 KEYS "ACL_RULE*"')["stdout"]
+    logger.info("Current ACL_RULE keys in CONFIG_DB:\n%s", current_rules)
+
+    # Directly update the ACL rule in CONFIG_DB using Redis
+    rule_key = f"ACL_RULE|{ACL_TABLE_NAME}|rule_1"
+
+    logger.info("Updating CONFIG_DB ACL rule with key: %s", rule_key)
+
+    # First check if the rule exists
+    exists = duthost.shell(f'redis-cli -n 4 EXISTS "{rule_key}"')["stdout"]
+    logger.info("Rule exists in CONFIG_DB: %s", exists)
+
+    if exists.strip() == "0":
+        logger.warning("Rule doesn't exist in CONFIG_DB, checking different key format...")
+        # Try alternative key format
+        alt_rule_key = f"ACL_RULE:{ACL_TABLE_NAME}|rule_1"
+        exists_alt = duthost.shell(f'redis-cli -n 4 EXISTS "{alt_rule_key}"')["stdout"]
+        logger.info("Alternative rule key exists: %s", exists_alt)
+        if exists_alt.strip() == "1":
+            rule_key = alt_rule_key
+
+    # Show current rule content
+    current_rule = duthost.shell(f'redis-cli -n 4 HGETALL "{rule_key}"')["stdout"]
+    logger.info("Current rule content before modification:\n%s", current_rule)
+
+    # Update the MAC rewrite action field directly
+    cmd = f'redis-cli -n 4 HSET "{rule_key}" INNER_SRC_MAC_REWRITE_ACTION "{new_src_mac}"'
+    result = duthost.shell(cmd)
+    logger.info("HSET result: %s", result["stdout"])
+
+    # Also update other fields to ensure consistency
+    duthost.shell(f'redis-cli -n 4 HSET "{rule_key}" priority "1005"')
+    duthost.shell(f'redis-cli -n 4 HSET "{rule_key}" TUNNEL_VNI "{vni}"')
+    duthost.shell(f'redis-cli -n 4 HSET "{rule_key}" INNER_SRC_IP "{inner_src_ip}"')
+
+    # Verify the update in CONFIG_DB
+    updated_rule = duthost.shell(f'redis-cli -n 4 HGETALL "{rule_key}"')["stdout"]
+    logger.info("Updated rule content in CONFIG_DB:\n%s", updated_rule)
+
+    def _check_state_db_mac_updated(duthost, table_name, expected_mac):
+        state_db_key = f"ACL_RULE_TABLE|{table_name}|rule_1"
+        result = duthost.shell(f'redis-cli -n 6 HGET "{state_db_key}" "INNER_SRC_MAC_REWRITE_ACTION"')["stdout"]
+        return expected_mac.upper() in result.upper()
+
+    logger.info("Waiting for CONFIG_DB changes to propagate to STATE_DB...")
+    pytest_assert(wait_until(30, 5, 2, _check_state_db_mac_updated, duthost, ACL_TABLE_NAME, new_src_mac),
+                  f"STATE_DB not updated with new MAC {new_src_mac}")
+
+    # Verify the modification in STATE_DB
+    logger.info("Verifying ACL rule modification in STATE_DB...")
+    state_db_key = f"ACL_RULE_TABLE|{ACL_TABLE_NAME}|rule_1"
+
+    db_cmd = f"redis-cli -n 6 HGETALL \"{state_db_key}\""
+    state_db_output = duthost.shell(db_cmd)["stdout"]
+
+    logger.info("STATE_DB entry for modified ACL rule:\n%s", state_db_output)
+
+    # Check if the rule is active in STATE_DB (this indicates successful propagation)
+    if "status" in state_db_output and "Active" in state_db_output:
+        logger.info("ACL rule is active in STATE_DB, indicating successful propagation")
+        # Also verify the CONFIG_DB has the correct MAC to confirm the update
+        config_verification = duthost.shell(f'redis-cli -n 4 HGET "{rule_key}" INNER_SRC_MAC_REWRITE_ACTION')["stdout"]
+        pytest_assert(config_verification.strip() == new_src_mac,
+                      f"CONFIG_DB does not have expected MAC {new_src_mac}, got: {config_verification.strip()}")
+
+    logger.info("ACL rule successfully modified to use MAC: %s", new_src_mac)
+
+
+def remove_acl_rules(duthost):
+    duthost.copy(src=os.path.join(FILES_DIR, ACL_REMOVE_RULES_FILE), dest=TMP_DIR)
+    remove_rules_dut_path = os.path.join(TMP_DIR, ACL_REMOVE_RULES_FILE)
+    duthost.command("acl-loader update full {} --table_name {}".format(remove_rules_dut_path, ACL_TABLE_NAME))
+
+    def _check_acl_rule_absent(duthost, table_name, rule_name):
+        result = duthost.shell(
+            f'redis-cli -n 6 KEYS "ACL_RULE_TABLE|{table_name}|{rule_name}"'
+        )["stdout"]
+        return rule_name not in result
+
+    pytest_assert(wait_until(30, 5, 2, _check_acl_rule_absent, duthost, ACL_TABLE_NAME, "rule_1"),
+                  "ACL rule still in STATE_DB after removal")
+
+    # === STATE_DB Deletion Check ===
+    logger.info("Checking STATE_DB to confirm ACL rule deletion...")
+    state_db_key = f"ACL_RULE_TABLE:{ACL_TABLE_NAME}|rule_1"
+    db_cmd = f"redis-cli -n 6 EXISTS \"{state_db_key}\""
+    exists_output = duthost.shell(db_cmd)["stdout"]
+
+    logger.info(f"STATE_DB EXISTS check for {state_db_key}: {exists_output}")
+    pytest_assert(exists_output.strip() == "0", f"ACL rule {state_db_key} still exists in STATE_DB")
+
+
+def create_vxlan_vnet_config(duthost, tunnel_name, src_ip, portchannel_name="PortChannel101", router_mac=None):
+    # --- VXLAN parameters ---
+    vnet_base = VXLAN_VNI
+    ptf_vtep = PTF_VTEP_IP
+    dut_vtep = DUT_VTEP_IP
+
+    ecmp_utils.Constants['KEEP_TEMP_FILES'] = True
+    ecmp_utils.Constants['DEBUG'] = False
+
+    # --- Build overlay config JSON ---
+    dut_json = {
+        "VXLAN_TUNNEL": {
+            tunnel_name: {"src_ip": dut_vtep}
+        },
+        "VNET": {
+            "Vnet1": {
+                "vni": str(vnet_base),
+                "vxlan_tunnel": tunnel_name,
+                "scope": "default",
+                "peer_list": "",
+                "advertise_prefix": "false",
+                "overlay_dmac": "25:35:45:55:65:75"
+            }
+        },
+        "VNET_ROUTE_TUNNEL": {
+            "Vnet1|150.0.3.1/32": {"endpoint": ptf_vtep}
+        }
+    }
+
+    # Copy overlay config to DUT
+    config_content = json.dumps(dut_json, indent=4)
+    logger.info("Applying comprehensive VXLAN/VNET config:\n%s", config_content)
+
+    duthost.copy(content=config_content, dest="/tmp/config_db_vxlan_vnet.json")
+    duthost.shell("sonic-cfggen -j /tmp/config_db_vxlan_vnet.json --write-to-db")
+
+    # Clean up temp file
+    duthost.shell("rm /tmp/config_db_vxlan_vnet.json")
+
+    def _check_vxlan_tunnel_config(duthost, tunnel_name):
+        result = duthost.shell(f'redis-cli -n 0 KEYS "VXLAN_TUNNEL|{tunnel_name}"')["stdout"]
+        return tunnel_name in result
+
+    pytest_assert(wait_until(60, 5, 5, _check_vxlan_tunnel_config, duthost, tunnel_name),
+                  f"VXLAN tunnel {tunnel_name} not found in APP_DB after config reload")
+
+    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=VXLAN_UDP_PORT, dutmac=router_mac)
+
+    # Allow time for VXLAN switch config to propagate through swss pipeline
+    def _check_vxlan_switch_config(duthost):
+        result = duthost.shell('redis-cli -n 0 KEYS "SWITCH_TABLE:switch"', module_ignore_errors=True)
+        return "SWITCH_TABLE:switch" in result.get("stdout", "")
+
+    pytest_assert(wait_until(10, 2, 2, _check_vxlan_switch_config, duthost),
+                  "SWITCH_TABLE:switch not found in APP_DB after configure_vxlan_switch")
+
+
+def backup_config(duthost):
+    logger.info("Creating configuration backup...")
+    try:
+        duthost.shell(f"cp {CONFIG_DB_PATH} {CONFIG_DB_PATH}.bak")
+        logger.info("Configuration backup created successfully")
+    except Exception as e:
+        logger.error(f"Failed to create configuration backup: {e}")
+        raise
+
+
+def cleanup_test_configuration(duthost, vxlan_tunnel_name=None):
+    try:
+        # Restore original configuration from backup
+        logger.info("Restoring original configuration from backup...")
+        result = duthost.shell(f"mv {CONFIG_DB_PATH}.bak {CONFIG_DB_PATH}", module_ignore_errors=True)
+
+        if result.get("rc", 0) != 0:
+            logger.warning("Backup file not found or move failed, trying alternative cleanup...")
+            # Fallback to manual cleanup if backup restoration fails
+            try:
+                logger.info("Attempting manual ACL cleanup as fallback...")
+                duthost.shell(f"config acl remove table {ACL_TABLE_NAME}", module_ignore_errors=True)
+            except Exception as e:
+                logger.warning(f"Manual ACL cleanup failed: {e}")
+        else:
+            logger.info("Configuration backup restored successfully")
+
+        # Reload configuration to apply the restored config
+        logger.info("Reloading configuration to apply restored settings...")
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+        logger.info("Configuration reload completed")
+
+    except Exception as e:
+        logger.error(f"Failed during configuration cleanup: {e}")
+        # Don't raise the exception to avoid masking test failures
+
+    finally:
+        # Clean up temporary files
+        try:
+            logger.info("Cleaning up temporary files...")
+            temp_files = [
+                "/tmp/acl_update.json",
+                "/tmp/vnet_route_update.json",
+                "/tmp/bgp_and_interface_update.json",
+                "/tmp/vnet_vxlan_update.json",
+                "/tmp/swss_config_update.json",
+                "/tmp/config_db_vxlan_vnet.json",
+                f"/tmp/{ACL_RULES_FILE}",
+                f"/tmp/{ACL_REMOVE_RULES_FILE}",
+                "/tmp/acl_rule_modify.json"  # Clean up modify rule temp file
+            ]
+
+            for file_path in temp_files:
+                try:
+                    duthost.shell(f"rm -f {file_path}", module_ignore_errors=True)
+                except Exception as e:
+                    logger.debug(f"Could not remove {file_path}: {e}")
+
+            logger.info("Temporary file cleanup completed")
+
+        except Exception as e:
+            logger.warning(f"Failed to clean up temporary files: {e}")
+
+    logger.info("=== Configuration cleanup completed ===")
+
+
+def _send_and_verify_mac_rewrite(ptfadapter, ptf_port_1, duthost,
+                                 src_ip, dst_ip, orig_src_mac, expected_inner_src_mac,
+                                 table_name, rule_name):
+    router_mac = duthost.facts["router_mac"]
+
+    # Create input packet
+    options = {'ip_ecn': 0}
+    pkt_opts = {
+        "pktlen": 100,
+        "eth_dst": router_mac,
+        "eth_src": orig_src_mac,
+        "ip_dst": dst_ip,
+        "ip_src": src_ip,
+        "ip_id": 105,
+        "ip_ttl": 64,
+        "tcp_sport": 1234,
+        "tcp_dport": 5000
+    }
+
+    pkt_opts.update(options)
+    input_pkt = testutils.simple_tcp_packet(**pkt_opts)
+
+    # Get ACL counter before sending
+    count_before = get_acl_counter(duthost, table_name, rule_name, timeout=0)
+
+    # Send packet
+    logger.info(f"Sending TCP packet on port {ptf_port_1}")
+    send_packet(ptfadapter, ptf_port_1, input_pkt)
+
+    # Poll for VXLAN packets with inner MAC rewrite
+    poll_start = datetime.now()
+    poll_timeout = 8  # seconds
+    success = False
+
+    while (datetime.now() - poll_start).total_seconds() < poll_timeout:
+        res = dp_poll(ptfadapter, timeout=2)
+        if not isinstance(res, ptfadapter.dataplane.PollSuccess):
+            continue
+
+        ether = Ether(res.packet)
+        if IP in ether and UDP in ether and ether[UDP].dport == VXLAN_UDP_PORT:
+            try:
+                # Extract VXLAN payload (skip 8-byte VXLAN header)
+                vxlan_payload = bytes(ether[UDP].payload)[8:]
+                if len(vxlan_payload) < 14:  # Need at least Ethernet header
+                    continue
+
+                # Parse inner Ethernet frame
+                inner_eth = Ether(vxlan_payload)
+                if not inner_eth.haslayer(Ether):
+                    continue
+
+                # Check if inner source MAC matches expected rewritten MAC
+                inner_src_mac = inner_eth.src.lower()
+                expected_mac = expected_inner_src_mac.lower()
+
+                if inner_src_mac == expected_mac:
+                    logger.info(f"Successfully verified VXLAN packet with inner MAC rewrite: {inner_src_mac}")
+                    success = True
+                    break
+
+            except Exception as e:
+                logger.warning(f"Error parsing VXLAN packet: {e}")
+                continue
+
+    elapsed_time = (datetime.now() - poll_start).total_seconds()
+    if success:
+        logger.info(f"Packet verification completed in {elapsed_time:.2f} seconds")
+    else:
+        raise AssertionError(f"No valid VXLAN packet with expected inner source MAC {expected_inner_src_mac} "
+                             f"received after {elapsed_time:.2f} seconds")
+
+    # Check ACL counter incremented
+    count_after = get_acl_counter(duthost, table_name, rule_name)
+    logger.info("ACL counter for IP %s: before=%s, after=%s", src_ip, count_before, count_after)
+    pytest_assert(count_after >= count_before + 1,
+                  f"ACL counter did not increment for {src_ip}. before={count_before}, after={count_after}")
+
+
+def _test_inner_src_mac_rewrite(setUp, scenario_name):
+    # Extract test data from setUp fixture
+    duthost = setUp['duthost']
+    ptfadapter = setUp['ptfadapter']
+    scenario = setUp['test_scenarios'][scenario_name]
+
+    ptf_port_1 = setUp['ptf_port_1']
+    bind_ports = setUp['bind_ports']
+
+    # Extract scenario-specific MAC addresses
+    original_inner_src_mac = scenario['original_mac']
+    first_modified_mac = scenario['first_modified_mac']
+    second_modified_mac = scenario['second_modified_mac']
+
+    # Configuration values
+    RULE_NAME = "rule_1"
+    table_name = ACL_TABLE_NAME
+
+    # Standard values from VXLAN/VNET configuration
+    inner_dst_ip = "150.0.3.1"  # Route destination
+    vni_id = str(VXLAN_VNI)  # VNI from configuration
+    inner_src_ip = "201.0.0.101"  # Source IP for test packets
+
+    try:
+        setup_acl_table_type(duthost, acl_type_name=ACL_TABLE_TYPE)
+        setup_acl_table(duthost, bind_ports)
+
+        # Configure ACL rule based on scenario
+        if scenario_name == "single_ip_test":
+            # Use specific source IP for ACL rule matching (single IP)
+            acl_rule_prefix = f"{inner_src_ip}/32"
+            logger.info(f"Single IP test: Using ACL rule prefix {acl_rule_prefix}")
+        else:  # range_test
+            # Use broader subnet for range testing (matches multiple IPs)
+            acl_rule_prefix = "201.0.0.0/24"  # Matches the 201.0.0.x range including 201.0.0.101
+            logger.info(f"Range test: Using ACL rule prefix {acl_rule_prefix}")
+
+        setup_acl_rules(duthost, acl_rule_prefix, vni_id, first_modified_mac)
+
+        # Test with the configured source IP
+        _send_and_verify_mac_rewrite(
+            ptfadapter, ptf_port_1, duthost, inner_src_ip, inner_dst_ip, original_inner_src_mac,
+            first_modified_mac, table_name, RULE_NAME
+        )
+
+        # For range test, also test with different IPs in the range
+        if scenario_name == "range_test":
+            test_ips = ["201.0.0.102", "201.0.0.103", "201.0.0.104"]  # Additional IPs in the 201.0.0.0/24 range
+            for test_ip in test_ips:
+                logger.info(f"Range test: Verifying rewrite with IP {test_ip}")
+                _send_and_verify_mac_rewrite(
+                    ptfadapter, ptf_port_1, duthost, test_ip, inner_dst_ip, original_inner_src_mac,
+                    first_modified_mac, table_name, RULE_NAME)
+
+        # Modify ACL rule to use new MAC address (much more efficient than remove/recreate)
+        logger.info("Step 3: Modifying ACL rule to use new MAC: %s", second_modified_mac)
+        modify_acl_rule(duthost, acl_rule_prefix, vni_id, second_modified_mac)
+
+        logger.info("Step 4: Verifying rewrite with second modified MAC: %s", second_modified_mac)
+        _send_and_verify_mac_rewrite(
+            ptfadapter, ptf_port_1, duthost, inner_src_ip, inner_dst_ip, original_inner_src_mac,
+            second_modified_mac, table_name, RULE_NAME
+        )
+
+        logger.info("=== All test steps completed successfully ===")
+
+    finally:
+        # Clean up ACL configuration (VXLAN/VNET cleanup handled at module level)
+        try:
+            remove_acl_rules(duthost)
+            remove_acl_table(duthost)
+            logger.info("ACL cleanup completed successfully")
+        except Exception as e:
+            logger.warning(f"ACL cleanup failed: {e}")
+            # Don't raise the exception to avoid masking test failures
+
+
+def test_single_ip_acl_rule(setUp):
+    """
+    Test ACL rule for inner source MAC rewriting with single IP (/32) matching.
+    Validates that ACL rules can target specific IP addresses for MAC rewriting.
+    """
+    _test_inner_src_mac_rewrite(setUp, "single_ip_test")
+
+
+def test_range_ip_acl_rule(setUp):
+    """
+    Test ACL rule for inner source MAC rewriting with IP range (/24) matching.
+    Validates that ACL rules can target IP subnets and rewrite MAC for multiple IPs.
+    """
+    _test_inner_src_mac_rewrite(setUp, "range_test")

--- a/tests/bgp/templates/vnet_config_db.j2
+++ b/tests/bgp/templates/vnet_config_db.j2
@@ -1,0 +1,127 @@
+{
+{% for k in cfg_t0 %}
+{%     if k == 'BGP_NEIGHBOR' %}
+    "BGP_NEIGHBOR": {
+{%         set neighbors = cfg_t0['BGP_NEIGHBOR'] %}
+{%         set vnet1_names = ['ARISTA01T1', 'ARISTA02T1'] %}
+{%         set ns = namespace(entries=[]) %}
+{%         for neigh, data in neighbors.items() | sort %}
+{%             set is_ipv6 = ':' in neigh %}
+{%             set is_vnet1 = data['name'] in vnet1_names %}
+{%             if is_vnet1 %}
+{%                 set ns.entries = ns.entries + [('Vnet1|' ~ neigh, data)] %}
+{%             elif is_ipv6 %}
+{%                 set ns.entries = ns.entries + [('Vnet2|' ~ neigh, data)] %}
+{%             endif %}
+{%         endfor %}
+{%         for key, val in ns.entries %}
+{{ '\n        ' if not loop.first else '        ' }}"{{ key }}": {{ val | to_nice_json | indent(width=8) }}{% if not loop.last %},{% endif %}
+{%         endfor %}
+{{ '\n    ' }}},
+{%     elif k == 'BGP_PEER_RANGE' %}
+    "BGP_PEER_RANGE": {
+{%         set neighbors = cfg_t0['BGP_NEIGHBOR'] %}
+{%         for neigh, data in neighbors.items() %}
+{%             if data['name'] == 'ARISTA03T1' and ':' not in neigh %}
+        "Vnet2|BGPSLBPassive": {
+            "ip_range": [
+                "{{ data['local_addr'] }}/29"
+            ],
+            "peer_asn": "{{ data['asn'] }}",
+            "src_address": "{{ data['local_addr'] }}",
+            "name": "BGPSLBPassive"
+        }
+{%             endif %}
+{%         endfor %}
+    },
+{%     elif k == 'LOOPBACK_INTERFACE' %}
+    "LOOPBACK_INTERFACE": {
+        "Loopback0": {"vnet_name": "Vnet1"},
+        "Loopback2": {"vnet_name": "Vnet2"},
+        "Loopback0|10.1.0.32/32": {},
+        "Loopback0|FC00:1::32/128": {},
+        "Loopback2|10.1.0.32/32": {},
+        "Loopback2|FC00:1::32/128": {}
+    },
+{%     elif k == 'PORTCHANNEL_INTERFACE' %}
+    "PORTCHANNEL_INTERFACE": {
+{%        for pc in cfg_t0['PORTCHANNEL_INTERFACE'] | sort %}
+{#     each pc have 3 keys: pc, pc|ipv4 and pc|ipv6 #}
+{%             if cfg_t0['PORTCHANNEL_INTERFACE'] | length == 12  %}
+{%                 if pc in ['PortChannel101', 'PortChannel102'] %}
+        "{{ pc }}": {"vnet_name": "Vnet1"}
+{%-                elif pc in ['PortChannel103', 'PortChannel104'] %}
+        "{{ pc }}": {"vnet_name": "Vnet2"}
+{%-                else %}
+        "{{ pc }}": {{ cfg_t0['PORTCHANNEL_INTERFACE'][pc] }}
+{%-                endif %}
+{%-            else %}
+{%                 if pc in ['PortChannel101', 'PortChannel102', 'PortChannel103', 'PortChannel104'] %}
+        "{{ pc }}": {"vnet_name": "Vnet1"}
+{%-                elif pc in ['PortChannel105', 'PortChannel106', 'PortChannel107', 'PortChannel108'] %}
+        "{{ pc }}": {"vnet_name": "Vnet2"}
+{%-                else %}
+        "{{ pc }}": {{ cfg_t0['PORTCHANNEL_INTERFACE'][pc] }}
+{%-                endif %}
+{%-            endif %}
+{%-            if not loop.last %},{% endif %}
+
+{%        endfor %}
+    },
+{%     elif k == 'VLAN' %}
+    "VLAN": {
+        "Vlan1000": {
+            "dhcp_servers": [
+{%              for dhcp in cfg_t0['VLAN']['Vlan1000']['dhcp_servers'] %}
+                {{ dhcp | to_nice_json }}{% if not loop.last %},
+{% endif %}
+{% endfor %}
+
+            ],
+            "vlanid": "1000"},
+        "Vlan2000": {
+            "vlanid": "2000"}
+    },
+{%     elif k == 'VLAN_INTERFACE' %}
+    "VLAN_INTERFACE": {
+        "Vlan1000": {"vnet_name": "Vnet1"},
+        "Vlan2000": {"vnet_name": "Vnet2"},
+        "Vlan1000|192.168.0.1/21": {},
+        "Vlan1000|FC00:168::1/117": {},
+        "Vlan2000|192.168.0.1/21": {},
+        "Vlan2000|FC00:168::1/117": {}
+    },
+{%     elif k == 'VLAN_MEMBER' %}
+    "VLAN_MEMBER": {
+{%         for port in vlan_ports['Vlan1000'] %}
+        "Vlan1000|{{ port }}": {
+            "tagging_mode": "untagged"
+        },
+{%         endfor %}
+{%         for port in vlan_ports['Vlan2000'] %}
+        "Vlan2000|{{ port }}": {
+            "tagging_mode": "untagged"
+        }{%             if not loop.last %},{% endif %}
+
+{%         endfor %}
+    },
+{%     else %}
+    "{{ k }}": {{ cfg_t0[k] | to_nice_json | indent}},
+{%     endif %}
+{% endfor %}
+    "VNET": {
+        "Vnet1": {
+            "vni": "799999",
+            "vxlan_tunnel": "vtep_v4"
+        },
+        "Vnet2": {
+            "vni": "799998",
+            "vxlan_tunnel": "vtep_v4"
+        }
+    },
+    "VXLAN_TUNNEL": {
+        "vtep_v4": {
+            "src_ip": "10.1.0.32"
+        }
+    }
+}

--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -1,0 +1,608 @@
+import sys
+import time
+from copy import deepcopy
+import json
+import logging
+import traceback
+import yaml
+
+from natsort import natsorted
+import pytest
+
+from tests.common.reboot import reboot
+from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies     # noqa F401
+import ptf.testutils as testutils
+from ptf.mask import Mask
+from scapy.all import IP, Ether
+
+pytestmark = [
+    pytest.mark.topology('t0'),
+    pytest.mark.disable_loganalyzer
+]
+
+logger = logging.getLogger(__name__)
+
+# global variables
+g_vars = {}
+
+TEMPLATE_CONFIGS = {
+    "vnet_dynamic_peer_add": {
+        "BGP_PEER_RANGE": {
+            "Vnet2|BGPSLBPassive": {
+                "ip_range": [],
+                "peer_asn": "",
+                "src_address": "",
+                "name": "BGPSLBPassive"
+            }
+        }
+    },
+    "vnet_dynamic_peer_del": {
+        "BGP_PEER_RANGE": {
+            "Vnet2|BGPSLBPassive": {
+                "ip_range": [],
+                "peer_asn": "",
+                "src_address": "",
+                "name": "BGPSLBPassive"
+            }
+        }
+    }
+}
+
+
+# helper functions
+def get_vlan_members(vlan_name, cfg_facts):
+    tmp_member_list = []
+
+    for m in list(cfg_facts['VLAN_MEMBER'].keys()):
+        v, port = m.split('|')
+        if vlan_name == v:
+            tmp_member_list.append(port)
+
+    return natsorted(tmp_member_list)
+
+
+def get_cfg_facts(duthost):
+    # return config db contents(running-config)
+    tmp_facts = json.loads(duthost.shell(
+        "sonic-cfggen -d --print-data")['stdout'])
+
+    port_name_list_sorted = natsorted(list(tmp_facts['PORT'].keys()))
+    port_index_map = {}
+    for idx, val in enumerate(port_name_list_sorted):
+        port_index_map[val] = idx
+
+    tmp_facts['config_port_indices'] = port_index_map
+
+    return tmp_facts
+
+
+def setup_vnet_cfg(duthost, localhost, cfg_facts):
+    '''
+    setup vrf configuration on dut before test suite
+    '''
+
+    cfg_t0 = deepcopy(cfg_facts)
+
+    cfg_t0.pop('config_port_indices', None)
+
+    # get members from Vlan1000, and move half of them to Vlan2000 in vrf basic cfg
+    ports = get_vlan_members('Vlan1000', cfg_facts)
+
+    vlan_ports = {'Vlan1000': ports[:len(ports)//2],
+                  'Vlan2000': ports[len(ports)//2:]}
+
+    extra_vars = {'cfg_t0': cfg_t0,
+                  'vlan_ports': vlan_ports}
+
+    duthost.host.options['variable_manager'].extra_vars.update(extra_vars)
+
+    duthost.template(src="bgp/templates/vnet_config_db.j2",
+                     dest="/tmp/config_db_vnet.json")
+    duthost.shell("cp /tmp/config_db_vnet.json /etc/sonic/config_db.json")
+
+    reboot(duthost, localhost)
+
+
+# fixtures
+@pytest.fixture(scope="module")
+def dut_facts(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    return duthost.facts
+
+
+@pytest.fixture(scope="module")
+def cfg_facts(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    return get_cfg_facts(duthost)
+
+
+def restore_config_db(localhost, duthost):
+    # In case something went wrong in previous reboot, wait until the DUT is accessible to ensure that
+    # the `mv /etc/sonic/config_db.json.bak /etc/sonic/config_db.json` is executed on DUT.
+    # If the DUT is still inaccessible after timeout, we may have already lose the DUT. Something sad happened.
+    localhost.wait_for(host=g_vars["dut_ip"],
+                       port=22,
+                       state='started',
+                       search_regex='OpenSSH_[\\w\\.]+ Debian',
+                       timeout=180)   # Similiar approach to increase the chance that the next line get executed.
+    duthost.shell("mv /etc/sonic/config_db.json.bak /etc/sonic/config_db.json")
+    reboot(duthost, localhost)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_vnet(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, localhost,
+              skip_test_module_over_backend_topologies):        # noqa F811
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # backup config_db.json
+    duthost.shell("cp /etc/sonic/config_db.json /etc/sonic/config_db.json.bak")
+
+    # Setup global variables
+    global g_vars
+
+    try:
+        # Setup dut
+        g_vars["dut_ip"] = duthost.host.options["inventory_manager"].get_host(
+            duthost.hostname).vars["ansible_host"]
+        # Don't care about 'pmon' and 'lldp' here
+        duthost.critical_services = [
+            "swss", "syncd", "database", "teamd", "bgp"]
+        cfg_t0 = get_cfg_facts(duthost)  # generate cfg_facts for t0 topo
+
+        bgp_neighbors = cfg_t0.get("BGP_NEIGHBOR", {})
+
+        g_vars["vnet1"] = {"static": [], "dynamic": []}
+        g_vars["vnet2"] = {"static": [], "dynamic": {"ARISTA03T1": "", "ARISTA04T1": ""}}
+        peer_asn = list(bgp_neighbors.values())[0]["asn"]
+        TEMPLATE_CONFIGS["vnet_dynamic_peer_add"]["BGP_PEER_RANGE"]["Vnet2|BGPSLBPassive"]["peer_asn"] = peer_asn
+        TEMPLATE_CONFIGS["vnet_dynamic_peer_del"]["BGP_PEER_RANGE"]["Vnet2|BGPSLBPassive"]["peer_asn"] = peer_asn
+        for neighbor_ip, attrs in bgp_neighbors.items():
+            name = attrs.get("name", "")
+            # Check if IPv6 (contains ':')
+            is_ipv6 = ":" in neighbor_ip
+            if name in ["ARISTA01T1", "ARISTA02T1"]:
+                # Static neighbors for vnet1
+                g_vars["vnet1"]["static"].append(neighbor_ip)
+            elif name == "ARISTA03T1":
+                if is_ipv6:
+                    # Static neighbors for vnet2 (IPv6)
+                    g_vars["vnet2"]["static"].append(neighbor_ip)
+                else:
+                    # Dynamic neighbors for vnet2 (IPv4)
+                    g_vars["vnet2"]["dynamic"]["ARISTA03T1"] = neighbor_ip
+                    peer_cfg_add = TEMPLATE_CONFIGS["vnet_dynamic_peer_add"]["BGP_PEER_RANGE"]["Vnet2|BGPSLBPassive"]
+                    peer_cfg_del = TEMPLATE_CONFIGS["vnet_dynamic_peer_del"]["BGP_PEER_RANGE"]["Vnet2|BGPSLBPassive"]
+                    peer_cfg_add["src_address"] = attrs['local_addr']
+                    peer_cfg_del["src_address"] = attrs['local_addr']
+                    peer_cfg_add["ip_range"].append(f"{attrs['local_addr']}/31")
+                    peer_cfg_del["ip_range"].append(f"{attrs['local_addr']}/31")
+            elif name == "ARISTA04T1":
+                if is_ipv6:
+                    # Static neighbors for vnet2 (IPv6)
+                    g_vars["vnet2"]["static"].append(neighbor_ip)
+                else:
+                    # Dynamic neighbors for vnet2 (IPv4)
+                    g_vars["vnet2"]["dynamic"]["ARISTA04T1"] = neighbor_ip
+                    peer_cfg_add = TEMPLATE_CONFIGS["vnet_dynamic_peer_add"]["BGP_PEER_RANGE"]["Vnet2|BGPSLBPassive"]
+                    peer_cfg_add["ip_range"].append(f"{attrs['local_addr']}/31")
+
+        setup_vnet_cfg(duthost, localhost, cfg_t0)
+
+        duthost.shell("sonic-clear arp")
+        duthost.shell("sonic-clear nd")
+        duthost.shell("sonic-clear fdb all")
+
+        with open("../ansible/vars/topo_{}.yml".format(tbinfo['topo']['name']), 'r') as fh:
+            g_vars['topo_properties'] = yaml.safe_load(fh)
+
+        g_vars['props'] = g_vars['topo_properties']['configuration_properties']['common']
+
+    except Exception as e:
+        # Ensure that config_db is restored.
+        # If exception is raised in setup, the teardown code won't be executed. That's why we need to capture
+        # exception and do cleanup here in setup part (code before 'yield').
+        logger.error("Exception raised in setup: {}".format(repr(e)))
+        logger.error(json.dumps(
+            traceback.format_exception(*sys.exc_info()), indent=2))
+
+        restore_config_db(localhost, duthost)
+
+        # Setup failed. There is no point to continue running the cases.
+        # If this line is hit, script execution will stop here
+        pytest.fail("Vnet testing setup failed")
+
+    # --------------------- Testing -----------------------
+    yield
+
+    # --------------------- Teardown -----------------------
+    restore_config_db(localhost, duthost)
+
+
+@pytest.fixture(scope="module")
+def mg_facts(duthosts, rand_one_dut_hostname, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    return mg_facts
+
+
+def validate_state_db_entry(duthost, peer, vnet, dynamic_peer):
+    '''
+    Validate the entry for a given peer in the state db.
+    '''
+    if dynamic_peer:
+        peer_config_db_key = "BGP_PEER_RANGE" + "|" + vnet + "|" + peer
+    else:
+        peer_config_db_key = "BGP_NEIGHBOR" + "|" + vnet + "|" + peer
+    peer_state_db_key = "BGP_PEER_CONFIGURED_TABLE" + "|" + vnet + "|" + peer
+    expected_state = duthost.shell(
+        'redis-cli -n 4 --json HGETALL "{}"'.format(str(peer_config_db_key)))['stdout']
+    expected_state = json.loads(expected_state)
+    if isinstance(expected_state, dict):
+        expected_state = {k.rstrip('@'): v for k, v in expected_state.items()}
+    peer_state = duthost.shell(
+        'redis-cli -n 6 --json HGETALL "{}"'.format(str(peer_state_db_key)))['stdout']
+    peer_state = json.loads(peer_state)
+    assert peer_state == expected_state, \
+        "Peer {} vnet {} state in state db is not {}. Found {}".format(peer, vnet, expected_state, peer_state)
+
+
+def get_bgp_peer_uptime(duthost, static_peers, dynamic_peer=None):
+    '''
+    Get the uptime of the static and dynamic peers.
+    '''
+    static_peers_uptime = {}
+    bgp_summary_string = duthost.shell("vtysh -c 'show bgp vrf Vnet2 summary json'")['stdout']
+    bgp_summary = json.loads(bgp_summary_string)
+    for static_peer in static_peers:
+        static_peers_uptime[static_peer] = bgp_summary['ipv4Unicast']['peers'][static_peer]['peerUptimeMsec']
+    if dynamic_peer is not None:
+        dynamic_peer_uptime = bgp_summary['ipv4Unicast']['peers'][dynamic_peer]['peerUptimeMsec']
+        return static_peers_uptime, dynamic_peer_uptime
+    else:
+        return static_peers_uptime
+
+
+def validate_dynamic_peer_established(bgp_summary, template):
+    '''
+    Validate that the dynamic peer is in the established state.
+    '''
+    dyn_peer1 = g_vars["vnet2"]["dynamic"]["ARISTA03T1"]
+    dyn_peer2 = g_vars["vnet2"]["dynamic"]["ARISTA04T1"]
+    if template == 'vnet_dynamic_peer_add':
+        assert (
+            dyn_peer1 in bgp_summary['ipv4Unicast']['peers']
+            and bgp_summary['ipv4Unicast']['peers'][dyn_peer1]['state'] == 'Established'
+        ), f"BGP peer {dyn_peer1} not in Established state or missing from summary"
+        assert (
+            dyn_peer2 in bgp_summary['ipv4Unicast']['peers']
+            and bgp_summary['ipv4Unicast']['peers'][dyn_peer2]['state'] == 'Established'
+        ), f"BGP peer {dyn_peer2} not in Established state or missing from summary"
+    elif template == 'vnet_dynamic_peer_del':
+        assert (
+            dyn_peer1 in bgp_summary['ipv4Unicast']['peers']
+            and bgp_summary['ipv4Unicast']['peers'][dyn_peer1]['state'] == 'Established'
+        ), f"BGP peer {dyn_peer1} not in Established state or missing from summary"
+        assert (
+            dyn_peer2 not in bgp_summary['ipv4Unicast']['peers']
+        ), f"BGP peer {dyn_peer2} should not be in show bgp summary output"
+
+
+def modify_dynamic_peer_cfg(duthost, template):
+    '''
+    modify dynamic peer configuration on DUT
+    '''
+    if template not in TEMPLATE_CONFIGS:
+        raise ValueError(f"Unknown template name: {template}")
+
+    config_dict = TEMPLATE_CONFIGS[template]
+    config_json_str = json.dumps(config_dict, indent=4)
+
+    temp_location = f"/tmp/{template}.json"
+
+    # Copy rendered config to DUT and apply it
+    duthost.copy(content=config_json_str, dest=temp_location)
+    duthost.shell(f"sonic-cfggen -j {temp_location} --write-to-db")
+    time.sleep(10)
+    validate_state_db_entry(duthost, "BGPSLBPassive", "Vnet2", True)
+
+
+def dynamic_range_add_delete(duthost, template):
+    '''
+    Validate the behavior when a different dynamic range is added/deleted.
+    '''
+    static_peers = g_vars["vnet2"]["static"]
+    dynamic_peer = g_vars["vnet2"]["dynamic"]["ARISTA03T1"]
+    static_peer_uptime_before, dynamic_peer_uptime_before = get_bgp_peer_uptime(
+        duthost, static_peers, dynamic_peer)
+    time.sleep(10)
+    modify_dynamic_peer_cfg(duthost, template)
+    if template == 'vnet_dynamic_peer_add':
+        time.sleep(120)
+
+    static_peer_uptime_after, dynamic_peer_uptime_after = get_bgp_peer_uptime(
+        duthost, static_peers, dynamic_peer)
+
+    for static_peer in static_peers:
+        assert static_peer_uptime_after[static_peer] >= static_peer_uptime_before[static_peer] + 2*10*1000, \
+            f"Static peer {static_peer} should not flap when a different dynamic range is added/deleted!"
+    assert dynamic_peer_uptime_after >= dynamic_peer_uptime_before + 2*10*1000, \
+        "Peer from other range should not flap when a different dynamic range is added/deleted!"
+
+    bgp_summary_string = duthost.shell("vtysh -c 'show bgp vrf Vnet2 summary json'")['stdout']
+    bgp_summary = json.loads(bgp_summary_string)
+    validate_dynamic_peer_established(bgp_summary, template)
+
+
+def get_core_dumps(duthost):
+    '''
+    Check if there is a core dump file in the /var/core directory.
+    '''
+    cmd = "ls /var/core 2>/dev/null"  # List only core dump files (core*)
+    result = duthost.shell(cmd)['stdout'].strip()
+
+    # If result is empty, no core dumps exist, otherwise core dumps are present
+    return result.split('\n') if result else []
+
+
+def get_ptf_port_index(interface_name):
+    """
+    Convert Ethernet interface name to PTF port index (Ethernet112 → 28).
+    """
+    return int(interface_name.replace("Ethernet", "")) // 4
+
+
+def get_expected_unexpected_ptf_ports(cfg_facts, vnet_expected, vnet_unexpected):
+    """
+    Return two lists of unique PTF port indices:
+    - expected_ptf_ports: ports belonging to vnet_expected
+    - unexpected_ptf_ports: ports belonging to vnet_unexpected
+    """
+    portchannel_interfaces = cfg_facts.get("PORTCHANNEL_INTERFACE", {})
+    portchannel_members = cfg_facts.get("PORTCHANNEL_MEMBER", {})
+
+    expected_portchannels = set()
+    unexpected_portchannels = set()
+
+    # Identify portchannels per vnet
+    for pc, attrs in portchannel_interfaces.items():
+        if "|" in pc:
+            continue  # skip sub-entries with IPs
+        vnet_name = attrs.get("vnet_name")
+        if vnet_name == vnet_expected:
+            expected_portchannels.add(pc)
+        elif vnet_name == vnet_unexpected:
+            unexpected_portchannels.add(pc)
+
+    def collect_ptf_ports(portchannels):
+        ptf_ports = set()
+        for key in portchannel_members:
+            try:
+                pc, iface = key.split("|")
+            except ValueError:
+                # Malformed key (should be pc|member)
+                continue
+            if pc in portchannels:
+                ptf_ports.add(get_ptf_port_index(iface))
+        return sorted(ptf_ports)
+
+    expected_ptf_ports = collect_ptf_ports(expected_portchannels)
+    unexpected_ptf_ports = collect_ptf_ports(unexpected_portchannels)
+
+    return expected_ptf_ports, unexpected_ptf_ports
+
+
+def test_dynamic_peer_vnet(duthosts, rand_one_dut_hostname, cfg_facts):
+    '''
+    Tests for static and dynamic peers inside a vnet.
+    '''
+    try:
+        duthost = duthosts[rand_one_dut_hostname]
+        props = g_vars['props']
+        route_count = props['podset_number'] * \
+            props['tor_number'] * props['tor_subnet_number']
+
+        # Validate static and dynamic peers are established and have correct route counts inside VNET.
+        for vnet in cfg_facts['VNET']:
+            bgp_summary_string = duthost.shell(
+                "vtysh -c 'show bgp vrf {} summary json'".format(vnet))['stdout']
+            bgp_summary = json.loads(bgp_summary_string)
+            for info in bgp_summary:
+                for peer, attr in list(bgp_summary[info]['peers'].items()):
+                    prefix_count = attr['pfxRcd']
+                    # skip ipv6 peers under 'ipv4Unicast' and compare only ipv4 peers under 'ipv4Unicast',
+                    # and ipv4 peers under 'ipv6Unicast'
+                    if ((info == "ipv4Unicast" and attr['idType'] == 'ipv6') or
+                            (info == "ipv6Unicast" and attr['idType'] == 'ipv4')):
+                        continue
+                    else:
+                        assert int(prefix_count) >= 6000, "%s should received %s route prefixes!" % (
+                            peer, route_count)
+                        if 'dynamicPeer' in attr:
+                            validate_state_db_entry(duthost, peer, vnet, True)
+                        else:
+                            validate_state_db_entry(duthost, peer, vnet, False)
+
+        # Verify changing ip_range for dynamic peers
+        bgp_summary_string = duthost.shell("vtysh -c 'show bgp vrf Vnet2 summary json'")['stdout']
+        bgp_summary = json.loads(bgp_summary_string)
+        validate_dynamic_peer_established(bgp_summary, 'vnet_dynamic_peer_add')
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_del')
+        bgp_summary_string = duthost.shell("vtysh -c 'show bgp vrf Vnet2 summary json'")['stdout']
+        bgp_summary = json.loads(bgp_summary_string)
+        validate_dynamic_peer_established(bgp_summary, 'vnet_dynamic_peer_del')
+
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+    except Exception as e:
+        logger.error("Exception raised in test_setup_vnet: {}".format(repr(e)))
+        pytest.fail("Vnet testing setup failed")
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+
+
+def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, cfg_facts):
+    '''
+    Verify that the traffic to the peer in Vnet1 is forwarded correctly.
+    Send a UDP packet to with the destination as one of the routes learned via bgp in Vnet1
+    and verify that it is received on the correct port in Vnet1.
+    Also verify that the packet is not received on the other ports which belong to Vnet2.
+    '''
+    try:
+        duthost = duthosts[rand_one_dut_hostname]
+        router_mac = duthost.facts["router_mac"]
+        # Destination IP is one of the routes learned via bgp in Vnet1
+        dst_ip = "193.11.248.129"
+        expected_ports, unexpected_ports = get_expected_unexpected_ptf_ports(cfg_facts, "Vnet1", "Vnet2")
+        send_port = expected_ports[0]
+        src_mac = ptfadapter.dataplane.get_mac(0, send_port)
+
+        inner_pkt = testutils.simple_udp_packet(
+            eth_dst=router_mac,
+            eth_src=src_mac,
+            ip_dst=dst_ip,
+            ip_src="20.20.20.1",
+            udp_sport=1234,
+            udp_dport=4321,
+        )
+
+        expected_pkt = Mask(inner_pkt)
+        expected_pkt.set_do_not_care_scapy(Ether, "dst")
+        expected_pkt.set_do_not_care_scapy(Ether, "src")
+        expected_pkt.set_do_not_care_scapy(IP, "ttl")
+        expected_pkt.set_do_not_care_scapy(IP, "chksum")
+
+        logger.info(f"Sending UDP packet on port {send_port}")
+        testutils.send(ptfadapter, send_port, inner_pkt)
+
+        logger.info(f"Expecting UDP packet on one of {expected_ports}")
+        testutils.verify_packet_any_port(ptfadapter, expected_pkt, expected_ports)
+
+        logger.info(f"Verifying packet is not received on ports {unexpected_ports}")
+        testutils.verify_no_packet_any(ptfadapter, expected_pkt, unexpected_ports)
+    except Exception as e:
+        logger.error("Exception raised in test_bgp_vnet_route_forwarding: {}".format(repr(e)))
+        pytest.fail("Packet test for per vnet BGP failed")
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+
+
+def test_add_delete_ip_range(duthosts, rand_one_dut_hostname):
+    '''
+    Verify adding and deleting of a new dynamic ip range.
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    try:
+        # Prepare initial config
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_del')
+
+        # Verify adding a new dynamic range
+        dynamic_range_add_delete(duthost, 'vnet_dynamic_peer_add')
+
+        # Verify deleting a dynamic range
+        dynamic_range_add_delete(duthost, 'vnet_dynamic_peer_del')
+
+        # Restore the config
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+    except Exception as e:
+        logger.error("Exception raised in test_add_delete_ip_range: {}".format(repr(e)))
+        pytest.fail("Adding/deleting IP range for dynamic peers failed")
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+
+
+def test_dynamic_peer_group_delete(duthosts, rand_one_dut_hostname):
+    '''
+    Validate the behavior when a dynamic peer group is deleted.
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    try:
+        static_peers = g_vars["vnet2"]["static"]
+        static_peer_uptime_before = get_bgp_peer_uptime(duthost, static_peers)
+        redis_cmd = 'redis-cli -n 4 DEL "BGP_PEER_RANGE|Vnet2|BGPSLBPassive"'
+        duthost.shell(redis_cmd)
+        time.sleep(10)
+
+        static_peer_uptime_after = get_bgp_peer_uptime(duthost, static_peers)
+        for static_peer in static_peers:
+            assert static_peer_uptime_after[static_peer] >= static_peer_uptime_before[static_peer] + 10000, \
+                f"Static peer {static_peer} should not flap when a dynamic peer group is deleted!"
+
+        bgp_summary_string = duthost.shell("vtysh -c 'show bgp vrf Vnet2 summary json'")['stdout']
+        bgp_summary = json.loads(bgp_summary_string)
+        total_peers = bgp_summary['ipv4Unicast']['dynamicPeers']
+        assert int(total_peers) == 0, "There should be no dynamic peer. Found {}".format(total_peers)
+
+        validate_state_db_entry(duthost, "BGPSLBPassive", "Vnet2", True)
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+    except Exception as e:
+        logger.error("Exception raised in test_dynamic_peer_group_delete: {}".format(repr(e)))
+        pytest.fail("Dynamic peer group deletion test failed")
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+
+
+def test_dynamic_peer_modify_stress(duthosts, rand_one_dut_hostname):
+    '''
+    Stress test for modifying dynamic peer configuration.
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    try:
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        time.sleep(120)
+        static_peers = g_vars["vnet2"]["static"]
+        dynamic_peer = g_vars["vnet2"]["dynamic"]["ARISTA03T1"]
+        static_peer_uptime_before, dynamic_peer_uptime_before = get_bgp_peer_uptime(
+            duthost, static_peers, dynamic_peer)
+        core_dumps_before = get_core_dumps(duthost)
+
+        for i in range(20):
+            modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_del')
+            modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+
+        static_peer_uptime_after, dynamic_peer_uptime_after = get_bgp_peer_uptime(
+            duthost, static_peers, dynamic_peer)
+
+        for static_peer in static_peers:
+            assert static_peer_uptime_after[static_peer] >= static_peer_uptime_before[static_peer] + 20*20*1000, \
+                f"Static peer {static_peer} should not flap when a dynamic peer is modified!"
+        assert dynamic_peer_uptime_after >= dynamic_peer_uptime_before, \
+            f"Dynamic peer {dynamic_peer} should not flap when a dynamic peer is modified!"
+        core_dumps_after = get_core_dumps(duthost)
+        assert core_dumps_before == core_dumps_after, \
+            "Core dumps should not be generated when modifying dynamic peer configuration."
+        # restore the config
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+    except Exception as e:
+        logger.error("Exception raised in test_dynamic_peer_modify_stress: {}".format(repr(e)))
+        pytest.fail("Stress test for dynamic peer group modification failed")
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+
+
+def test_dynamic_peer_delete_stress(duthosts, rand_one_dut_hostname):
+    '''
+    Stress test for deleting dynamic peer configuration.
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    try:
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        time.sleep(120)
+        static_peers = g_vars["vnet2"]["static"]
+        static_peer_uptime_before = get_bgp_peer_uptime(duthost, static_peers)
+        core_dumps_before = get_core_dumps(duthost)
+
+        for i in range(20):
+            redis_cmd = 'redis-cli -n 4 DEL "BGP_PEER_RANGE|Vnet2|BGPSLBPassive"'
+            duthost.shell(redis_cmd)
+            time.sleep(10)
+            modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+            bgp_summary_string = duthost.shell("vtysh -c 'show bgp vrf Vnet2 summary json'")['stdout']
+            bgp_summary = json.loads(bgp_summary_string)
+            validate_dynamic_peer_established(bgp_summary, 'vnet_dynamic_peer_add')
+
+        static_peer_uptime_after = get_bgp_peer_uptime(duthost, static_peers)
+        for static_peer in static_peers:
+            assert static_peer_uptime_after[static_peer] >= static_peer_uptime_before[static_peer] + 20*20*1000, \
+                f"Static peer {static_peer} should not flap when a dynamic peer is deleted!"
+        core_dumps_after = get_core_dumps(duthost)
+        assert core_dumps_before == core_dumps_after, \
+            "Core dumps should not be generated when deleting dynamic peer configuration."
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+    except Exception as e:
+        logger.error("Exception raised in test_dynamic_peer_delete_stress: {}".format(repr(e)))
+        pytest.fail("Stress test for dynamic peer group deletion failed")
+        modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')

--- a/tests/common/gnmi_setup.py
+++ b/tests/common/gnmi_setup.py
@@ -1,0 +1,350 @@
+"""
+Module for setting up gNMI target used by tests
+that require SAI validation.
+"""
+# TODO refactor this module
+# Move tests/gnmi/helper.py to tests/common/gnmi_helper.py
+# copy of code from tests/gnmi/helper.py
+
+from pathlib import Path
+
+import logging
+import shutil
+import pytest
+import time
+
+import tests.common.gu_utils as gu_utils
+
+from tests.common.helpers.gnmi_utils import GNMIEnvironment
+from tests.common.utilities import wait_until
+from tests.common.helpers.ntp_helper import NtpDaemon, get_ntp_daemon_in_use   # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+# Wait time in seconds after starting GNMI server
+GNMI_SERVER_START_WAIT_TIME = 5
+
+
+def create_ext_conf(ip, filename):
+    text = '''
+[ req_ext ]
+subjectAltName = @alt_names
+[alt_names]
+DNS.1   = hostname.com
+IP      = %s
+''' % ip
+    with open(filename, 'w') as file:
+        file.write(text)
+    return
+
+
+def add_gnmi_client_common_name(duthost, cname, role="readwrite"):
+    command = 'sudo sonic-db-cli CONFIG_DB hset "GNMI_CLIENT_CERT|{}" "role@" "{}"'.format(cname, role)
+    duthost.shell(command, module_ignore_errors=True)
+
+
+def del_gnmi_client_common_name(duthost, cname):
+    duthost.shell('sudo sonic-db-cli CONFIG_DB del "GNMI_CLIENT_CERT|{}"'.format(cname), module_ignore_errors=True)
+
+
+def check_system_time_sync(duthost):
+    """
+    Checks if the DUT's time is synchronized with the NTP server.
+    If not synchronized, it attempts to restart the NTP service.
+    """
+
+    ntp_daemon = get_ntp_daemon_in_use(duthost)
+
+    if ntp_daemon == NtpDaemon.CHRONY:
+        ntp_status_cmd = "chronyc -c tracking"
+        restart_ntp_cmd = "sudo systemctl restart chrony"
+    else:
+        ntp_status_cmd = "ntpstat"
+        restart_ntp_cmd = "sudo systemctl restart ntp"
+
+    ntp_status = duthost.command(ntp_status_cmd, module_ignore_errors=True)
+    if (ntp_daemon == NtpDaemon.CHRONY and "Not synchronised" not in ntp_status["stdout"]) or \
+            (ntp_daemon != NtpDaemon.CHRONY and "unsynchronised" not in ntp_status["stdout"]):
+        logger.info("DUT %s is synchronized with NTP server.", duthost)
+        return True
+    else:
+        logger.info("DUT %s is NOT synchronized. Restarting NTP service...", duthost)
+        duthost.command(restart_ntp_cmd)
+        time.sleep(5)
+        # Rechecking status after restarting NTP
+        ntp_status = duthost.command(ntp_status_cmd, module_ignore_errors=True)
+        if (ntp_daemon == NtpDaemon.CHRONY and "Not synchronised" not in ntp_status["stdout"]) or \
+                (ntp_daemon != NtpDaemon.CHRONY and "synchronized" in ntp_status["stdout"]):
+            logger.info("DUT %s is now synchronized with NTP server.", duthost)
+            return True
+        else:
+            logger.error("DUT %s: NTP synchronization failed. Please check manually.", duthost)
+            return False
+
+
+def dump_gnmi_log(duthost):
+    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    dut_command = "docker exec %s cat /root/gnmi.log" % (env.gnmi_container)
+    res = duthost.shell(dut_command, module_ignore_errors=True)
+    logger.info("GNMI log: " + res['stdout'])
+    return res['stdout']
+
+
+def dump_system_status(duthost):
+    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    dut_command = "docker exec %s ps -efwww" % (env.gnmi_container)
+    res = duthost.shell(dut_command, module_ignore_errors=True)
+    logger.info("GNMI process: " + res['stdout'])
+    dut_command = "docker exec %s date" % (env.gnmi_container)
+    res = duthost.shell(dut_command, module_ignore_errors=True)
+    logger.info("System time: " + res['stdout'] + res['stderr'])
+
+
+def check_gnmi_status(duthost):
+    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    dut_command = "docker exec %s supervisorctl status %s" % (env.gnmi_container, env.gnmi_program)
+    output = duthost.shell(dut_command, module_ignore_errors=True)
+    return "RUNNING" in output['stdout']
+
+
+def apply_cert_config(duthost):
+    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    # Get subtype
+    cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    metadata = cfg_facts["DEVICE_METADATA"]["localhost"]
+    subtype = metadata.get('subtype', None)
+    # Stop all running program
+    dut_command = "docker exec %s supervisorctl status" % (env.gnmi_container)
+    output = duthost.shell(dut_command, module_ignore_errors=True)
+    for line in output['stdout_lines']:
+        res = line.split()
+        if len(res) < 3:
+            continue
+        program = res[0]
+        status = res[1]
+        if status == "RUNNING":
+            dut_command = "docker exec %s supervisorctl stop %s" % (env.gnmi_container, program)
+            duthost.shell(dut_command, module_ignore_errors=True)
+    dut_command = "docker exec %s pkill %s" % (env.gnmi_container, env.gnmi_process)
+    duthost.shell(dut_command, module_ignore_errors=True)
+    dut_command = "docker exec %s bash -c " % env.gnmi_container
+    dut_command += "\"/usr/bin/nohup /usr/sbin/%s -logtostderr --port %s " % (env.gnmi_process, env.gnmi_port)
+    dut_command += "--server_crt /etc/sonic/telemetry/gnmiserver.crt --server_key /etc/sonic/telemetry/gnmiserver.key "
+    dut_command += "--config_table_name GNMI_CLIENT_CERT "
+    dut_command += "--client_auth cert "
+    dut_command += "--enable_crl=true "
+    if subtype == 'SmartSwitch':
+        dut_command += "--zmq_address=tcp://127.0.0.1:8100 "
+    dut_command += "--ca_crt /etc/sonic/telemetry/gnmiCA.pem -gnmi_native_write=true -v=10 >/root/gnmi.log 2>&1 &\""
+    duthost.shell(dut_command)
+
+    # Setup gnmi client cert common name
+    role = "gnmi_readwrite,gnmi_config_db_readwrite,gnmi_appl_db_readwrite,gnmi_dpu_appl_db_readwrite,gnoi_readwrite"
+    add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
+    add_gnmi_client_common_name(duthost, "test.client.revoked.gnmi.sonic", role)
+
+    is_time_synced = False
+    for i in range(3):
+        time.sleep(GNMI_SERVER_START_WAIT_TIME)
+        dut_command = "sudo netstat -nap | grep %d" % env.gnmi_port
+        output = duthost.shell(dut_command, module_ignore_errors=True)
+        if is_time_synced is False and duthost.facts['platform'] != 'x86_64-kvm_x86_64-r0':
+            is_time_synced = wait_until(60, 3, 0, check_system_time_sync, duthost)
+            assert is_time_synced, "Failed to synchronize DUT system time with NTP Server"
+        if env.gnmi_process not in output['stdout']:
+            # Dump tcp port status and gnmi log
+            logger.info("TCP port status: " + output['stdout'])
+            dump_gnmi_log(duthost)
+            dump_system_status(duthost)
+            pytest.fail("Failed to start gnmi server")
+
+
+def recover_cert_config(duthost):
+    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    cmds = [
+        'systemctl reset-failed %s' % (env.gnmi_container),
+        'systemctl restart %s' % (env.gnmi_container)
+    ]
+    duthost.shell_cmds(cmds=cmds)
+
+    # Remove gnmi client cert common name
+    del_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
+    del_gnmi_client_common_name(duthost, "test.client.revoked.gnmi.sonic")
+    assert wait_until(60, 3, 0, check_gnmi_status, duthost), "GNMI service failed to start"
+
+
+def create_certificates(localhost, duthost_mgmt_ip, cert_path: Path):
+    """
+    Create GNMI CA, server and client certificates
+    :param localhost: localhost fixture
+    :param duthost_mgmt_ip: DUT management IP
+    :param cert_path: Path to store the certificates
+    :return: True if successful, False otherwise
+    """
+    logger.info("Starting certificate creation process.")
+    logger.debug(f"Parameters - duthost_mgmt_ip: {duthost_mgmt_ip}, cert_path: {cert_path}")
+
+    dest_dir = cert_path
+    old_dest_dir = dest_dir.with_name(dest_dir.name + ".old")
+    try:
+        if dest_dir.exists():
+            logger.debug(f"Destination directory {dest_dir} exists.")
+            if old_dest_dir.exists():
+                logger.debug(f"Old destination directory {old_dest_dir} exists. Removing it.")
+                shutil.rmtree(old_dest_dir)
+            dest_dir.rename(old_dest_dir)
+            logger.info(f"Renamed existing directory {dest_dir} to {old_dest_dir}.")
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(f"Created new directory {dest_dir}.")
+    except Exception as e:
+        logger.error(f"Failed to create directory {dest_dir}: {e}")
+        raise Exception(f"Failed to create directory {dest_dir}: {e}")
+
+    # Create CA key and certificate
+    logger.info("Creating CA key and certificate.")
+    key_file = str(dest_dir / 'gnmiCA.key')
+    out_file = str(dest_dir / 'gnmiCA.pem')
+    logger.debug(f"CA key file: {key_file}, CA certificate file: {out_file}")
+    local_command = f"openssl genrsa -out {key_file} 2048"
+    localhost.shell(local_command)
+    local_command = (
+        f"openssl req -x509 -new -nodes -key {key_file} "
+        f"-sha256 -days 1825 -subj '/CN=test.gnmi.sonic' "
+        f"-out {out_file}"
+    )
+    out = localhost.shell(local_command)
+    if out['rc'] != 0:
+        logger.error(f"Failed to create CA certificate {out['stderr']}")
+        return False
+
+    # Create server key
+    logger.info("Creating server key.")
+    key_file = str(dest_dir / 'gnmiserver.key')
+    logger.debug(f"Server key file: {key_file}")
+    local_command = f"openssl genrsa -out {key_file} 2048"
+    out = localhost.shell(local_command)
+    if out['rc'] != 0:
+        logger.error(f"Failed to create server key {out['stderr']}")
+        return False
+
+    # Create server CSR
+    logger.info("Creating server CSR.")
+    out_file = str(dest_dir / 'gnmiserver.csr')
+    logger.debug(f"Server CSR file: {out_file}")
+    local_command = (
+        f"openssl req -new -key {key_file} "
+        f"-subj '/CN=test.server.gnmi.sonic' -out {out_file}"
+    )
+    localhost.shell(local_command)
+    if out['rc'] != 0:
+        logger.error(f"Failed to create server CSR {out['stderr']}")
+        return False
+
+    # Sign server certificate
+    logger.info("Signing server certificate.")
+    extfile_path = str(dest_dir / 'extfile.cnf')
+    logger.debug(f"Extension file path: {extfile_path}")
+    create_ext_conf(duthost_mgmt_ip, extfile_path)
+    ca_key = str(dest_dir / 'gnmiCA.key')
+    ca_pem = str(dest_dir / 'gnmiCA.pem')
+    in_file = str(dest_dir / 'gnmiserver.csr')
+    out_file = str(dest_dir / 'gnmiserver.crt')
+    logger.debug(f"CA key: {ca_key}, CA PEM: {ca_pem}, Input CSR: {in_file}, Output CRT: {out_file}")
+    local_command = (
+        f"openssl x509 -req -in {in_file} "
+        f"-CA {ca_pem} -CAkey {ca_key} -CAcreateserial "
+        f"-out {out_file} -days 825 -sha256 "
+        f"-extensions req_ext -extfile {extfile_path}"
+    )
+    out = localhost.shell(local_command)
+    if out['rc'] != 0:
+        logger.error(f"Failed to sign server certificate {out['stderr']}")
+        return False
+
+    # Create client key
+    logger.info("Creating client key.")
+    key_file = str(dest_dir / 'gnmiclient.key')
+    logger.debug(f"Client key file: {key_file}")
+    local_command = f"openssl genrsa -out {key_file} 2048"
+    out = localhost.shell(local_command)
+    if out['rc'] != 0:
+        logger.error(f"Failed to create client key {out['stderr']}")
+        return False
+
+    # Create client CSR
+    logger.info("Creating client CSR.")
+    out_file = str(dest_dir / 'gnmiclient.csr')
+    logger.debug(f"Client CSR file: {out_file}")
+    local_command = (
+        f"openssl req -new -key {key_file} "
+        f"-subj '/CN=test.client.gnmi.sonic' -out {out_file}"
+    )
+    out = localhost.shell(local_command)
+    if out['rc'] != 0:
+        logger.error(f"Failed to create client CSR {out['stderr']}")
+        return False
+
+    # Sign client certificate
+    logger.info("Signing client certificate.")
+    in_file = str(dest_dir / 'gnmiclient.csr')
+    ca_pem = str(dest_dir / 'gnmiCA.pem')
+    ca_key = str(dest_dir / 'gnmiCA.key')
+    out_file = str(dest_dir / 'gnmiclient.crt')
+    logger.debug(f"CA key: {ca_key}, CA PEM: {ca_pem}, Input CSR: {in_file}, Output CRT: {out_file}")
+    local_command = (
+        f"openssl x509 -req -in {in_file} "
+        f"-CA {ca_pem} -CAkey {ca_key} "
+        f"-CAcreateserial -out {out_file} -days 825 -sha256"
+    )
+    out = localhost.shell(local_command)
+    if out['rc'] != 0:
+        logger.error(f"Failed to sign client certificate {out['stderr']}")
+        return False
+
+    logger.info("Certificate creation process completed successfully.")
+    return True
+
+
+def copy_certificates_to_dut(local_path, duthost):
+    """
+    Copy the certificates to the DUT
+    :param local_path: Path to the certificates on localhost
+    :param duthost: DUT host object
+    """
+    logger.info("Starting to copy certificates to the DUT.")
+    certs = ['gnmiCA.pem', 'gnmiserver.crt', 'gnmiserver.key', 'gnmiclient.crt', 'gnmiclient.key']
+    for cert in certs:
+        local_file = str(local_path / cert)
+        remote_file = str(Path('/etc/sonic/telemetry') / cert)
+        logger.debug(f"Copying {local_file} to {remote_file}.")
+        out = duthost.copy(src=local_file, dest=remote_file)
+        if out.get('failed') is True:
+            logger.error(f"Failed to copy {cert} to DUT: {out}")
+            return False
+    logger.info("All certificates copied to the DUT successfully.")
+    return True
+
+
+def apply_certs(duthost, checkpoint_name):
+    """
+    Apply the certificates to the DUT
+    :param duthost: DUT host object
+    """
+    logger.info(f"Creating checkpoint '{checkpoint_name}' on the DUT.")
+    gu_utils.create_checkpoint(duthost, checkpoint_name)
+    logger.info("Applying certificate configuration on the DUT.")
+    apply_cert_config(duthost)
+    logger.info("Certificate configuration applied successfully.")
+
+
+def remove_certs(duthost, checkpoint_name):
+    """
+    Remove the certificates from the DUT
+    :param duthost: DUT host object
+    :param checkpoint_name: Name of the checkpoint to rollback to
+    """
+    logger.info(f"Rolling back to checkpoint '{checkpoint_name}' on the DUT.")
+    gu_utils.rollback(duthost, checkpoint_name)
+    logger.info("Recovering certificate configuration on the DUT.")
+    recover_cert_config(duthost)
+    logger.info("Certificate configuration removed successfully.")

--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -1,0 +1,481 @@
+import json
+import time
+import sys
+from ipaddress import IPv4Address
+import pytest
+import logging
+import traceback
+import random
+from tests.common.config_reload import config_reload
+from tests.ptf_runner import ptf_runner
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa:F401
+from tests.common.vxlan_ecmp_utils import Ecmp_Utils
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+
+logger = logging.getLogger(__name__)
+ecmp_utils = Ecmp_Utils()
+
+pytestmark = [
+    pytest.mark.topology('t0'),
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.device_type('physical'),
+    pytest.mark.asic('cisco-8000')
+]
+
+VNET_NAME = "Vnet1"
+TUNNEL_NAME = "tunnel_v4"
+VNI = 10000
+PREFIX = "150.0.3.1/32"
+INITIAL_ENDPOINTS = ["100.0.1.10", "100.0.2.10"]
+CHANGED_ENDPOINTS = ["100.0.3.10", "100.0.4.10"]
+PACKET_MULTIPLIER = 10
+
+
+# ---------- Utility ----------
+def get_loopback_ip(cfg_facts):
+    for key in cfg_facts.get("LOOPBACK_INTERFACE", {}):
+        if key.startswith("Loopback0|") and "." in key:
+            return key.split("|")[1].split("/")[0]
+    pytest.fail("Cannot find IPv4 Loopback0 address in LOOPBACK_INTERFACE")
+
+
+def apply_chunk(duthost, payload, name):
+    content = json.dumps(payload, indent=2)
+    dest = f"/tmp/{name}.json"
+    duthost.copy(content=content, dest=dest)
+    duthost.shell(f"sonic-cfggen -j {dest} --write-to-db")
+
+
+def _update_vxlan_endpoints(duthost, vnet, prefix, endpoints, vni, mac_address=None):
+    ep_str = ",".join(endpoints)
+    logger.info(
+        f"Updating VNET_ROUTE_TUNNEL {vnet}|{prefix} "
+        f"with {len(endpoints)} endpoints, vni={vni}, mac={mac_address}"
+    )
+    cmd = (
+        f"sonic-db-cli CONFIG_DB hmset 'VNET_ROUTE_TUNNEL|{vnet}|{prefix}' "
+        f"endpoint '{ep_str}' vni '{vni}'"
+    )
+    if mac_address:
+        cmd += f" mac_address '{mac_address}'"
+
+    duthost.shell(cmd)
+    time.sleep(3)
+
+
+def get_available_vlan_id_and_ports(cfg_facts, num_ports_needed):
+    """
+    Return vlan id and available ports in that vlan if there are enough ports available.
+    Args:
+        cfg_facts: DUT config facts
+        num_ports_needed: number of available ports needed for test
+    """
+    port_status = cfg_facts["PORT"]
+    vlan_id = -1
+    available_ports = []
+    pytest_require("VLAN_MEMBER" in cfg_facts, "Can't get vlan member")
+    for vlan_name, members in list(cfg_facts["VLAN_MEMBER"].items()):
+        # Number of members in vlan is insufficient
+        if len(members) < num_ports_needed:
+            continue
+
+        # Get available ports in vlan
+        possible_ports = []
+        for vlan_member in members:
+            if port_status[vlan_member].get("admin_status", "down") != "up":
+                continue
+
+            possible_ports.append(vlan_member)
+            if len(possible_ports) == num_ports_needed:
+                available_ports = possible_ports[:]
+                vlan_id = int(''.join([i for i in vlan_name if i.isdigit()]))
+                break
+
+        if vlan_id != -1:
+            break
+
+    logger.debug(f"Vlan {vlan_id} has available ports: {available_ports}")
+    return available_ports
+
+
+# ---------- Single-VNET setup ----------
+def vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
+                         config_facts, dut_indx, vxlan_port):
+    ports = get_available_vlan_id_and_ports(config_facts, 1)
+    pytest_assert(ports and len(ports) >= 1, "Not enough ports for VNET setup")
+
+    port_indexes = config_facts["port_index_map"]
+
+    host_interfaces = tbinfo["topo"]["ptf_map"][str(dut_indx)]
+    ptf_ports_available_in_topo = {host_interfaces[k]: f"eth{k}" for k in host_interfaces}
+    logger.info(f"PTF port map: {ptf_ports_available_in_topo}")
+
+    ecmp_utils.Constants["KEEP_TEMP_FILES"] = False
+    ecmp_utils.Constants["DEBUG"] = True
+
+    ingress_if = ports[0]
+    logger.info(f"Selected ingress interface: {ingress_if}")
+
+    duthost.shell(f"config vlan member del all {ingress_if} || true")
+
+    dut_vtep = get_loopback_ip(cfg_facts)
+    logger.info(f"Creating VXLAN tunnel {TUNNEL_NAME} with source {dut_vtep}")
+    apply_chunk(duthost, {"VXLAN_TUNNEL": {TUNNEL_NAME: {"src_ip": dut_vtep}}}, "vxlan_tunnel")
+    apply_chunk(duthost, {"VNET": {VNET_NAME: {"vni": str(VNI), "vxlan_tunnel": TUNNEL_NAME}}}, "vnet")
+
+    ptf_port_index = port_indexes[ingress_if]
+    port_name = ptf_ports_available_in_topo[ptf_port_index]
+
+    dut_ip = "201.0.1.1"
+    apply_chunk(
+        duthost,
+        {"INTERFACE": {ingress_if: {"vnet_name": VNET_NAME}, f"{ingress_if}|{dut_ip}/24": {}}},
+        "intf_bind",
+    )
+
+    ptf_ip = "201.0.1.101"
+
+    ptfhost.shell(f"ip addr flush dev {port_name}")
+    ptfhost.shell(f"ip addr add {ptf_ip}/24 dev {port_name}")
+    ptfhost.shell(f"ip link set {port_name} up")
+
+    logger.info(f"Programming route {PREFIX} -> {','.join(INITIAL_ENDPOINTS)}")
+    apply_chunk(
+        duthost,
+        {"VNET_ROUTE_TUNNEL": {f"{VNET_NAME}|{PREFIX}": {"endpoint": ",".join(INITIAL_ENDPOINTS), "vni": str(VNI)}}},
+        "route_tunnel",
+    )
+    time.sleep(5)
+
+    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=vxlan_port)
+
+    return {
+        "dut_vtep": dut_vtep,
+        "ptf_src_ip": ptf_ip,
+        "dst_ip": PREFIX.split("/")[0],
+        "ptf_ingress_port": ptf_port_index,
+        "router_mac": duthost.facts["router_mac"],
+        "vxlan_port": vxlan_port,
+    }
+
+
+@pytest.fixture(scope="module", autouse=True)
+def one_vnet_setup_teardown(
+    duthosts,
+    rand_one_dut_hostname,
+    ptfhost,
+    tbinfo,
+    localhost,
+    request,
+    scaled_vnet_params
+):
+    """
+    Module-level setup:
+    - Configures 1 VNET, 1 VXLAN tunnel, and 1 VNET route
+    - Passes num_endpoints from scaled_vnet_params
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    try:
+        cfg_facts = json.loads(duthost.shell("sonic-cfggen -d --print-data")["stdout"])
+        config_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
+        duts_map = tbinfo["duts_map"]
+        dut_indx = duts_map[duthost.hostname]
+        vxlan_port = request.config.option.vxlan_port
+
+        num_endpoints = scaled_vnet_params.get("num_endpoints", 511) or 511
+        setup_params = vxlan_setup_one_vnet(duthost, ptfhost, tbinfo, cfg_facts,
+                                            config_facts, dut_indx, vxlan_port)
+        setup_params["num_endpoints"] = int(num_endpoints)
+    except Exception as e:
+        logger.error("Exception raised in setup: {}".format(repr(e)))
+        logger.error(json.dumps(
+            traceback.format_exception(*sys.exc_info()), indent=2))
+        config_reload(duthost, safe_reload=True, yang_validate=False)
+        pytest.fail("Vnet testing setup failed")
+
+    yield setup_params, duthost, ptfhost
+
+    config_reload(duthost, safe_reload=True, yang_validate=False)
+
+
+# ---------- PTF runner helper ----------
+def run_vxlan_ptf_test(ptfhost, endpoints, params, num_packets, mac_list=None):
+    logger.info(f"Calling VXLAN ECMP PTF test: {len(endpoints)} endpoints, {num_packets} packets")
+
+    endpoints_file = "/tmp/ptf_endpoints.json"
+    ptfhost.copy(content=json.dumps(endpoints), dest=endpoints_file)
+    ptf_params = params.copy()
+    ptf_params.update({
+        "endpoints_file": endpoints_file,
+        "num_packets": num_packets
+    })
+    if mac_list:
+        macs_file = "/tmp/ptf_macs.json"
+        ptfhost.copy(content=json.dumps(mac_list), dest=macs_file)
+        ptf_params.update({
+            "macs_file": macs_file,
+        })
+    params_path = "/tmp/ptf_params.json"
+    ptfhost.copy(content=json.dumps(ptf_params), dest=params_path)
+
+    ptf_runner(
+        ptfhost,
+        "ptftests",
+        "vxlan_ecmp_ptftest.VxlanEcmpTest",
+        platform_dir="ptftests",
+        params={"params_file": params_path},
+        log_file="/tmp/vxlan_ecmp_ptftest.log",
+    )
+
+
+# ---------- Tests ----------
+def test_ecmp_two_endpoints(ptfhost, one_vnet_setup_teardown):
+    logger.info("Running test_ecmp_two_endpoints")
+    setup, duthost, _ = one_vnet_setup_teardown
+    run_vxlan_ptf_test(
+        ptfhost,
+        INITIAL_ENDPOINTS,
+        setup,
+        num_packets=6,
+    )
+
+
+def test_ecmp_change_endpoints(ptfhost, one_vnet_setup_teardown):
+    logger.info("Running test_ecmp_change_endpoints")
+    setup, duthost, _ = one_vnet_setup_teardown
+    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, CHANGED_ENDPOINTS, VNI)
+    run_vxlan_ptf_test(
+        ptfhost,
+        CHANGED_ENDPOINTS,
+        setup,
+        num_packets=6,
+    )
+
+
+def test_ecmp_scale(ptfhost, one_vnet_setup_teardown):
+    logger.info("Running test_ecmp_scale")
+    setup, duthost, _ = one_vnet_setup_teardown
+    num_endpoints = setup["num_endpoints"]
+
+    base_ip = int(IPv4Address("100.0.10.1"))
+    endpoints = [str(IPv4Address(base_ip + i)) for i in range(num_endpoints)]
+    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, endpoints, VNI)
+    time.sleep(20)
+
+    num_packets = num_endpoints * PACKET_MULTIPLIER
+    run_vxlan_ptf_test(
+        ptfhost,
+        endpoints,
+        setup,
+        num_packets=num_packets,
+    )
+
+
+def test_vxlan_mac_vni(ptfhost, one_vnet_setup_teardown):
+    """
+    Validate that endpoint[i] → mac_address[i] mapping is honored
+    for a single prefix with multiple endpoints.
+    """
+
+    setup, duthost, _ = one_vnet_setup_teardown
+    num_endpoints = setup["num_endpoints"]
+
+    logger.info(f"Running MAC+VNI multi-endpoint scale test with {num_endpoints} endpoints")
+
+    # --- Build endpoints list ---
+    base_ip = int(IPv4Address("100.0.50.1"))
+    endpoints = [str(IPv4Address(base_ip + i)) for i in range(num_endpoints)]
+
+    # --- Build deterministic MAC list ---
+    # 52:54:00:00:xx:yy (unique per endpoint)
+    mac_list = [f"52:54:00:{i//256:02x}:{i%256:02x}:aa" for i in range(num_endpoints)]
+    mac_list_str = ",".join(mac_list)
+    updated_vni = 5001
+
+    logger.info(f"Generated {len(endpoints)} endpoints + {len(mac_list)} MACs")
+    logger.info(f"MAC list: {mac_list_str}")
+
+    # --- Program into VNET_ROUTE_TUNNEL table ---
+    _update_vxlan_endpoints(
+        duthost,
+        VNET_NAME,
+        PREFIX,
+        endpoints,
+        updated_vni,
+        mac_address=mac_list_str
+    )
+
+    # --- Prepare PTF params ---
+    num_packets = num_endpoints * PACKET_MULTIPLIER
+    ptf_params = setup.copy()
+    ptf_params.update({
+        "mac_vni_verify": "yes",
+        "vni": updated_vni,
+    })
+
+    logger.info("Calling PTF for MAC+VNI multi-endpoint validation...")
+
+    run_vxlan_ptf_test(
+        ptfhost,
+        endpoints,
+        ptf_params,
+        num_packets=num_packets,
+        mac_list=mac_list
+    )
+
+    logger.info("MAC+VNI multi-endpoint scale test completed successfully")
+
+
+def test_ecmp_scale_add_endpoint(ptfhost, one_vnet_setup_teardown):
+    setup, duthost, _ = one_vnet_setup_teardown
+    num = setup["num_endpoints"]
+
+    base_ip = int(IPv4Address("100.0.10.1"))
+
+    # Step 1 — Program initial endpoints
+    initial_endpoints = [str(IPv4Address(base_ip + i)) for i in range(num)]
+    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, initial_endpoints, VNI)
+    time.sleep(5)
+
+    # Step 2 — Modify: add one endpoint
+    new_endpoint = str(IPv4Address(base_ip + num))
+    logger.info(f"Adding new endpoint: {new_endpoint}")
+    modified_endpoints = initial_endpoints + [new_endpoint]
+
+    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, modified_endpoints, VNI)
+    time.sleep(5)
+    logger.info(f"Updated endpoint list programmed, total now = {len(modified_endpoints)}")
+
+    num_packets = len(modified_endpoints) * PACKET_MULTIPLIER
+
+    run_vxlan_ptf_test(
+        ptfhost,
+        modified_endpoints,
+        setup,
+        num_packets=num_packets,
+    )
+
+
+def test_ecmp_scale_delete_endpoint(ptfhost, one_vnet_setup_teardown):
+    setup, duthost, _ = one_vnet_setup_teardown
+    num = setup["num_endpoints"]
+
+    base_ip = int(IPv4Address("100.0.10.1"))
+
+    # Step 1 — Initial endpoints
+    endpoints = [str(IPv4Address(base_ip + i)) for i in range(num)]
+    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, endpoints, VNI)
+    time.sleep(5)
+
+    # Step 2 — Random endpoint delete
+    del_idx = random.randint(0, num - 1)
+    deleted_ep = endpoints[del_idx]
+    logger.info(f"Deleting endpoint at index {del_idx}: {deleted_ep}")
+    modified_endpoints = endpoints[:del_idx] + endpoints[del_idx + 1:]
+
+    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, modified_endpoints, VNI)
+    time.sleep(10)
+    logger.info(f"Updated endpoint list programmed, remaining endpoints = {len(modified_endpoints)}")
+
+    ptf_params = {
+        **setup,
+        "deleted_endpoints": [deleted_ep]
+    }
+
+    num_packets = len(modified_endpoints) * PACKET_MULTIPLIER
+
+    run_vxlan_ptf_test(
+        ptfhost,
+        modified_endpoints,
+        ptf_params,
+        num_packets=num_packets,
+    )
+
+
+def test_ecmp_scale_modify_endpoint(ptfhost, one_vnet_setup_teardown):
+    setup, duthost, _ = one_vnet_setup_teardown
+    num = setup["num_endpoints"]
+
+    base_ip = int(IPv4Address("100.0.10.1"))
+
+    # Step 1 — Initial endpoints
+    endpoints = [str(IPv4Address(base_ip + i)) for i in range(num)]
+    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, endpoints, VNI)
+    time.sleep(5)
+
+    # Step 2 — Random index choose to remove
+    mod_idx = random.randint(0, num - 1)
+    removed_ep = endpoints[mod_idx]
+
+    # Create a new endpoint that is NOT in the list
+    new_ep = str(IPv4Address(base_ip + num + 100))
+    logger.info(f"Replacing endpoint at index {mod_idx}: {removed_ep} → {new_ep}")
+    modified_endpoints = endpoints[:mod_idx] + [new_ep] + endpoints[mod_idx + 1:]
+
+    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, modified_endpoints, VNI)
+    time.sleep(5)
+    logger.info(f"Modified endpoint list programmed, total endpoints = {len(modified_endpoints)}")
+    ptf_params = {
+        **setup,
+        "deleted_endpoints": [removed_ep]
+    }
+
+    num_packets = len(modified_endpoints) * PACKET_MULTIPLIER
+
+    run_vxlan_ptf_test(
+        ptfhost,
+        modified_endpoints,
+        ptf_params,
+        num_packets=num_packets,
+    )
+
+
+def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
+    setup, duthost, _ = one_vnet_setup_teardown
+    num = setup["num_endpoints"]
+
+    base_ip = int(IPv4Address("100.0.10.1"))
+
+    # Step 1 — Initial endpoints
+    endpoints = [str(IPv4Address(base_ip + i)) for i in range(num)]
+    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, endpoints, VNI)
+    time.sleep(5)
+
+    # Step 2 — Initial MAC list
+    mac_list = [f"52:54:00:{i//256:02x}:{i%256:02x}:aa" for i in range(num)]
+    mac_string = ",".join(mac_list)
+
+    # Push initial MAC list
+    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, endpoints, VNI, mac_address=mac_string)
+    time.sleep(5)
+
+    # Step 3 — Random index to modify
+    mod_idx = random.randint(0, num - 1)
+    new_mac = f"52:54:99:{mod_idx//256:02x}:{mod_idx%256:02x}:cc"
+    logger.info(f"Modifying MAC for endpoint index {mod_idx}: new MAC = {new_mac}")
+
+    # Update the list
+    mac_list[mod_idx] = new_mac
+    mac_string2 = ",".join(mac_list)
+
+    # Push modified MAC list
+    _update_vxlan_endpoints(duthost, VNET_NAME, PREFIX, endpoints, VNI, mac_address=mac_string2)
+    time.sleep(10)
+
+    ptf_params = {
+        **setup,
+        "mac_vni_verify": "yes",
+        "modified_mac_index": mod_idx,
+        "modified_mac_value": new_mac,
+        "vni": VNI,
+    }
+
+    num_packets = num * PACKET_MULTIPLIER
+
+    run_vxlan_ptf_test(
+        ptfhost,
+        endpoints,
+        ptf_params,
+        num_packets=num_packets,
+        mac_list=mac_list
+    )

--- a/tests/vxlan/test_vxlan_tunnel_route_scale.py
+++ b/tests/vxlan/test_vxlan_tunnel_route_scale.py
@@ -1,0 +1,598 @@
+import json
+import random
+import sys
+import time
+import logging
+import pytest
+import traceback
+from tests.common.config_reload import config_reload
+from tests.common.utilities import wait_until
+from ipaddress import IPv4Address
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.ptf_runner import ptf_runner
+from tests.common.vxlan_ecmp_utils import Ecmp_Utils
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa:F401
+
+logger = logging.getLogger(__name__)
+ecmp_utils = Ecmp_Utils()
+
+PTF_VTEP = "100.0.1.10"
+TUNNEL_NAME = "tunnel_v4"
+VNI_BUCKET_SIZE = 1000
+
+pytestmark = [
+    pytest.mark.topology('t0'),
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.device_type('physical'),
+    pytest.mark.asic('cisco-8000')
+]
+
+
+# -------------------------------------------------------------------
+# Utility Functions
+# -------------------------------------------------------------------
+def get_loopback_ip(cfg_facts):
+    for key in cfg_facts.get("LOOPBACK_INTERFACE", {}):
+        if key.startswith("Loopback0|") and "." in key:
+            return key.split("|")[1].split("/")[0]
+
+    pytest.fail("Cannot find IPv4 Loopback0 address in LOOPBACK_INTERFACE")
+
+
+def generate_routes_and_endpoint(vnet_id: int, count: int, endpoint_offset=0):
+    base = int(IPv4Address(f"30.{vnet_id}.0.0"))
+    endpoint_base = int(IPv4Address(f"100.{vnet_id}.0.0")) + endpoint_offset
+    return [f"{IPv4Address(base + i)}/32" for i in range(count)], \
+           [f"{IPv4Address(endpoint_base + i)}" for i in range(count)]
+
+
+def apply_chunk(duthost, payload, config_name):
+    content = json.dumps(payload, indent=2)
+    file_dest = f"/tmp/{config_name}_chunk.json"
+    duthost.copy(content=content, dest=file_dest)
+    duthost.shell(f"sonic-cfggen -j {file_dest} --write-to-db")
+
+
+def all_vnet_routes_in_state_db(duthost, num_vnets, routes_per_vnet):
+    try:
+        total_expected = num_vnets * routes_per_vnet
+        dump_cmd = "redis-dump -d 6 -k 'VNET_ROUTE_TUNNEL_TABLE|*'"
+        dump_text = duthost.shell(dump_cmd)["stdout"]
+        logger.debug(f"redis-dump full output: {dump_text}")
+
+        if not dump_text.strip():
+            logger.warning("redis-dump returned empty output")
+            return False
+
+        dump_dict = json.loads(dump_text)
+        logger.debug(f"Parsed redis-dump entries: {len(dump_dict)} keys")
+        total_active = 0
+
+        for vnet_id in range(1, num_vnets + 1):
+            vnet_name = f"Vnet{vnet_id}"
+            prefix = f"VNET_ROUTE_TUNNEL_TABLE|{vnet_name}|30.{vnet_id}."
+            count_active = 0
+            for key, entry in dump_dict.items():
+                if not key.startswith(prefix):
+                    continue
+                value = entry.get("value", {})
+                if isinstance(value, dict) and value.get("state") == "active":
+                    count_active += 1
+
+            logger.info(f"{vnet_name}: ACTIVE routes = {count_active}/{routes_per_vnet}")
+            total_active += count_active
+
+        logger.info(f"STATE_DB total ACTIVE = {total_active}/{total_expected}")
+
+        return total_active >= total_expected
+
+    except Exception as e:
+        logger.warning(f"Error checking STATE_DB route readiness: {e}")
+        return False
+
+
+def get_available_vlan_id_and_ports(cfg_facts, num_ports_needed):
+    """
+    Return vlan id and available ports in that vlan if there are enough ports available.
+
+    Args:
+        cfg_facts: DUT config facts
+        num_ports_needed: number of available ports needed for test
+    """
+    port_status = cfg_facts["PORT"]
+    vlan_id = -1
+    available_ports = []
+    pytest_require("VLAN_MEMBER" in cfg_facts, "Can't get vlan member")
+    for vlan_name, members in list(cfg_facts["VLAN_MEMBER"].items()):
+        # Number of members in vlan is insufficient
+        if len(members) < num_ports_needed:
+            continue
+
+        # Get available ports in vlan
+        possible_ports = []
+        for vlan_member in members:
+            if port_status[vlan_member].get("admin_status", "down") != "up":
+                continue
+
+            possible_ports.append(vlan_member)
+            if len(possible_ports) == num_ports_needed:
+                available_ports = possible_ports[:]
+                vlan_id = int(''.join([i for i in vlan_name if i.isdigit()]))
+                break
+
+        if vlan_id != -1:
+            break
+
+    logger.debug(f"Vlan {vlan_id} has available ports: {available_ports}")
+    return available_ports
+
+
+def restore_config_db(localhost, duthost, ptfhost, setup_params=None):
+    logger.info("Restoring DUT config DB from backup")
+    try:
+        if setup_params and "vnet_ptf_map" in setup_params and ptfhost:
+            vnet_map = setup_params["vnet_ptf_map"]
+            logger.info(f"Flushing IPs on {len(vnet_map)} PTF interfaces")
+            for vnet, info in vnet_map.items():
+                port_name = info.get("ptf_intf")
+                if port_name:
+                    logger.info(f"Flushing IP address on {port_name}")
+                    try:
+                        ptfhost.shell(f"ip addr flush dev {port_name}")
+                    except Exception as e:
+                        logger.warning(f"Failed to flush {port_name}: {e}")
+                else:
+                    logger.warning(f"No ptf_intf defined for {vnet}")
+    except Exception as e:
+        logger.warning(f"PTF interface cleanup failed: {e}")
+
+    # Restore DUT config
+    duthost.shell("mv /etc/sonic/config_db.json.bak /etc/sonic/config_db.json")
+    config_reload(duthost, safe_reload=True, yang_validate=False)
+
+
+def generate_routes_to_test_file(ptfhost, num_samples, num_routes, vnet, routes,
+                                 endpoints, mac_addresses=None, vnis=None):
+    """
+    Generate a JSON file containing test routes and corresponding endpoints, MACs, and VNIs.
+    This file can be used by PTF tests to validate VXLAN encapsulation and routing.
+    """
+    num_routes_to_test = num_routes if num_samples < 0 else min(num_samples, num_routes)
+
+    test_data = []
+    sample_indices = sorted(random.sample(
+        range(num_routes),
+        min(num_routes_to_test, num_routes)
+    ))
+    for i in sample_indices:
+        entry = {
+            "route": routes[i].split("/")[0],  # Strip prefix length for test
+            "endpoint": endpoints[i],
+            "mac_address": mac_addresses[i] if mac_addresses else None,
+            "vni": vnis[i] if vnis else None
+        }
+        test_data.append(entry)
+
+    content = json.dumps(test_data, indent=2)
+    file_dest = f"/tmp/vxlan_test_routes_{vnet}.json"
+    ptfhost.copy(content=content, dest=file_dest)
+    logger.info(f"Generated test routes file at {file_dest}")
+
+    return file_dest
+
+
+def vxlan_setup_config(config_facts, cfg_facts, duthost, dut_indx, ptfhost,
+                       tbinfo, num_vnets, routes_per_vnet, vnet_base, vxlan_port, samples_per_vnet):
+    ports = get_available_vlan_id_and_ports(config_facts, num_vnets)
+    pytest_assert(ports and len(ports) >= num_vnets, "Not enough ports for VNET setup")
+
+    port_indexes = config_facts["port_index_map"]
+
+    host_interfaces = tbinfo["topo"]["ptf_map"][str(dut_indx)]
+    ptf_ports_available_in_topo = {host_interfaces[k]: f"eth{k}" for k in host_interfaces}
+    logger.info(f"PTF port map: {ptf_ports_available_in_topo}")
+
+    ecmp_utils.Constants["KEEP_TEMP_FILES"] = False
+    ecmp_utils.Constants["DEBUG"] = True
+
+    for p in ports:
+        duthost.shell(f"config vlan member del all {p} || true")
+
+    dut_vtep = get_loopback_ip(cfg_facts)
+    ptf_vtep = PTF_VTEP
+    vxlan_tun = TUNNEL_NAME
+    apply_chunk(duthost, {"VXLAN_TUNNEL": {vxlan_tun: {"src_ip": dut_vtep}}}, "vxlan_tunnel")
+    res = duthost.shell("redis-cli -n 0 hget 'SWITCH_TABLE:switch' vxlan_router_mac")
+    vxlan_router_mac = res["stdout"].strip()
+
+    if not vxlan_router_mac:
+        vxlan_router_mac = duthost.facts["router_mac"]
+
+    logger.info(f"Using VXLAN router MAC: {vxlan_router_mac}")
+
+    vnet_ptf_map = {}
+
+    for idx in range(num_vnets):
+        vnet_id = idx + 1
+        vnet_name = f"Vnet{vnet_id}"
+        vni = vnet_base + vnet_id
+        iface = ports[idx]
+        ptf_port_index = port_indexes[iface]
+        port_name = ptf_ports_available_in_topo[ptf_port_index]
+
+        dut_intf_ip = f"201.0.{vnet_id}.1"
+        ingress_ptf_ip = f"201.0.{vnet_id}.101"
+
+        vnet_ptf_map[vnet_name] = {
+            "vnet_id": vnet_id,
+            "dut_intf": iface,
+            "ptf_intf": port_name,
+            "ptf_ifindex": ptf_port_index,
+        }
+
+        logger.info(f"Configuring {vnet_name} on {iface} <-> {port_name}")
+
+        ptfhost.shell(f"ip addr flush dev {port_name}")
+        ptfhost.shell(f"ip addr add {ingress_ptf_ip}/24 dev {port_name}")
+        ptfhost.shell(f"ip link set {port_name} up")
+
+        apply_chunk(
+            duthost,
+            {
+                "VNET": {
+                    vnet_name: {
+                        "vni": str(vni),
+                        "vxlan_tunnel": vxlan_tun
+                    }
+                }
+            },
+            f"vnet_{vnet_name}",
+        )
+        time.sleep(1)
+        apply_chunk(
+            duthost,
+            {
+                "INTERFACE": {
+                    iface: {"vnet_name": vnet_name},
+                    f"{iface}|{dut_intf_ip}/24": {},
+                }
+            },
+            f"intf_{vnet_name}",
+        )
+
+    routes_to_test_file_paths = {}
+    for idx in range(num_vnets):
+        vnet_id = idx + 1
+        vnet_name = f"Vnet{vnet_id}"
+        vni = vnet_base + vnet_id
+        logger.info(f"Generating {routes_per_vnet} routes for {vnet_name}")
+        routes, endpoints = generate_routes_and_endpoint(vnet_id, routes_per_vnet)
+        vnet_routes = {
+            f"{vnet_name}|{routes[i]}": {"endpoint": endpoints[i]} for i in range(routes_per_vnet)
+        }
+
+        logger.info(f"Applying {len(vnet_routes)} routes for {vnet_name}")
+        apply_chunk(duthost, {"VNET_ROUTE_TUNNEL": vnet_routes}, f"vnet_routes_{vnet_name}")
+
+        logger.info(f"Generating test routes file for {vnet_name} during setup.")
+        file_path = generate_routes_to_test_file(
+            ptfhost,
+            samples_per_vnet,
+            routes_per_vnet,
+            vnet_name,
+            routes,
+            endpoints
+        )
+        routes_to_test_file_paths[vnet_name] = file_path
+        time.sleep(3)
+
+    logger.info("Discovering PortChannel egress members ...")
+    egress_ptf_if = []
+    pc_members = cfg_facts.get("PORTCHANNEL_MEMBER", {})
+
+    for pc_key in pc_members.keys():
+        # key format: "PortChannel101|Ethernet0"
+        _, member = pc_key.split("|")
+        if member in port_indexes:
+            ptf_index = port_indexes[member]
+            if ptf_index in ptf_ports_available_in_topo:
+                egress_ptf_if.append(ptf_index)
+
+    pytest_assert(egress_ptf_if, "No egress PTF interfaces discovered from PortChannels")
+    logger.info(f"Egress PTF interfaces: {egress_ptf_if}")
+
+    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=vxlan_port, dutmac=vxlan_router_mac)
+
+    logger.info("Waiting for all VNET routes to appear in STATE_DB (max 120s)")
+    ready_state = wait_until(
+        120, 10, 0,
+        all_vnet_routes_in_state_db,
+        duthost,
+        num_vnets,
+        routes_per_vnet
+    )
+    if not ready_state:
+        logger.warning("Timeout waiting for all VNET routes in STATE_DB")
+        pytest.fail("STATE_DB route programming incomplete after 120 s")
+    else:
+        logger.info("All VNET routes detected in STATE_DB")
+
+    setup_params = {
+        "dut_vtep": dut_vtep,
+        "ptf_vtep": ptf_vtep,
+        "vnet_base": vnet_base,
+        "num_vnets": num_vnets,
+        "routes_per_vnet": routes_per_vnet,
+        "vnet_ptf_map": vnet_ptf_map,
+        "egress_ptf_if": egress_ptf_if,
+        "vxlan_port": vxlan_port,
+        "router_mac": duthost.facts["router_mac"],
+        "mac_switch": vxlan_router_mac,
+        "samples_per_vnet": samples_per_vnet,
+        "routes_to_test_file_paths": routes_to_test_file_paths
+    }
+    return setup_params
+
+
+@pytest.fixture(scope="module", autouse=True)
+def vxlan_scale_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, tbinfo,
+                               scaled_vnet_params, localhost, request):
+    duthost = duthosts[rand_one_dut_hostname]
+    logger.info(f"Starting VXLAN scale setup on DUT: {duthost.hostname}")
+    setup_params = {}
+
+    duthost.shell("cp /etc/sonic/config_db.json /etc/sonic/config_db.json.bak")
+    try:
+        cfg_facts = json.loads(duthost.shell("sonic-cfggen -d --print-data")["stdout"])
+        config_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
+        num_vnets = scaled_vnet_params.get("num_vnet") or 5
+        routes_per_vnet = scaled_vnet_params.get("num_routes") or 1000
+        samples_per_vnet = request.config.getoption("num_samples") or -1
+        vnet_base = 10000
+        duts_map = tbinfo["duts_map"]
+        dut_indx = duts_map[duthost.hostname]
+        vxlan_port = request.config.option.vxlan_port
+
+        logger.info(f"Using num_vnets={num_vnets}, routes_per_vnet={routes_per_vnet}")
+
+        setup_params = vxlan_setup_config(
+            config_facts,
+            cfg_facts,
+            duthost,
+            dut_indx,
+            ptfhost,
+            tbinfo,
+            num_vnets,
+            routes_per_vnet,
+            vnet_base,
+            vxlan_port,
+            samples_per_vnet
+        )
+    except Exception as e:
+        logger.error("Exception raised in setup: {}".format(repr(e)))
+        logger.error(json.dumps(
+            traceback.format_exception(*sys.exc_info()), indent=2))
+        restore_config_db(localhost, duthost, ptfhost, setup_params)
+        pytest.fail("Vnet testing setup failed")
+
+    yield setup_params, duthost
+
+    restore_config_db(localhost, duthost, ptfhost, setup_params)
+    logger.info("VXLAN scale setup and teardown completed")
+
+
+# -------------------------------------------------------------------
+# Testcases
+# -------------------------------------------------------------------
+def test_vxlan_scale_traffic(vxlan_scale_setup_teardown, ptfhost):
+    """
+    Run the full-scale VXLAN traffic test via PTF.
+    """
+    setup_params, duthost = vxlan_scale_setup_teardown
+    logger.info("Launching PTF VXLANScaleTest with params: %s", setup_params)
+
+    ptf_runner(
+        ptfhost,
+        "ptftests",
+        "vxlan_traffic_scale.VXLANScaleTest",
+        platform_dir="ptftests",
+        params=setup_params,
+        qlen=1000,
+        log_file="/tmp/vxlan_traffic_scale.log",
+        is_python3=True
+    )
+
+    logger.info("VXLAN traffic test completed successfully")
+
+
+def test_vxlan_scale_config_reload(vxlan_scale_setup_teardown, ptfhost, duthosts, rand_one_dut_hostname):
+    setup_params, duthost = vxlan_scale_setup_teardown
+    logger.info("Running VXLAN scale config reload test")
+
+    num_vnets = setup_params["num_vnets"]
+    routes_per_vnet = setup_params["routes_per_vnet"]
+
+    logger.info("Saving config before reload...")
+    duthost.shell("config save -y")
+    time.sleep(10)
+    logger.info("Performing config reload...")
+    duthost.shell("config reload -y")
+    time.sleep(10)
+
+    logger.info("Waiting for VNET routes to repopulate STATE_DB after reload (max 120s)")
+    ready = wait_until(
+        120, 30, 0,
+        all_vnet_routes_in_state_db,
+        duthost,
+        num_vnets,
+        routes_per_vnet
+    )
+
+    if not ready:
+        pytest.fail("State DB VNET routes failed to repopulate after config reload")
+
+    logger.info("All VNET routes restored in STATE_DB after reload")
+    logger.info("Running PTF traffic after config reload")
+
+    ptf_runner(
+        ptfhost,
+        "ptftests",
+        "vxlan_traffic_scale.VXLANScaleTest",
+        platform_dir="ptftests",
+        params=setup_params,
+        qlen=1000,
+        log_file="/tmp/vxlan_traffic_scale_reload.log",
+        is_python3=True
+    )
+
+    logger.info("VXLAN scale config-reload test PASSED")
+
+
+def test_vxlan_scale_mac_vni(vxlan_scale_setup_teardown, ptfhost):
+    """
+    Modify all /32 VNET routes created in setup:
+    - Assign unique deterministic MAC per route
+    - Assign a VNI bucket per route index
+    - Apply updates via sonic-cfggen JSON chunks (FAST)
+    """
+    setup, duthost = vxlan_scale_setup_teardown
+
+    vnet_base = setup["vnet_base"]
+    routes_per_vnet = setup["routes_per_vnet"]
+
+    logger.info("Updating ALL VNET routes with deterministic MAC + VNI (cfggen batch mode)...")
+
+    def gen_mac(vnet_id, idx, base_mac="52:54:aa"):
+        hi = (idx >> 8) & 0xFF
+        lo = idx & 0xFF
+        return f"{base_mac}:{vnet_id:02x}:{hi:02x}:{lo:02x}"
+
+    def gen_vni(vnet_id, idx, group_size=VNI_BUCKET_SIZE, offset=0):
+        bucket = idx // group_size
+        return vnet_base + (vnet_id * group_size) + bucket + offset
+
+    # Add mac and vni to routes and run datapath test
+    for vnet_name, mapping in setup["vnet_ptf_map"].items():
+        vnet_id = mapping["vnet_id"]
+
+        logger.info(f"Building JSON update for {vnet_name}, {routes_per_vnet} routes")
+
+        route_updates = {}
+
+        routes, endpoints = generate_routes_and_endpoint(vnet_id, routes_per_vnet)
+        all_macs_for_vnet = [gen_mac(vnet_id, i) for i in range(routes_per_vnet)]
+        all_vnis_for_vnet = [gen_vni(vnet_id, i) for i in range(routes_per_vnet)]
+        for i in range(routes_per_vnet):
+            route_updates[f"{vnet_name}|{routes[i]}"] = {
+                "endpoint": endpoints[i],
+                "mac_address": all_macs_for_vnet[i],
+                "vni": str(all_vnis_for_vnet[i])
+            }
+
+        # Write JSON file
+        cfg_file = f"/tmp/{vnet_name}_route_macvni.json"
+        duthost.copy(content=json.dumps({"VNET_ROUTE_TUNNEL": route_updates}, indent=2),
+                     dest=cfg_file)
+
+        # Apply with cfggen
+        logger.info(f"Applying updates for {vnet_name} via sonic-cfggen")
+        duthost.shell(f"sonic-cfggen -j {cfg_file} --write-to-db")
+
+        # Generate new test routes file with MAC and VNI for PTF validation
+        # file path should be same as initial setup
+        logger.info(f"Generating new test routes file with MAC/VNI for {vnet_name}")
+        generate_routes_to_test_file(
+            ptfhost,
+            setup["samples_per_vnet"],
+            routes_per_vnet,
+            vnet_name,
+            routes,
+            endpoints,
+            mac_addresses=all_macs_for_vnet,
+            vnis=all_vnis_for_vnet
+        )
+
+    time.sleep(20)
+
+    logger.info("All route MAC+VNI updates applied via batch cfggen.")
+
+    # ---- Run PTF ----
+    ptf_params = {
+        **setup,
+        "mac_vni_per_vnet": "yes",
+        "vni_batch_size": VNI_BUCKET_SIZE,
+    }
+
+    ptf_runner(
+        ptfhost,
+        "ptftests",
+        "vxlan_traffic_scale.VXLANScaleTest",
+        platform_dir="ptftests",
+        params=ptf_params,
+        log_file="/tmp/vxlan_scale_macvni.log",
+        is_python3=True
+    )
+
+    # Modify mac, vni, and endpoint and rerun datapath test
+    for vnet_name, mapping in setup["vnet_ptf_map"].items():
+        vnet_id = mapping["vnet_id"]
+
+        logger.info(f"Building JSON update for {vnet_name}, {routes_per_vnet} routes")
+
+        route_updates = {}
+        routes, endpoints = generate_routes_and_endpoint(vnet_id, routes_per_vnet, 1)
+        all_macs_for_vnet = [gen_mac(vnet_id, i, base_mac="52:54:bb") for i in range(routes_per_vnet)]
+        all_vnis_for_vnet = [gen_vni(vnet_id, i, offset=1) for i in range(routes_per_vnet)]
+        for i in range(routes_per_vnet):
+            route_updates[f"{vnet_name}|{routes[i]}"] = {
+                "endpoint": endpoints[i],
+                "mac_address": all_macs_for_vnet[i],
+                "vni": str(all_vnis_for_vnet[i]),
+            }
+
+        # Write JSON file
+        cfg_file = f"/tmp/{vnet_name}_route_macvni.json"
+        duthost.copy(content=json.dumps({"VNET_ROUTE_TUNNEL": route_updates}, indent=2),
+                     dest=cfg_file)
+
+        # Apply with cfggen
+        logger.info(f"Applying updates for {vnet_name} via sonic-cfggen")
+        duthost.shell(f"sonic-cfggen -j {cfg_file} --write-to-db")
+
+        # Generate new test routes file with MAC and VNI for PTF validation
+        # file path should be same as initial setup
+        logger.info(f"Generating new test routes file with MAC/VNI for {vnet_name}")
+        generate_routes_to_test_file(
+            ptfhost,
+            setup["samples_per_vnet"],
+            routes_per_vnet,
+            vnet_name,
+            routes,
+            endpoints,
+            mac_addresses=all_macs_for_vnet,
+            vnis=all_vnis_for_vnet
+        )
+
+    time.sleep(20)
+
+    logger.info("All route MAC+VNI updates applied via batch cfggen.")
+
+    # ---- Run PTF ----
+    ptf_params = {
+        **setup,
+        "mac_vni_per_vnet": "yes",
+        "vni_batch_size": VNI_BUCKET_SIZE,
+        "base_mac": "52:54:bb",
+    }
+
+    ptf_runner(
+        ptfhost,
+        "ptftests",
+        "vxlan_traffic_scale.VXLANScaleTest",
+        platform_dir="ptftests",
+        params=ptf_params,
+        log_file="/tmp/vxlan_scale_macvni.log",
+        is_python3=True
+    )
+
+    logger.info("MAC+VNI scale verification complete.")

--- a/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
+++ b/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
@@ -1,0 +1,778 @@
+import logging
+import json
+import os
+from ptf.mask import Mask
+from ptf.packet import Ether, IP, UDP, TCP
+import ptf.testutils as testutils
+import pytest
+import time
+from tests.common.gnmi_setup import apply_cert_config, recover_cert_config
+from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.config_reload import config_reload
+from tests.common.utilities import wait_until
+from tests.common.vxlan_ecmp_utils import Ecmp_Utils
+from tests.common.helpers.dut_utils import check_container_state
+from tests.common.helpers.gnmi_utils import GNMIEnvironment, gnmi_container, create_gnmi_certs, \
+    delete_gnmi_certs
+
+ecmp_utils = Ecmp_Utils()
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("t0"),
+    pytest.mark.device_type('physical'),
+    pytest.mark.asic('cisco-8000')
+]
+
+CONFIG_DB_PATH = '/etc/sonic/config_db.json'
+EXABGP_CONFIG_PATH = "/etc/exabgp/exabgp_vnet_bgp.conf"
+EXABGP_PORT = 5100
+
+PORTCHANNEL_NAMES = ["PortChannel1031", "PortChannel1032"]
+VXLAN_PORT = 4789
+TUNNEL_ENDPOINT = "100.0.1.10"
+INNER_SRC_MAC = "00:11:22:33:44:55"
+INNER_SRC_IP = "2.2.2.2"
+BASE_VNI = 1000
+NUM_VNETS = 2
+
+ACL_TYPE_NAME = "INNER_SRC_MAC_REWRITE_TYPE"
+ACL_TABLE_NAME = "INNER_SRC_MAC_REWRITE_TABLE"
+
+GNMI_PATH_PREFIX = "/CONFIG_DB/localhost"
+
+temp_files = []
+
+
+def validate_encap_wl_to_t1(duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs):
+    logger.info("Starting WL to T1 VXLAN encapsulation test...")
+
+    for _, val in subintfs_info.items():
+        # Build inner TCP packet to inject from southbound side
+        pkt_opts = {
+            "eth_dst": duthost.facts['router_mac'],
+            "eth_src": ptfadapter.dataplane.get_mac(0, val["ptf_port_index"]),
+            "ip_dst": "150.0.0.10",
+            "ip_src": INNER_SRC_IP,
+            "ip_id": 105,
+            "ip_ttl": 64,
+            "dl_vlan_enable": True,
+            "vlan_vid": val["vlan"],
+            "tcp_sport": 1234,
+            "tcp_dport": 5000,
+            "pktlen": 100
+        }
+
+        inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+
+        # Build expected packet
+        vxlan_router_mac = duthost.shell("sonic-db-cli APPL_DB HGET 'SWITCH_TABLE:switch' 'vxlan_router_mac'")
+        pkt_opts["eth_src"] = INNER_SRC_MAC  # expected rewritten inner src mac
+        pkt_opts["eth_dst"] = vxlan_router_mac['stdout'].strip()
+        pkt_opts["ip_ttl"] = 63
+        pkt_opts["dl_vlan_enable"] = False
+        pkt_opts["pktlen"] = 96  # 100 - 4, remove vlan tag length
+
+        inner_exp_pkt = testutils.simple_tcp_packet(**pkt_opts)
+
+        expected_pkt = testutils.simple_vxlan_packet(
+            eth_dst="aa:bb:cc:dd:ee:ff",
+            eth_src=duthost.facts['router_mac'],
+            ip_src=test_configs["loopback_ip"],
+            ip_dst=TUNNEL_ENDPOINT,
+            ip_id=0,
+            ip_flags=0x2,
+            udp_sport=1234,
+            udp_dport=VXLAN_PORT,
+            with_udp_chksum=False,
+            vxlan_vni=int(val["vnet_vni"]),
+            inner_frame=inner_exp_pkt
+        )
+
+        masked_expected_pkt = Mask(expected_pkt)
+        masked_expected_pkt.set_ignore_extra_bytes()
+        masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
+        masked_expected_pkt.set_do_not_care_packet(UDP, 'sport')
+        masked_expected_pkt.set_do_not_care_packet(UDP, 'chksum')
+        masked_expected_pkt.set_do_not_care_packet(IP, "ttl")
+        masked_expected_pkt.set_do_not_care_packet(IP, "chksum")
+        masked_expected_pkt.set_do_not_care_packet(IP, "id")
+        masked_expected_pkt.set_do_not_care_packet(IP, "len")
+        masked_expected_pkt.set_do_not_care_packet(IP, "tos")
+
+        # Clear packet queue on all ports and get initial acl counter
+        ptfadapter.dataplane.flush()
+
+        # Send TCP packet from WL port
+        testutils.send(ptfadapter, val['ptf_port_index'], inner_pkt)
+
+        # Verify VXLAN encapsulated pkt on T1 port with rewritten inner src MAC
+        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, test_configs["t1_ptf_port_nums"], timeout=2)
+
+    logger.info("WL to T1 VXLAN encapsulation test passed.")
+
+
+def validate_decap_t1_to_wl(duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs):
+    logger.info("Starting T1 to WL VXLAN decapsulation test...")
+
+    ports_per_vnet = {}
+    for _, val in subintfs_info.items():
+        vni = val["vnet_vni"]
+        if vni not in ports_per_vnet:
+            ports_per_vnet[vni] = []
+        ports_per_vnet[vni].append(val["ptf_port_index"])
+
+    for _, val in subintfs_info.items():
+        pkt_opts = {
+            "eth_dst": "aa:bb:cc:dd:ee:ff",
+            "eth_src": duthost.facts['router_mac'],
+            "ip_src": "8.8.8.8",
+            "ip_dst": "10.11.255.255",
+            "tcp_sport": 1234,
+            "tcp_dport": 4321,
+            "pktlen": 100
+        }
+
+        # Build inner TCP packet expected on WL port
+        inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+
+        # Build VXLAN encapsulated packet to inject from T1 side
+        vxlan_pkt = testutils.simple_vxlan_packet(
+            eth_dst=duthost.facts['router_mac'],
+            eth_src=ptfadapter.dataplane.get_mac(0, test_configs["t1_ptf_port_nums"][0]),
+            ip_src="1.1.1.1",
+            ip_dst=test_configs["loopback_ip"],
+            udp_sport=1234,
+            udp_dport=VXLAN_PORT,
+            with_udp_chksum=False,
+            vxlan_vni=int(val["vnet_vni"]),
+            inner_frame=inner_pkt
+        )
+
+        # Build expected inner packet after decapsulation
+        pkt_opts["vlan_vid"] = val["vlan"]
+        pkt_opts["dl_vlan_enable"] = True
+        pkt_opts["pktlen"] = 104     # 100 + 4, add vlan tag length
+        expected_inner_pkt = testutils.simple_tcp_packet(**pkt_opts)
+
+        masked_expected_pkt = Mask(expected_inner_pkt)
+        masked_expected_pkt.set_ignore_extra_bytes()
+        masked_expected_pkt.set_do_not_care_packet(Ether, 'dst')
+        masked_expected_pkt.set_do_not_care_packet(IP, "ttl")
+        masked_expected_pkt.set_do_not_care_packet(IP, "chksum")
+        masked_expected_pkt.set_do_not_care_packet(IP, "id")
+        masked_expected_pkt.set_do_not_care_packet(TCP, 'chksum')
+        masked_expected_pkt.set_do_not_care_packet(IP, "len")
+        masked_expected_pkt.set_do_not_care_packet(IP, "tos")
+
+        # Clear packet queue on all ports
+        ptfadapter.dataplane.flush()
+
+        # Send VXLAN encapsulated pkt from T1 port
+        testutils.send(ptfadapter, test_configs["t1_ptf_port_nums"][0], vxlan_pkt)
+
+        # Verify decapsulated unencapsulated packet on southbound port
+        testutils.verify_packet_any_port(ptfadapter, masked_expected_pkt, ports_per_vnet[val["vnet_vni"]], timeout=2)
+
+    logger.info("T1 to WL VXLAN decapsulation test passed.")
+
+
+def cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info):
+    """
+    Return duthost and ptfhost to original state.
+
+    Args:
+        duthost: DUT host
+        ptfhost: PTF host
+        bond_port_mapping: map of bond port name (bond#) to ptf port name (eth#)
+    """
+    # Restore config db
+    logger.debug("cleanup: Loading backup config db json.")
+    duthost.shell(f"mv {CONFIG_DB_PATH}.bak {CONFIG_DB_PATH}")
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
+
+    # clean up gnmi server
+    recover_cert_config(duthost)
+
+    cmds = []
+    # Remove sub port
+    try:
+        for _, val in subintfs_info.items():
+            sub_port = val["bond_name"]
+            ip = val['ptf_ip']
+            cmds.append("ip address del {} dev {}".format(ip, sub_port))
+            cmds.append("ip link del {}".format(sub_port))
+        ptfhost.shell_cmds(cmds=cmds)
+    except Exception as e:
+        logger.error(f"Error occurred while cleaning up sub interfaces: {e}")
+
+    cmds = []
+    # Remove bond ports
+    try:
+        for key, val in wl_portchannel_info.items():
+            bond_port = val["bond_port"]
+            port_name = val["ptf_port_name"]
+            cmds.append("ip link set {} nomaster".format(bond_port))
+            cmds.append("ip link set {} nomaster".format(port_name))
+            cmds.append("ip link set {} up".format(port_name))
+            cmds.append("ip link del {}".format(bond_port))
+        ptfhost.shell_cmds(cmds=cmds)
+    except Exception as e:
+        logger.error(f"Error occurred while cleaning up bond interfaces: {e}")
+
+    # Stop exabgp process
+    kill_exabgp = f"""
+MAIN_PID=$(pgrep -f "exabgp {EXABGP_CONFIG_PATH}")
+if [ -n "$MAIN_PID" ]; then
+    echo "Killing test ExaBGP instance PID=$MAIN_PID"
+    kill -9 $MAIN_PID 2>/dev/null
+fi
+"""
+    ptfhost.shell(kill_exabgp, module_ignore_errors=True)
+
+    kill_http_api = f"""
+API_PID=$(pgrep -f "/usr/share/exabgp/http_api.py {EXABGP_PORT}")
+if [ -n "$API_PID" ]; then
+    echo "Killing test http_api.py PID=$API_PID"
+    kill -9 $API_PID 2>/dev/null
+fi
+"""
+    ptfhost.shell(kill_http_api, module_ignore_errors=True)
+
+    # Remove tmp files
+    for file in temp_files:
+        if os.path.exists(file):
+            os.remove(file)
+
+    # cleanup gnmi cert files
+    delete_gnmi_certs(localhost)
+
+
+def get_available_vlan_id_and_ports(cfg_facts, num_ports_needed):
+    """
+    Return vlan id and available ports in that vlan if there are enough ports available.
+
+    Args:
+        cfg_facts: DUT config facts
+        num_ports_needed: number of available ports needed for test
+    """
+    port_status = cfg_facts["PORT"]
+    vlan_id = -1
+    available_ports = []
+    pytest_require("VLAN_MEMBER" in cfg_facts, "Can't get vlan member")
+    for vlan_name, members in list(cfg_facts["VLAN_MEMBER"].items()):
+        # Number of members in vlan is insufficient
+        if len(members) < num_ports_needed:
+            continue
+
+        # Get available ports in vlan
+        possible_ports = []
+        for vlan_member in members:
+            if port_status[vlan_member].get("admin_status", "down") != "up":
+                continue
+
+            possible_ports.append(vlan_member)
+            if len(possible_ports) == num_ports_needed:
+                available_ports = possible_ports[:]
+                vlan_id = int(''.join([i for i in vlan_name if i.isdigit()]))
+                break
+
+        if vlan_id != -1:
+            break
+
+    logger.debug(f"Vlan {vlan_id} has available ports: {available_ports}")
+    return vlan_id, available_ports
+
+
+def convert_ip_int_to_str(ip_int, prefix_size=31):
+    """
+    Convert integer IP to string format with prefix size.
+    """
+    return f"{ip_int >> 24 & 0xFF}.{ip_int >> 16 & 0xFF}.{ip_int >> 8 & 0xFF}.{ip_int & 0xFF}/{prefix_size}"
+
+
+def convert_str_to_ip_int(ip_str):
+    """
+    Convert string IP to integer format.
+    """
+    ip_parts = ip_str.split('/')
+    ip = ip_parts[0]
+    octets = ip.split('.')
+    ip_int = int(octets[0]) << 24 | int(octets[1]) << 16 | int(octets[2]) << 8 | int(octets[3])
+    prefix = int(ip_parts[1]) if len(ip_parts) > 1 else 32
+    return ip_int, prefix
+
+
+def generate_subintfs_ips(num_vnets, num_portchannels, start_ip_int, prefix_size=31):
+    """
+    Generate subnets for subintfs, incrementing third octect for each vnet, and fourth octet for each portchannel.
+    """
+    num_ips_per_prefix = 2 ** (32 - prefix_size)
+    pytest_assert(num_ips_per_prefix * num_portchannels + (start_ip_int & 0xFF) < 0xFF,
+                  "Not enough IP addresses in last octet to allocate for subinterfaces.")
+    pytest_assert(num_vnets + (start_ip_int >> 8 & 0xFF) < 0xFF,
+                  "Not enough IP addresses in third octet to allocate for subinterfaces.")
+
+    all_subintf_ips = []
+    all_ptf_ips = []
+
+    for i in range(num_portchannels):
+        subintf_ips = []
+        ptf_ips = []
+        fourth_octet_offset = i * num_ips_per_prefix
+        for j in range(num_vnets):
+            ip_int = start_ip_int + fourth_octet_offset + (j << 8)
+            subintf_ips.append(
+                convert_ip_int_to_str(ip_int, prefix_size)
+            )
+            ptf_ips.append(
+                convert_ip_int_to_str(ip_int + 1, prefix_size)
+            )
+
+        all_subintf_ips.append(subintf_ips)
+        all_ptf_ips.append(ptf_ips)
+
+    return all_subintf_ips, all_ptf_ips
+
+
+def gnmi_set_update_config_db_json(duthost, ptfhost, path, value, filename="test_config"):
+    """
+    Send GNMI set request with GNMI client. This helper will only send add/update requests with a json value format.
+    """
+    filename += ".txt"
+    with open(filename, 'w') as file:
+        file.write(json.dumps(value))
+    ptfhost.copy(src=filename, dest='/tmp')
+
+    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    ip = duthost.mgmt_ip
+    port = env.gnmi_port
+
+    cmd = f"/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py \
+        --timeout 10 -t {ip} -p {port} -xo sonic-db -rcert /root/gnmiCA.pem \
+        -pkey /root/gnmiclient.key -cchain /root/gnmiclient.crt -m set-update \
+        --xpath \"{path}\" --value \"@/tmp/{filename}\""
+    ptfhost.shell(cmd)
+
+    temp_files.append(filename)
+
+
+def setup_acl_config(duthost, ptfhost, ports, vnet_vnis):
+    """
+    Add a custom ACL table type definition to CONFIG_DB.
+    """
+    gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/ACL_TABLE_TYPE", {
+        ACL_TYPE_NAME: {
+            "BIND_POINTS": [
+                "PORT",
+                "PORTCHANNEL"
+            ],
+            "MATCHES": [
+                "INNER_SRC_IP",
+                "TUNNEL_VNI"
+            ],
+            "ACTIONS": [
+                "COUNTER",
+                "INNER_SRC_MAC_REWRITE_ACTION"
+            ]
+        }
+    }, "acl_type")
+
+    gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/ACL_TABLE", {
+        ACL_TABLE_NAME: {
+            "policy_desc": ACL_TABLE_NAME,
+            "ports": ports,
+            "stage": "egress",
+            "type": ACL_TYPE_NAME
+        }
+    }, "acl_table")
+
+    gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/ACL_RULE", {
+        f"{ACL_TABLE_NAME}|rule_{vni}": {
+            "INNER_SRC_IP": f"{INNER_SRC_IP}/32",
+            "INNER_SRC_MAC_REWRITE_ACTION": INNER_SRC_MAC,
+            "TUNNEL_VNI": f"{vni}",
+            "PRIORITY": f"{vni}"
+        } for vni in vnet_vnis
+    }, "acl_rule")
+
+    # Check acl table and rules are set
+    def _acl_table_and_rule_active(duthost):
+        acl_table = duthost.shell(
+            f"sonic-db-cli STATE_DB HGET 'ACL_TABLE_TABLE|{ACL_TABLE_NAME}' 'status'",
+            module_ignore_errors=True)
+        if acl_table.get('stdout', '').strip().lower() != "active":
+            return False
+
+        for vni in vnet_vnis:
+            acl_rule = duthost.shell(
+                f"sonic-db-cli STATE_DB HGET 'ACL_RULE_TABLE|{ACL_TABLE_NAME}|rule_{vni}' 'status'",
+                module_ignore_errors=True)
+            if acl_rule.get('stdout', '').strip().lower() != "active":
+                return False
+        return True
+
+    pytest_assert(wait_until(60, 2, 0, _acl_table_and_rule_active, duthost),
+                  f"ACL table {ACL_TABLE_NAME} or its rules not active after 60 seconds.")
+
+
+def setup_vnet_routes(duthost, ptfhost, vnet_vnis):
+    gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/VNET_ROUTE_TUNNEL", {
+        f"Vnet{vni}|0.0.0.0/0": {
+            "endpoint": TUNNEL_ENDPOINT
+        } for vni in vnet_vnis
+    }, "vnet_routes")
+
+    # Check vnet routes are set
+    time.sleep(5)
+    for vni in vnet_vnis:
+        route_tunnel = duthost.shell(f"sonic-db-cli STATE_DB HGET \
+                                     'VNET_ROUTE_TUNNEL_TABLE|Vnet{vni}|0.0.0.0/0' 'state'")
+        pytest_assert(route_tunnel['stdout'].strip().lower() == "active",
+                      f"VNET route tunnel for Vnet{vni} not active.")
+
+
+def setup_bgp(duthost, ptfhost, vnet_vnis, dut_ips, ptf_ips, subnet_ip, loopback_ip, bgp_port, vnet_route_ip):
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    dut_asn = config_facts['DEVICE_METADATA']['localhost']['bgp_asn']
+    neighbors = config_facts['BGP_NEIGHBOR']
+    peer_asn = list(neighbors.values())[0]["asn"]
+
+    for vni in vnet_vnis:
+        gnmi_set_update_config_db_json(
+            duthost,
+            ptfhost,
+            f"{GNMI_PATH_PREFIX}/BGP_PEER_RANGE/Vnet{vni}|WLPARTNER_PASSIVE_V4",
+            {
+                "ip_range": [subnet_ip],
+                "name": "WLPARTNER_PASSIVE_V4",
+                "peer_asn": peer_asn,
+                "src_address": loopback_ip
+            },
+            f"bgp_peer_{vni}")
+
+    exabgp_config = f"""
+process api-vnets {{
+    run /usr/bin/python /usr/share/exabgp/http_api.py {bgp_port};
+    encoder json;
+}}
+"""
+
+    for dut_ips_per_portchannel, ptf_ips_per_portchannel in zip(dut_ips, ptf_ips):
+        for dut_ip, ptf_ip in zip(dut_ips_per_portchannel, ptf_ips_per_portchannel):
+            exabgp_config += f"""
+neighbor {dut_ip.split('/')[0]} {{
+    router-id {ptf_ip.split('/')[0]};
+    local-address {ptf_ip.split('/')[0]};
+    local-as {peer_asn};
+    peer-as {dut_asn};
+    api {{
+        processes [api-vnets];
+    }}
+    family {{
+        ipv4 unicast;
+    }}
+    static {{
+        route {vnet_route_ip} next-hop {ptf_ip.split('/')[0]};
+    }}
+}}
+"""
+
+    with open('/tmp/exabgp_update.conf', "w") as f:
+        f.write(exabgp_config)
+
+    ptfhost.copy(src='/tmp/exabgp_update.conf', dest=EXABGP_CONFIG_PATH)
+    ptfhost.shell(f"nohup exabgp {EXABGP_CONFIG_PATH} > /var/log/exabgp_all_vnets.log 2>&1 &")
+
+    # Check vrf bgp session is up
+    time.sleep(40)
+    for vni in vnet_vnis:
+        vnet_bgps = duthost.show_and_parse(f"show ip bgp vrf Vnet{vni} summary")
+        pytest_assert(len(vnet_bgps) > 0, f"No BGP sessions found for vnet Vnet{vni}.")
+        for val in vnet_bgps:
+            pytest_assert(val["neighborname"] == "WLPARTNER_PASSIVE_V4" and val["state/pfxrcd"].isdigit()
+                          and int(val["state/pfxrcd"]) > 0, f"BGP neighbor not found for vnet Vnet{vni}.")
+
+
+def setup_portchannel_subintfs(duthost, ptfhost, portchannel_info, vnet_vnis, base_vlan, dut_ips, ptf_ips):
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    has_subintfs = len(config_facts.get("VLAN_SUB_INTERFACE", {})) > 0
+
+    subintfs_info = {}
+
+    cmds = []
+    for i in range(len(vnet_vnis)):
+        for j, (key, val) in enumerate(portchannel_info.items()):
+            po_num = val["portchannel_num"]
+            bond_port = val["bond_port"]
+            subintf_name = f"Po{po_num}.{base_vlan + i}"
+
+            if not has_subintfs:
+                gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE", {
+                    subintf_name: {
+                        "admin_status": "up",
+                        "vlan": str(base_vlan + i),
+                        "vnet_name": f"Vnet{vnet_vnis[i]}"
+                    },
+                    f"{subintf_name}|{dut_ips[j][i]}": {}
+                }, subintf_name)
+                has_subintfs = True
+            else:
+                gnmi_set_update_config_db_json(
+                    duthost,
+                    ptfhost,
+                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}",
+                    {
+                        "admin_status": "up",
+                        "vlan": str(base_vlan + i),
+                        "vnet_name": f"Vnet{vnet_vnis[i]}"
+                    },
+                    subintf_name)
+                gnmi_set_update_config_db_json(
+                    duthost,
+                    ptfhost,
+                    f"{GNMI_PATH_PREFIX}/VLAN_SUB_INTERFACE/{subintf_name}|{dut_ips[j][i].replace('/','~1')}",
+                    {},
+                    f"{subintf_name}_ip")
+
+            # Configure ptf port commands
+            cmds.append(f"ip link add link {bond_port} name {bond_port}.{base_vlan + i} type vlan id {base_vlan + i}")
+            cmds.append(f"ip address add {ptf_ips[j][i]} dev {bond_port}.{base_vlan + i}")
+            cmds.append(f"ip link set {bond_port}.{base_vlan + i} up")
+
+            subintfs_info[subintf_name] = {
+                "portchannel_name": key,
+                "portchannel_num": po_num,
+                "ptf_port_index": val["ptf_port_index"],
+                "bond_name": f"{bond_port}.{base_vlan + i}",
+                "dut_ip": dut_ips[j][i],
+                "ptf_ip": ptf_ips[j][i],
+                "vlan": base_vlan + i,
+                "vnet": f"Vnet{vnet_vnis[i]}",
+                "vnet_vni": vnet_vnis[i],
+            }
+
+    ptfhost.shell_cmds(cmds=cmds)
+    ptfhost.shell("supervisorctl restart ptf_nn_agent")
+    time.sleep(5)
+
+    return subintfs_info
+
+
+def setup_portchannels(duthost, ptfhost, config_facts, port_indexes, ptf_ports_available_in_topo):
+    vlan_id, ports = get_available_vlan_id_and_ports(config_facts, len(PORTCHANNEL_NAMES))
+    pytest_assert(len(ports) == len(PORTCHANNEL_NAMES),
+                  f"Found {len(ports)} available ports. Needed {len(PORTCHANNEL_NAMES)} ports for the test.")
+
+    cmds = []
+    wl_portchannel_mapping_info = {}
+    for i in range(len(PORTCHANNEL_NAMES)):
+        duthost.shell(f'config vlan member del {vlan_id} {ports[i]}')
+
+        gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/PORTCHANNEL/{PORTCHANNEL_NAMES[i]}", {
+            "admin_status": "up"
+        }, PORTCHANNEL_NAMES[i])
+        gnmi_set_update_config_db_json(
+            duthost,
+            ptfhost,
+            f"{GNMI_PATH_PREFIX}/PORTCHANNEL_MEMBER/{PORTCHANNEL_NAMES[i]}|{ports[i]}",
+            {},
+            f"{PORTCHANNEL_NAMES[i]}_member")
+
+        # Configure ptf port commands
+        dut_port_index = port_indexes[ports[i]]
+        ptf_port_name = ptf_ports_available_in_topo[dut_port_index]["name"]
+        ptf_port_index = ptf_ports_available_in_topo[dut_port_index]["index"]
+
+        bond_port = 'bond{}'.format(ptf_port_index)
+        cmds.append("ip link add {} type bond".format(bond_port))
+        cmds.append("ip link set {} type bond miimon 100 mode 802.3ad".format(bond_port))
+        cmds.append("ip link set {} down".format(ptf_port_name))
+        cmds.append("ip link set {} master {}".format(ptf_port_name, bond_port))
+        cmds.append("ip link set dev {} up".format(bond_port))
+        cmds.append("ifconfig {} mtu 9216 up".format(bond_port))
+
+        wl_portchannel_mapping_info[PORTCHANNEL_NAMES[i]] = {
+            "portchannel_num": ''.join(filter(str.isdigit, PORTCHANNEL_NAMES[i])),
+            "ptf_port_name": ptf_port_name,
+            "ptf_port_index": ptf_port_index,
+            "bond_port": bond_port,
+        }
+
+    ptfhost.shell_cmds(cmds=cmds)
+    ptfhost.shell("supervisorctl restart ptf_nn_agent")
+    time.sleep(5)
+
+    return wl_portchannel_mapping_info
+
+
+def setup_vnets(duthost, ptfhost, num_vnets, tunnel, base_vni):
+    gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/VNET", {
+        f"Vnet{base_vni + i}": {
+            "vni": f"{base_vni + i}",
+            "vxlan_tunnel": tunnel
+        } for i in range(num_vnets)
+    }, "vnet")
+
+    return [base_vni + i for i in range(num_vnets)]
+
+
+def setup_vxlan_tunnel(duthost, ptfhost, name, src_ip):
+    gnmi_set_update_config_db_json(duthost, ptfhost, f"{GNMI_PATH_PREFIX}/VXLAN_TUNNEL", {
+        name: {
+            "src_ip": src_ip
+        }
+    }, "vxlan")
+
+
+def setup_gnmi_server(duthost, localhost, ptfhost):
+    '''
+    Setup GNMI server with client certificates
+    '''
+    # Check if GNMI is enabled on the device
+    pytest_require(
+        check_container_state(duthost, gnmi_container(duthost), should_be_running=True),
+        "Test was not supported on devices which do not support GNMI!")
+
+    create_gnmi_certs(duthost, localhost, ptfhost)
+    apply_cert_config(duthost)
+
+
+@pytest.fixture(scope="module")
+def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, ptfadapter, localhost):
+    duthost = duthosts[rand_one_dut_hostname]
+
+    # backup config_db.json for cleanup
+    duthost.shell(f"cp {CONFIG_DB_PATH} {CONFIG_DB_PATH}.bak")
+
+    ecmp_utils.Constants["KEEP_TEMP_FILES"] = False
+    ecmp_utils.Constants["DEBUG"] = True
+
+    wl_portchannel_info = None
+    subintfs_info = None
+
+    try:
+        config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+
+        port_indexes = config_facts['port_index_map']  # map of dut port name to dut port index
+        duts_map = tbinfo["duts_map"]
+        dut_indx = duts_map[duthost.hostname]
+        # Get available ports in PTF
+        host_interfaces = tbinfo["topo"]["ptf_map"][str(dut_indx)]  # map of ptf port index to dut port index
+        ptf_ports_available_in_topo = {}
+        for key in host_interfaces:
+            ptf_ports_available_in_topo[host_interfaces[key]] = {  # map of dut port index to ptf port info
+                "index": int(key),
+                "name": "eth{}".format(int(key))
+            }
+
+        # setup gnmi server
+        setup_gnmi_server(duthost, localhost, ptfhost)
+
+        # Remove everflow acl tables
+        duthost.remove_acl_table("EVERFLOW")
+        duthost.remove_acl_table("EVERFLOWV6")
+
+        # Create loopback interface
+        duthost.shell("config int ip add Loopback6 10.10.1.1")
+        loopback_ip = "10.10.1.1"
+
+        subnet_ip = "10.11.0.0/16"
+        subnet_ip_int, _ = convert_str_to_ip_int(subnet_ip)
+
+        # Set up vxlan
+        setup_vxlan_tunnel(duthost, ptfhost, "tunnel_v4", loopback_ip)
+
+        #  Set up vnets
+        vnet_vnis = setup_vnets(duthost, ptfhost, NUM_VNETS, "tunnel_v4", BASE_VNI)
+
+        # Set up portchannels
+        wl_portchannel_info = setup_portchannels(duthost, ptfhost, config_facts,
+                                                 port_indexes, ptf_ports_available_in_topo)
+
+        # Set up subintfs
+        dut_ips, ptf_ips = generate_subintfs_ips(NUM_VNETS, len(PORTCHANNEL_NAMES), start_ip_int=subnet_ip_int)
+        subintfs_info = setup_portchannel_subintfs(
+            duthost,
+            ptfhost,
+            wl_portchannel_info,
+            vnet_vnis,
+            base_vlan=10,
+            dut_ips=dut_ips,
+            ptf_ips=ptf_ips)
+
+        # Set up bgps
+        setup_bgp(
+            duthost,
+            ptfhost,
+            vnet_vnis,
+            dut_ips,
+            ptf_ips,
+            subnet_ip,
+            loopback_ip,
+            bgp_port=EXABGP_PORT,
+            vnet_route_ip=subnet_ip)
+
+        # Set up vnet routes
+        setup_vnet_routes(duthost, ptfhost, vnet_vnis)
+
+        # Setup acl configs
+        config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+        setup_acl_config(duthost, ptfhost, list(config_facts.get("PORTCHANNEL", {}).keys()), vnet_vnis)
+
+        # Configure vxlan port
+        ecmp_utils.configure_vxlan_switch(duthost, VXLAN_PORT, "00:12:34:56:78:9a")
+
+        # Get ptf eth of T1 portchannels
+        t1_ptf_port_nums = []
+        portchannel_members = config_facts.get("PORTCHANNEL_MEMBER", {})
+        for key in portchannel_members:
+            members = list(portchannel_members[key].keys())
+            for intf in members:
+                dut_port_idx = port_indexes.get(intf)
+                if dut_port_idx is None:
+                    continue
+                ptf_port = ptf_ports_available_in_topo.get(dut_port_idx)
+                if ptf_port is None:
+                    # Port not in this DUT's ptf_map (e.g. dualtor: port on other ToR)
+                    continue
+                if key not in wl_portchannel_info:
+                    t1_ptf_port_nums.append(ptf_port["index"])
+
+        # Check have enough T1 ports to run tests
+        pytest_assert(len(t1_ptf_port_nums) > 0, "No T1 side portchannel member ports found in PTF topo.")
+    except Exception as e:
+        # Cleanup on failure during setup
+        logger.error(f"Exception during setup: {repr(e)}.")
+        cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info)
+        pytest.fail(f"Setup failed: {repr(e)}")
+
+    test_configs = {"vnet_vnis": vnet_vnis, "t1_ptf_port_nums": t1_ptf_port_nums, "loopback_ip": loopback_ip}
+    yield duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs
+
+    # Cleanup
+    cleanup(duthost, ptfhost, localhost, wl_portchannel_info, subintfs_info)
+
+
+def test_vnet_with_bgp_intf_smacrewrite(common_setup_and_teardown):
+    duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs = common_setup_and_teardown
+
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    logger.debug("post-setup config_facts: {}".format(config_facts))
+
+    validate_decap_t1_to_wl(duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs)
+
+    validate_encap_wl_to_t1(duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs)
+
+    # Test datapath again after config reload
+    duthost.shell("config save -y")
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, yang_validate=False)
+    time.sleep(10)
+
+    # Configure vxlan port
+    ecmp_utils.configure_vxlan_switch(duthost, VXLAN_PORT, "00:12:34:56:78:9a")
+
+    validate_decap_t1_to_wl(duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs)
+
+    validate_encap_wl_to_t1(duthost, ptfadapter, wl_portchannel_info, subintfs_info, test_configs)


### PR DESCRIPTION
Backport the following test files from sonic-net/sonic-mgmt upstream/master:

VxLAN - ECMP endpoint scale:
- tests/vxlan/test_scale_ecmp.py
- ansible/roles/test/files/ptftests/py3/vxlan_ecmp_ptftest.py

VxLAN - tunnel route scale:
- tests/vxlan/test_vxlan_tunnel_route_scale.py
- ansible/roles/test/files/ptftests/py3/vxlan_traffic_scale.py

VxLAN - VNet BGP sub-interface:
- tests/common/gnmi_setup.py
- tests/vxlan/test_vxlan_vnet_bgp_subintf.py

BGP:
- tests/bgp/test_bgp_vnet.py
- tests/bgp/templates/vnet_config_db.j2

ACL:
- tests/acl/test_src_mac_rewrite.py