### PR TITLE
[code sync] Merge code from sonic-net/sonic-mgmt:202511 to 202603

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -116,13 +116,13 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             port_alias_to_name_map["etp65"] = "Ethernet512"
             port_alias_to_name_map["etp66"] = "Ethernet513"
         elif hwsku in ["Arista-7060X6-64DE-O128S2", "Arista-7060X6-64PE-O128S2", "Arista-7060X6-64PE-B-O128",
-                       "Arista-7060X6-64PE-B-O128S2"]:
+                       "Arista-7060X6-64PE-B-O128S2", "Arista-7060X6-64PE-O128"]:
             split_alias_list = ["a", "b"]
             for i in range(1, 65):
                 for j, split_alias in enumerate(split_alias_list):
                     alias = "etp{}{}".format(i, split_alias)
                     port_alias_to_name_map[alias] = "Ethernet%d" % ((i - 1) * 8 + j * 4)
-            if hwsku not in ["Arista-7060X6-64PE-B-O128"]:
+            if hwsku not in ["Arista-7060X6-64PE-B-O128", "Arista-7060X6-64PE-O128"]:
                 port_alias_to_name_map["etp65"] = "Ethernet512"
                 port_alias_to_name_map["etp66"] = "Ethernet513"
         elif hwsku in ["Arista-7060X6-64PE-B-P32O64", "Arista-7060X6-64PE-P32O64"]:

--- a/ansible/roles/eos/templates/lt2-o128-tor.j2
+++ b/ansible/roles/eos/templates/lt2-o128-tor.j2
@@ -1,0 +1,149 @@
+{% set host = configuration[hostname] %}
+{% set mgmt_ip = ansible_host %}
+{% set tornum = host['tornum'] %}
+{% if vm_type is defined and vm_type == "ceos" %}
+{% set mgmt_if_index = 0 %}
+{% else %}
+{% set mgmt_if_index = 1 %}
+{% endif %}
+no schedule tech-support
+!
+{% if vm_type is defined and vm_type == "ceos" %}
+agent LicenseManager shutdown
+agent PowerFuse shutdown
+agent PowerManager shutdown
+agent Thermostat shutdown
+agent LedPolicy shutdown
+agent StandbyCpld shutdown
+agent Bfd shutdown
+{% endif %}
+!
+hostname {{ hostname }}
+!
+vrf definition MGMT
+ rd 1:1
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management{{ mgmt_if_index }}
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+ipv6 unicast-routing
+!
+{% if disable_ceos_mgmt_gateway is defined and disable_ceos_mgmt_gateway == 'yes'%}
+{% elif vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
+!
+interface Management {{ mgmt_if_index }}
+ description TO LAB MGMT SWITCH
+ {% if vm_type is defined and vm_type == "ceos" %}
+ vrf MGMT
+{% else %}
+ vrf forwarding MGMT
+ {% endif %}
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+{% if name.startswith('Loopback') %}
+ description LOOPBACK
+{% else %}
+ mtu 9214
+ no switchport
+ no shutdown
+{% endif %}
+{% if name.startswith('Port-Channel') %}
+ port-channel min-links 1
+{% endif %}
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ iface['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+{% if iface['lacp'] is defined %}
+ channel-group {{ iface['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+ no shutdown
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+router bgp {{ host['bgp']['asn'] }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] | ansible.utils.ipaddr('address') }}
+ !
+ graceful-restart restart-time {{ bgp_gr_timer }}
+ graceful-restart
+ !
+{% if host['bgp']['confed_asn'] is defined and host['bgp']['confed_peers'] is defined %}
+ bgp confederation identifier {{ host['bgp']['confed_asn'] }}
+ bgp confederation peers {{ host['bgp']['confed_peers'] }}
+!
+{% endif %}
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
+{% if remote_ip | ansible.utils.ipv6 %}
+ address-family ipv6
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv4 }} description exabgp_v4
+ neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv6 }} description exabgp_v6
+ address-family ipv6
+  neighbor {{ props.nhipv6 }} activate
+ exit
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end

--- a/ansible/roles/fanout/library/port_config_gen.py
+++ b/ansible/roles/fanout/library/port_config_gen.py
@@ -279,6 +279,36 @@ class PortConfigGenerator(object):
             if port_name not in self.fanout_port_config:
                 self.fanout_port_config[port_name] = port_config
 
+        self._derive_subports()
+
+    def _derive_subports(self):
+        """Derive subport attribute for ports sharing the same physical index.
+
+        For OSFP modules split into subports (e.g., etp1a/etp1b), the subport
+        attribute tells the ASIC which subport of the physical module each
+        logical port maps to. The alias suffix (a=1, b=2, c=3, d=4) determines
+        the subport number.
+        """
+        # Group ports by index to detect multi-subport configurations
+        index_groups = {}
+        for port_name, port_config in self.fanout_port_config.items():
+            idx = port_config.get('index', '')
+            if idx not in index_groups:
+                index_groups[idx] = []
+            index_groups[idx].append(port_name)
+
+        for idx, port_names in index_groups.items():
+            if len(port_names) <= 1:
+                continue
+            # Multiple ports share the same index — these are subports
+            for port_name in port_names:
+                port_config = self.fanout_port_config[port_name]
+                if 'subport' in port_config:
+                    continue
+                alias = port_config.get('alias', '')
+                if alias and alias[-1].isalpha():
+                    port_config['subport'] = str(ord(alias[-1]) - ord('a') + 1)
+
 
 def main():
     module = AnsibleModule(

--- a/ansible/roles/fanout/templates/sonic_deploy_202505.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202505.j2
@@ -49,6 +49,9 @@
             "tpid": "0x9100",
         {% endif %}
     {% endif %}
+    {% if 'subport' in fanout_port_config[port_name] %}
+            "subport": "{{ fanout_port_config[port_name]['subport'] }}",
+    {% endif %}
     {% if 'peerdevice' in fanout_port_config[port_name] %}
             "admin_status": "up"
     {% else %}

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -18,15 +18,15 @@ pytestmark = [
 
 
 @pytest.fixture
-def setup(rand_selected_dut):
+def pause_arp_update(rand_selected_dut):
     cmds = [
         "docker exec swss supervisorctl stop arp_update",
         "ip neigh flush all"
     ]
-    rand_selected_dut.shell_cmds(cmds)
+    rand_selected_dut.shell_cmds(cmds=cmds)
     yield
     cmds[0] = "docker exec swss supervisorctl start arp_update"
-    # rand_selected_dut.shell_cmds(cmds)
+    rand_selected_dut.shell_cmds(cmds=cmds)
 
 
 def neighbor_learned(dut, target_ip):
@@ -47,6 +47,7 @@ def ip_version_string(version):
 
 @pytest.mark.parametrize("ip_version", [4, 6], ids=ip_version_string)
 def test_kernel_asic_mac_mismatch(
+    pause_arp_update,
     setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,
     toggle_all_simulator_ports_to_rand_selected_tor,  # noqa: F811
     rand_selected_dut, ip_version, setup_vlan_arp_responder,  # noqa: F811
@@ -84,7 +85,9 @@ def test_kernel_asic_mac_mismatch(
     asic_db_mac = rand_selected_dut.shell(
         f"sonic-db-cli APPL_DB hget 'NEIGH_TABLE:{vlan_name}:{target_ip}' 'neigh'"
     )['stdout']
-    pt_assert(neighbor_info[4].lower() != asic_db_mac.lower())
+    pt_assert(neighbor_info[4].lower() != asic_db_mac.lower(),
+              f"APPL_DB MAC was not corrupted: expected 00:00:00:00:00:00 but got {asic_db_mac}. "
+              "Ensure arp_update is stopped before modifying APPL_DB.")
     logger.info("APPL_DB and kernel are out of sync (expected)")
 
     rand_selected_dut.shell("docker exec swss supervisorctl start arp_update")

--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -88,6 +88,9 @@ SWITCH_MODELS = {
             }
         }
     },
+    "x86_64-nvidia_sn5600_simx-r0": {
+        "chip_type": "spectrum4"
+    },
     "x86_64-nvidia_sn5640-r0": {
         "chip_type": "spectrum5",
         "reboot": {
@@ -264,6 +267,9 @@ SWITCH_MODELS = {
                 "number": 1
             }
         }
+    },
+    "x86_64-mlnx_msn2700_simx-r0": {
+        "chip_type": "spectrum1"
     },
     "x86_64-mlnx_msn2700a1-r0": {
         "chip_type": "spectrum1",

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -160,7 +160,8 @@ arp/test_arp_extended.py::test_proxy_arp[v4-:
     conditions:
       - "'-v6-' in topo_name"
 
-arp/test_arp_update.py::test_kernel_asic_mac_mismatch[ipv4]:
+arp/test_arp_update.py::test_kernel_asic_mac_mismatch\[.*ipv4.*\]:
+  regex: true
   skip:
     reason: "skip for IPv6-only topologies"
     conditions:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -679,7 +679,7 @@ copp/test_copp.py::TestCOPP::test_trap_neighbor_miss:
     conditions_logical_operator: or
     conditions:
       - "(asic_type in ['broadcom'] and release in ['202411'])"
-      - "(topo_name not in ['t0', 't0-64', 't0-52', 't0-116', 't0-118', 't0-88-o8c80', 't0-isolated-d16u16s1', 't1-isolated-d28u1', 't0-isolated-d32u32s2', 't1-isolated-d56u2'])"
+      - "(topo_name not in ['t0', 't0-64', 't0-52', 't0-116', 't0-118', 't0-88-o8c80', 't0-isolated-d16u16s1', 't0-isolated-d32u32s2'])"
 
 #######################################
 #####            crm              #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5320,6 +5320,14 @@ vxlan/test_vxlan_underlay_ecmp.py:
     conditions:
       - "(is_multi_asic == True) or (platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0'])"
 
+vxlan/test_vxlan_vnet_bgp_subintf.py:
+  skip:
+    reason: "test_vxlan_vnet_bgp_subintf requires INNER_SRC_MAC_REWRITE_TYPE / SET_INNER_SRC_MAC; not supported on cisco-8000 202511 image (orchagent validate fails). Skip only when both apply."
+    conditions_logical_operator: and
+    conditions:
+      - "asic_type in ['cisco-8000']"
+      - "release in ['202511']"
+
 #######################################
 #####           wan_lacp          #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3138,6 +3138,12 @@ ipfwd/test_dip_sip.py:
       - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
       - "topo_type not in ['t0', 't1', 't2', 'm0', 'mx', 'm1']"
 
+ipfwd/test_dip_sip.py::test_ipv4_forwarding:
+  skip:
+    reason: "Skip for IPv6-only topologies"
+    conditions:
+      - "'-v6-' in topo_name"
+
 ipfwd/test_dir_bcast.py:
   skip:
     reason: "Unsupported topology."

--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -96,11 +96,11 @@ def print_logs(duthosts, ptfhost, print_dual_tor_logs=False, check_ptf_mgmt=True
             # check PTF device reachability
             if ptf.mgmt_ip:
                 cmds.append("ping {} -c 1 -W 3".format(ptf.mgmt_ip))
-                cmds.append("traceroute {}".format(ptf.mgmt_ip))
+                cmds.append("traceroute -n {}".format(ptf.mgmt_ip))
 
             if ptf.mgmt_ipv6:
                 cmds.append("ping6 {} -c 1 -W 3".format(ptf.mgmt_ipv6))
-                cmds.append("traceroute6 {}".format(ptf.mgmt_ipv6))
+                cmds.append("traceroute6 -n {}".format(ptf.mgmt_ipv6))
 
         results = dut.shell_cmds(cmds=cmds, module_ignore_errors=True, verbose=False)['results']
         outputs = []

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -883,7 +883,9 @@ def test_ecmp_group_member_flap(
             "single_fib_for_duts": single_fib_for_duts,
             "switch_type": switch_type,
             "asic_type": asic_type,
-            "skip_src_ports": filtered_ports
+            "skip_src_ports": filtered_ports,
+            "topo_name": updated_tbinfo['topo']['name'],
+            "topo_type": updated_tbinfo['topo']['type'],
         },
         log_file=log_file,
         qlen=PTF_QLEN,
@@ -939,7 +941,9 @@ def test_ecmp_group_member_flap(
             "single_fib_for_duts": single_fib_for_duts,
             "switch_type": switch_type,
             "asic_type": asic_type,
-            "skip_src_ports": filtered_ports
+            "skip_src_ports": filtered_ports,
+            "topo_name": updated_tbinfo['topo']['name'],
+            "topo_type": updated_tbinfo['topo']['type'],
         },
         log_file=member_down_log_file,
         qlen=PTF_QLEN,
@@ -989,7 +993,9 @@ def test_ecmp_group_member_flap(
             "single_fib_for_duts": single_fib_for_duts,
             "switch_type": switch_type,
             "asic_type": asic_type,
-            "skip_src_ports": filtered_ports
+            "skip_src_ports": filtered_ports,
+            "topo_name": updated_tbinfo['topo']['name'],
+            "topo_type": updated_tbinfo['topo']['type'],
         },
         log_file=member_up_log_file,
         qlen=PTF_QLEN,

--- a/tests/ipfwd/conftest.py
+++ b/tests/ipfwd/conftest.py
@@ -99,6 +99,8 @@ def get_port_facts(dut, mg_facts, port_status, switch_arptable, ignore_intfs,
                     elif addr.version == 6:
                         selected_port_facts[key + '_router_ipv6'] = intf['addr']
                         selected_port_facts[key + '_host_ipv6'] = intf['peer_addr']
+                        selected_port_facts[key + '_host_mac'] = \
+                            switch_arptable['arptable']['v6'][intf['peer_addr']]['macaddress']
             if up_port:
                 logger.info("{} port is {}".format(key, up_port))
                 break

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -4,7 +4,7 @@ import logging
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa: F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # noqa: F401
-from tests.common.utilities import wait_until
+from tests.common.utilities import wait_until, is_ipv6_only_topology
 
 DEFAULT_HLIM_TTL = 64
 WAIT_EXPECTED_PACKET_TIMEOUT = 5
@@ -60,7 +60,7 @@ def delete_static_route(duthost, static_route, nexthop_ip, asic_id):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def setup_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+def setup_static_route(duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname,
                        enum_rand_one_frontend_asic_index, gather_facts, request):
 
     """
@@ -86,18 +86,27 @@ def setup_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         None
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    nexthop_ipv4 = gather_facts['dst_host_ipv4']
+    is_v6_topo = is_ipv6_only_topology(tbinfo)
+
+    if not is_v6_topo:
+        nexthop_ipv4 = gather_facts['dst_host_ipv4']
+        # Configure IPv4 static route
+        try:
+            result = add_static_route(duthost, STATIC_ROUTE, nexthop_ipv4, enum_rand_one_frontend_asic_index)
+            if result['rc'] != 0:
+                raise Exception("Failed to add IPv4 static route: {}".format(result['stderr']))
+        except Exception as e:
+            logger.error("Error occurred while adding IPv4 static route: %s", str(e))
+            pytest.fail("IPv4 static route addition failed")
+        # Verify IPv4 route is in the routing table
+        try:
+            assert wait_until(60, 5, 0, check_route, duthost, STATIC_ROUTE, nexthop_ipv4,
+                              enum_rand_one_frontend_asic_index, 4, True), "IPv4 static route verification failed"
+        except Exception as e:
+            logger.error("Error occurred while verifying IPv4 static route: %s", str(e))
+            pytest.fail("IPv4 static route verification failed")
+
     nexthop_ipv6 = gather_facts['dst_host_ipv6']
-
-    # Configure IPv4 static route
-    try:
-        result = add_static_route(duthost, STATIC_ROUTE, nexthop_ipv4, enum_rand_one_frontend_asic_index)
-        if result['rc'] != 0:
-            raise Exception("Failed to add IPv4 static route: {}".format(result['stderr']))
-    except Exception as e:
-        logger.error("Error occurred while adding IPv4 static route: %s", str(e))
-        pytest.fail("IPv4 static route addition failed")
-
     # Configure IPv6 static route
     try:
         result = add_static_route(duthost, STATIC_ROUTE_IPV6, nexthop_ipv6, enum_rand_one_frontend_asic_index)
@@ -106,16 +115,6 @@ def setup_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     except Exception as e:
         logger.error("Error occurred while adding IPv6 static route: %s", str(e))
         pytest.fail("IPv6 static route addition failed")
-
-    # Verify IPv4 route is in the routing table
-
-    try:
-        assert wait_until(60, 5, 0, check_route, duthost, STATIC_ROUTE, nexthop_ipv4,
-                          enum_rand_one_frontend_asic_index, 4, True), "IPv4 static route verification failed"
-    except Exception as e:
-        logger.error("Error occurred while verifying IPv4 static route: %s", str(e))
-        pytest.fail("IPv4 static route verification failed")
-
     # # Verify IPv6 route is in the routing table
     try:
         assert wait_until(60, 5, 0, check_route, duthost, STATIC_ROUTE_IPV6, nexthop_ipv6,
@@ -128,8 +127,9 @@ def setup_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     yield
 
     # Use either individual functions
-    delete_ipv4_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                             enum_rand_one_frontend_asic_index, gather_facts)
+    if not is_v6_topo:
+        delete_ipv4_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                 enum_rand_one_frontend_asic_index, gather_facts)
     delete_ipv6_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                              enum_rand_one_frontend_asic_index, gather_facts)
 
@@ -138,12 +138,13 @@ def setup_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
 
 
 @pytest.fixture(autouse=True)
-def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+def setup_teardown(duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname,
                    enum_rand_one_frontend_asic_index, gather_facts):
     yield
     # Teardown - delete the static routes
-    delete_ipv4_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                             enum_rand_one_frontend_asic_index, gather_facts)
+    if not is_ipv6_only_topology(tbinfo):
+        delete_ipv4_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                 enum_rand_one_frontend_asic_index, gather_facts)
     delete_ipv6_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                              enum_rand_one_frontend_asic_index, gather_facts)
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -498,7 +498,7 @@ class TestSfpApi(PlatformApiTestBase):
                         UPDATED_EXPECTED_XCVR_INFO_KEYS = self.EXPECTED_AMPH_BACKPLANE_KEYS
                     else:
 
-                        if info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X"]:
+                        if info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X", "QSFP+C"]:
                             active_apsel_hostlane_count = 8
                             UPDATED_EXPECTED_XCVR_INFO_KEYS = self.EXPECTED_XCVR_INFO_KEYS + \
                                 self.EXPECTED_XCVR_NEW_CMIS_INFO_KEYS + \
@@ -531,8 +531,8 @@ class TestSfpApi(PlatformApiTestBase):
                     unexpected_keys = set(actual_keys) - set(UPDATED_EXPECTED_XCVR_INFO_KEYS +
                                                              self.NEWLY_ADDED_XCVR_INFO_KEYS)
                     for key in unexpected_keys:
-                        # hardware_rev is applicable only for QSFP-DD or OSFP
-                        if key == 'hardware_rev' and info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X"]:
+                        # hardware_rev is applicable only for QSFP-DD, OSFP or QSFP+C
+                        if key == 'hardware_rev' and info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X", "QSFP+C"]:
                             continue
                         self.expect(False, "Transceiver {} info contains unexpected field '{}'".format(i, key))
         self.assert_expectations()

--- a/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
+++ b/tests/platform_tests/counterpoll/test_counterpoll_watermark.py
@@ -202,8 +202,8 @@ def test_counterpoll_queue_watermark_pg_drop(duthosts, localhost, enum_rand_one_
     with allure.step("enable and verify all {} counterpolls on {} ..."
                      .format(RELEVANT_COUNTERPOLLS, duthost.hostname)):
         for asic in duthost.asics:
-            ConterpollHelper.enable_counterpoll(duthost, RELEVANT_COUNTERPOLLS)
-            verify_counterpoll_status(duthost, RELEVANT_COUNTERPOLLS, ENABLE)
+            ConterpollHelper.enable_counterpoll(asic, RELEVANT_COUNTERPOLLS)
+            verify_counterpoll_status(asic, RELEVANT_COUNTERPOLLS, ENABLE)
     # count FLEXCOUNTER_DB countrpolls and put in results dict key per countrpoll
     with allure.step("check all counterpolls {} results on {} ...".format(RELEVANT_COUNTERPOLLS, duthost.hostname)):
         for counterpoll in RELEVANT_COUNTERPOLLS:

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -78,14 +78,15 @@ def route_config(nbrhosts, tbinfo):
 
 
 @pytest.fixture(scope='function')
-def dscp_config(dscp_mode, duthost, loganalyzer):
+def dscp_config(dscp_mode, rand_selected_dut, loganalyzer):
     """
     Test setup and teardown
 
     Args:
         request: pytest request
-        duthost (AnsibleHost): The DUT host
+        rand_selected_dut (AnsibleHost): The randomly selected DUT host
     """
+    duthost = rand_selected_dut
     asic_type = duthost.facts['asic_type']
 
     # global DSCP_TO_TC_MAP update is not supported on Broadcom platforms

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -190,19 +190,6 @@ class TestQosSai(QosSaiBase):
         are verified.
     """
 
-    SUPPORTED_HEADROOM_SKUS = [
-        'Arista-7060CX-32S-C32',
-        'Celestica-DX010-C32',
-        'Arista-7260CX3-D108C8',
-        'Arista-7260CX3-D108C10',
-        'Force10-S6100',
-        'Arista-7260CX3-Q64',
-        'Arista-7050CX3-32S-C32',
-        'Arista-7050CX3-32S-C28S4',
-        'Arista-7050CX3-32S-D48C8',
-        'dbmvtx9180_64osfp_128x400G_lab'
-    ]
-
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, disable_voq_watchdog_class_scope):
         return

--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -398,8 +398,8 @@ class TestAutoTechSupport:
         - Create 4 core/techsupport dummy files(each file 5%) which will use 20% of space in test folder
         - Trigger techsupport and check that dummy files + new created core/techsupport files available
         - Set core/techsupport max limit to 14
-        - Trigger techsupport and check that 2 oldest dummy files removed, all other + new created core/techsupport
-        files available
+        - Trigger techsupport and check that the oldest dummy files were removed to meet the storage limit
+        (exact count varies with techsupport size), verify oldest-first order and folder size within limit
         :param test_mode: test mode - core or techsupport
         :param global_rate_limit_zero: fixture which disable global rate limit
         :param feature_rate_limit_zero: fixture which disable feature rate limit
@@ -473,8 +473,27 @@ class TestAutoTechSupport:
 
                 with allure.step('Check that all expected stub files exist and unexpected does not exist'):
                     expected_max_usage = one_percent_in_mb * max_limit
-                    expected_stub_files = dummy_files_list[2:]
-                    not_expected_stub_files = dummy_files_list[:2]
+
+                    # Query all files that exist after cleanup has run & identify remaining files
+                    file_pattern = 'sonic_dump_*.tar.gz' if test_mode == 'techsupport' else '*.core.gz'
+                    files_after_cleanup = get_files_info(self.duthost, validation_folder, file_pattern)
+                    remaining_file_names = [f['name'] for f in files_after_cleanup]
+                    remaining_dummy_files = [f for f in remaining_file_names if f in dummy_files_list]
+
+                    # Determine which dummy files should exist based on oldest-first deletion strategy
+                    if remaining_dummy_files:
+                        oldest_remaining_idx = min([dummy_files_list.index(f) for f in remaining_dummy_files])
+
+                        # All dummy files from oldest_remaining_idx onward should still exist.
+                        expected_stub_files = dummy_files_list[oldest_remaining_idx:]
+
+                        # All dummy files before oldest_remaining_idx should have been deleted.
+                        not_expected_stub_files = dummy_files_list[:oldest_remaining_idx]
+                    else:
+                        # All dummy files were deleted by cleanup
+                        expected_stub_files = []
+                        not_expected_stub_files = dummy_files_list
+
                     validate_expected_stub_files(self.duthost, validation_folder, expected_stub_files,
                                                  expected_number_of_additional_files=2,
                                                  not_expected_stub_files_list=not_expected_stub_files,
@@ -1404,3 +1423,33 @@ def add_po_member(duthost, po_name, test_port, minigraph_facts):
             remove_acl_tables(duthost, failure_info)
 
         duthost.shell(add_po_member_cmd)
+
+
+def get_files_info(duthost, validation_folder, file_pattern='sonic_dump_*.tar.gz'):
+    """
+    Get size and modification time for all files matching pattern in folder.
+    This is used to query the actual state of files after cleanup has run.
+
+    :param duthost: duthost object
+    :param validation_folder: directory to search (e.g., '/var/dump/' or '/var/core/')
+    :param file_pattern: glob pattern for files to find (default: 'sonic_dump_*.tar.gz')
+    :return: list of dicts with 'name', 'size' (bytes), 'mtime' (timestamp as float)
+    """
+    # Use find command to get file size (%s), modification time (%T@), and filename (%f)
+    # printf format: "size timestamp filename\n"
+    cmd = f"find {validation_folder} -name '{file_pattern}' -type f -printf '%s %T@ %f\\n' 2>/dev/null"
+    result = duthost.shell(cmd)['stdout'].strip()
+
+    files_info = []
+    if result:
+        # Parse each line of output
+        for line in result.split('\n'):
+            parts = line.split()
+            if len(parts) >= 3:
+                files_info.append({
+                    'name': parts[2],
+                    'size': int(parts[0]),
+                    'mtime': float(parts[1])
+                })
+
+    return files_info

--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -287,10 +287,10 @@ def verify_snmp_counter(duthost, localhost, creds_all_duts, hostip, mg_facts, ri
     if not check_counter_with_margin(int(rif_snmp_facts['ifOutDiscards']), expected_out_discards, 'ifOutDiscards'):
         return False
 
-    if not check_counter_with_margin(int(rif_snmp_facts['ifInErrors']), COUNTER_VALUE, 'ifInErrors'):
+    if not check_counter_with_margin(int(rif_snmp_facts['ifInErrors']), COUNTER_VALUE * num_port_intfs, 'ifInErrors'):
         return False
 
-    if not check_counter_with_margin(int(rif_snmp_facts['ifOutErrors']), COUNTER_VALUE, 'ifOutErrors'):
+    if not check_counter_with_margin(int(rif_snmp_facts['ifOutErrors']), COUNTER_VALUE * num_port_intfs, 'ifOutErrors'):
         return False
 
     return True


### PR DESCRIPTION
```
* a6342c574a - Merge branch '202511' into '202603' (2026-04-23) [Zhijian Li]
* eed476773e - [action] [PR:20433] Fixed COPP trap neighbor miss test to skip t1 (#24151) (2026-04-23) [mssonicbld]
* 4417bca29f - [action] [PR:23486] skip vxlan vnet bgp subintf (#24141) (2026-04-23) [mssonicbld]
* e844a050fe - [action] [PR:23892] [test_auto_techsupport] Fix test_max_limit flakiness with dynamic cleanup validation (#24148) (2026-04-23) [mssonicbld]
* 78fb0c0281 - [action] [PR:23994] Remove unused variable in test_qos_sai.py (#24152) (2026-04-23) [mssonicbld]
* 563aabd837 - [202511] Fix ipfwd/test_dip_sip.py for v6 topo (#23958) (2026-04-22) [Mark Xiao]
* 31585a96ad - [action] [PR:23987] chore: add o128 support for port util (#24139) (2026-04-23) [mssonicbld]
* 8aed253f20 - [action] [PR:23814] fix: fanout configure subport and add missing eos template for lt2 (#24140) (2026-04-23) [mssonicbld]
* 585fefb3dc - [action] [PR:24082] Fix QoS DSCP test DUT mismatch in dualtor (#24142) (2026-04-23) [mssonicbld]
* 3a0e6119a5 - [action] [PR:23996] Fix test_counterpoll_watermark on multi-asic (#24130) (2026-04-23) [mssonicbld]
* 0659398526 - Add support for QSFP+C xcvr in test_get_transceiver_info in test_sfp.py (#23763) (2026-04-22) [HP]
* 6dd46981dc - [action] [PR:23912] Fix race condition in test_kernel_asic_mac_mismatch (#24125) (2026-04-22) [mssonicbld]
* 8935732eb5 - [action] [PR:24109] Add topo_name and topo_type to test_ecmp_group_member_flap (#24111) (2026-04-22) [mssonicbld]
* 8f966c15ab - [action] [PR:21831] Update the skip condition with fuzzy matching for test_kernel_asic_mac_mismatch (#23686) (2026-04-22) [mssonicbld]
* ca996a8b91 - [action] [PR:24058] Fix SNMP ifInErrors/ifOutErrors validation for multi-member PortChannels (#24097) (2026-04-22) [mssonicbld]
* 28237396ef - [action] [PR:21443] Add "-n" to traceroute to speed up sanity check (#21546) (2026-04-21) [mssonicbld]
* 61fc87c59a - [action] [PR:21261] [mellanox] Add mellanox data for two simx platform (#22015) (2026-04-21) [mssonicbld]
```
