### PR TITLE
[skip][test_sflow]: skip warmreboot tests on sn5640 SP5 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3742,7 +3742,27 @@ sflow/test_sflow.py:
   skip:
     reason: "Sflow feature is default disabled on vs platform"
     conditions:
-      - "asic_type in ['vs']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/21701"
+
+sflow/test_sflow.py::TestReboot::testFastreboot:
+  skip:
+    reason: "Dualtor topology doesn't support advanced-reboot"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+  xfail:
+    reason: "Test case has issue on sn5640 SP5 platform."
+    conditions:
+      - "platform in ['x86_64-nvidia_sn5640-r0']"
+
+sflow/test_sflow.py::TestReboot::testWarmreboot:
+  skip:
+    reason: "Dualtor topology doesn't support advanced-reboot"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+  xfail:
+    reason: "Test case has issue on sn5640 SP5 platform."
+    conditions:
+      - "platform in ['x86_64-nvidia_sn5640-r0']"
 
 #######################################
 #####      show_techsupport       #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3746,22 +3746,18 @@ sflow/test_sflow.py:
 
 sflow/test_sflow.py::TestReboot::testFastreboot:
   skip:
-    reason: "Dualtor topology doesn't support advanced-reboot"
+    reason: "Dualtor topology doesn't support advanced-reboot or Fastreboot is not supported on sn5640 SP5 platform."
+    conditions_logical_operator: or
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
-  xfail:
-    reason: "Test case has issue on sn5640 SP5 platform."
-    conditions:
       - "platform in ['x86_64-nvidia_sn5640-r0']"
 
 sflow/test_sflow.py::TestReboot::testWarmreboot:
   skip:
-    reason: "Dualtor topology doesn't support advanced-reboot"
+    reason: "Dualtor topology doesn't support advanced-reboot or Warmreboot is not supported on sn5640 SP5 platform."
+    conditions_logical_operator: or
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
-  xfail:
-    reason: "Test case has issue on sn5640 SP5 platform."
-    conditions:
       - "platform in ['x86_64-nvidia_sn5640-r0']"
 
 #######################################


### PR DESCRIPTION
Resolve 202412 conflicts in https://github.com/sonic-net/sonic-mgmt/pull/23447

 ### Description of PR
 
 Summary: Change xfail to skip for sFlow reboot test cases on SN5640 (SP5) platform.
 Fixes # (issue)
 
 ### Type of change
 
 - [ ] Bug fix
 - [ ] Testbed and Framework(new/improvement)
 - [ ] New Test case
     - [ ] Skipped for non-supported platforms
 - [x] Test case improvement
 
 
 ### Back port request
 - [ ] 202205
 - [ ] 202305
 - [ ] 202311
 - [ ] 202405
 - [ ] 202411
 - [ ] 202505
 - [x] 202511
 
 ### Approach
 #### What is the motivation for this PR?
 These test cases are currently failing on SN5640 SP5 platform due to a known issue. They should be skipped rather than marked as xfail.
 - sflow/test_sflow.py::TestReboot::testFastreboot
 - sflow/test_sflow.py::TestReboot::testWarmreboot
 
 #### How did you do it?
 Changed xfail to skip conditions for sFlow reboot test cases on SN5640 (SP5) platform in tests_mark_conditions.yaml. 
 
 #### How did you verify/test it?
 Verified it in internal setup.
 
 #### Any platform specific information?
 SN5640
 
 #### Supported testbed topology if it's a new test case?
 t0-isolated-d32u32s2
 
 ### Documentation