### PR TITLE
[code sync] Merge code from sonic-net/sonic-mgmt:202511 to 202603

### DIFF
--- a/ansible/roles/sonic/templates/configdb.j2
+++ b/ansible/roles/sonic/templates/configdb.j2
@@ -114,7 +114,7 @@
 {{ separator() }}
         "{{ dut_name }}": {
                 "hwsku": "SONiC-VM",
-                "mgmt_addr": "{{ hostvars[dut_name]['ansible_host'] }}",
+                "mgmt_addr": "{{ mgmt_ip }}",
                 "type": "TorRouter"
         },
         "exabgp": {

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -414,8 +414,9 @@
 - name: Save PTF image
   block:
   - shell: docker tag "{{ docker_registry_host }}/{{ ptf_imagename }}:{{ ptf_imagetag }}" docker-ptf
-  - shell: docker save -o docker-ptf.tar docker-ptf
-  - fetch: src=docker-ptf.tar dest=docker-ptf.tar flat=yes
-  - shell: rm -f docker-ptf.tar
+  - shell: docker save -o {{ root_path }}/images/docker-ptf.tar docker-ptf
+  - fetch: src={{ root_path }}/images/docker-ptf.tar dest=docker-ptf.tar flat=yes
+  - shell: rm -f {{ root_path }}/images/docker-ptf.tar
   run_once: yes
+  become: yes
   when: vm_type is defined and vm_type == "vsonic" and ptf_on_neighbor is defined and ptf_on_neighbor|bool == true

--- a/ansible/roles/vm_set/tasks/start_sonic_vm.yml
+++ b/ansible/roles/vm_set/tasks/start_sonic_vm.yml
@@ -2,11 +2,31 @@
     sonic_vm_storage_location: "{{ home_path }}/sonic-vm"
     when: sonic_vm_storage_location is not defined
 
-- name: Create directory for vm images and vm disks
+- set_fact:
+    disable_updategraph: False
+  when: disable_updategraph is not defined
+
+- name: Check if images folder exists
+  stat: path={{ sonic_vm_storage_location }}/images
+  register: images_folder_stat
+
+- name: Check if discs folder exists
+  stat: path={{ sonic_vm_storage_location }}/disks
+  register: discs_folder_stat
+
+- name: Create directory for vm images
   file: path={{ item }} state=directory mode=0755
   with_items:
     - "{{ sonic_vm_storage_location }}/images"
+  become: yes
+  when: not images_folder_stat.stat.exists
+
+- name: Create directory for vm disks
+  file: path={{ item }} state=directory mode=0755
+  with_items:
     - "{{ sonic_vm_storage_location }}/disks"
+  become: yes
+  when: not discs_folder_stat.stat.exists
 
 - set_fact:
     disk_image: "{{ sonic_vm_storage_location }}/disks/sonic_{{ dut_name }}.img"

--- a/ansible/vars/topo_t2_single_node_max_64p.yml
+++ b/ansible/vars/topo_t2_single_node_max_64p.yml
@@ -1,0 +1,1753 @@
+topology:
+  VMs:
+    VM01T3:
+      vlans:
+        - 0
+      vm_offset: 0
+
+    VM02T3:
+      vlans:
+        - 1
+      vm_offset: 1
+
+    VM03T3:
+      vlans:
+        - 2
+      vm_offset: 2
+
+    VM04T3:
+      vlans:
+        - 3
+      vm_offset: 3
+
+    VM05T3:
+      vlans:
+        - 4
+      vm_offset: 4
+
+    VM06T3:
+      vlans:
+        - 5
+      vm_offset: 5
+
+    VM07T3:
+      vlans:
+        - 6
+      vm_offset: 6
+
+    VM08T3:
+      vlans:
+        - 7
+      vm_offset: 7
+
+    VM09T3:
+      vlans:
+        - 8
+      vm_offset: 8
+
+    VM10T3:
+      vlans:
+        - 9
+      vm_offset: 9
+
+    VM11T3:
+      vlans:
+        - 10
+      vm_offset: 10
+
+    VM12T3:
+      vlans:
+        - 11
+      vm_offset: 11
+
+    VM13T3:
+      vlans:
+        - 12
+      vm_offset: 12
+
+    VM14T3:
+      vlans:
+        - 13
+      vm_offset: 13
+
+    VM15T3:
+      vlans:
+        - 14
+      vm_offset: 14
+
+    VM16T3:
+      vlans:
+        - 15
+      vm_offset: 15
+
+    VM17T3:
+      vlans:
+        - 16
+      vm_offset: 16
+
+    VM18T3:
+      vlans:
+        - 17
+      vm_offset: 17
+
+    VM19T3:
+      vlans:
+        - 18
+      vm_offset: 18
+
+    VM20T3:
+      vlans:
+        - 19
+      vm_offset: 19
+
+    VM21T3:
+      vlans:
+        - 20
+      vm_offset: 20
+
+    VM22T3:
+      vlans:
+        - 21
+      vm_offset: 21
+
+    VM23T3:
+      vlans:
+        - 22
+      vm_offset: 22
+
+    VM24T3:
+      vlans:
+        - 23
+      vm_offset: 23
+
+    VM25T3:
+      vlans:
+        - 24
+      vm_offset: 24
+
+    VM26T3:
+      vlans:
+        - 25
+      vm_offset: 25
+
+    VM27T3:
+      vlans:
+        - 26
+      vm_offset: 26
+
+    VM28T3:
+      vlans:
+        - 27
+      vm_offset: 27
+
+    VM29T3:
+      vlans:
+        - 28
+      vm_offset: 28
+
+    VM30T3:
+      vlans:
+        - 29
+      vm_offset: 29
+
+    VM31T3:
+      vlans:
+        - 30
+      vm_offset: 30
+
+    VM32T3:
+      vlans:
+        - 31
+      vm_offset: 31
+
+    VM01LT2:
+      vlans:
+        - 32
+      vm_offset: 32
+
+    VM02LT2:
+      vlans:
+        - 33
+      vm_offset: 33
+
+    VM03LT2:
+      vlans:
+        - 34
+      vm_offset: 34
+
+    VM04LT2:
+      vlans:
+        - 35
+      vm_offset: 35
+
+    VM05LT2:
+      vlans:
+        - 36
+      vm_offset: 36
+
+    VM06LT2:
+      vlans:
+        - 37
+      vm_offset: 37
+
+    VM07LT2:
+      vlans:
+        - 38
+      vm_offset: 38
+
+    VM08LT2:
+      vlans:
+        - 39
+      vm_offset: 39
+
+    VM09LT2:
+      vlans:
+        - 40
+      vm_offset: 40
+
+    VM10LT2:
+      vlans:
+        - 41
+      vm_offset: 41
+
+    VM11LT2:
+      vlans:
+        - 42
+      vm_offset: 42
+
+    VM12LT2:
+      vlans:
+        - 43
+      vm_offset: 43
+
+    VM13LT2:
+      vlans:
+        - 44
+      vm_offset: 44
+
+    VM14LT2:
+      vlans:
+        - 45
+      vm_offset: 45
+
+    VM15LT2:
+      vlans:
+        - 46
+      vm_offset: 46
+
+    VM16LT2:
+      vlans:
+        - 47
+      vm_offset: 47
+
+    VM17LT2:
+      vlans:
+        - 48
+      vm_offset: 48
+
+    VM18LT2:
+      vlans:
+        - 49
+      vm_offset: 49
+
+    VM19LT2:
+      vlans:
+        - 50
+      vm_offset: 50
+
+    VM20LT2:
+      vlans:
+        - 51
+      vm_offset: 51
+
+    VM21LT2:
+      vlans:
+        - 52
+      vm_offset: 52
+
+    VM22LT2:
+      vlans:
+        - 53
+      vm_offset: 53
+
+    VM23LT2:
+      vlans:
+        - 54
+      vm_offset: 54
+
+    VM24LT2:
+      vlans:
+        - 55
+      vm_offset: 55
+
+    VM25LT2:
+      vlans:
+        - 56
+      vm_offset: 56
+
+    VM26LT2:
+      vlans:
+        - 57
+      vm_offset: 57
+
+    VM27LT2:
+      vlans:
+        - 58
+      vm_offset: 58
+
+    VM28LT2:
+      vlans:
+        - 59
+      vm_offset: 59
+
+    VM29LT2:
+      vlans:
+        - 60
+      vm_offset: 60
+
+    VM30LT2:
+      vlans:
+        - 61
+      vm_offset: 61
+
+    VM31LT2:
+      vlans:
+        - 62
+      vm_offset: 62
+
+    VM32LT2:
+      vlans:
+        - 63
+      vm_offset: 63
+
+  DUT:
+    loopback:
+      ipv4:
+        - 10.1.0.1/32
+      ipv6:
+        - fc00:10::1/128
+
+configuration_properties:
+  common:
+    podset_number: 400
+    tor_number: 16
+    tor_subnet_number: 8
+    max_tor_subnet_number: 32
+    tor_subnet_size: 128
+    dut_asn: 65100
+    dut_type: UpperSpineRouter
+    nhipv4: 10.10.246.254
+    nhipv6: fc0a::ff
+  core:
+    swrole: core
+  leaf:
+    swrole: leaf
+
+configuration:
+  VM01T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.0
+        - fc00::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Port-Channel1:
+        ipv4: 10.0.0.1/31
+        ipv6: fc00::2/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+
+  VM02T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.2
+        - fc00::5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.2/32
+        ipv6: 2064:100::2/128
+      Port-Channel1:
+        ipv4: 10.0.0.3/31
+        ipv6: fc00::6/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.2/24
+      ipv6: fc0a::3/64
+
+  VM03T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.4
+        - fc00::9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.3/32
+        ipv6: 2064:100::3/128
+      Port-Channel1:
+        ipv4: 10.0.0.5/31
+        ipv6: fc00::a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::4/64
+
+  VM04T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.6
+        - fc00::d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.4/32
+        ipv6: 2064:100::4/128
+      Port-Channel1:
+        ipv4: 10.0.0.7/31
+        ipv6: fc00::e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.4/24
+      ipv6: fc0a::5/64
+
+  VM05T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.8
+        - fc00::11
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.5/32
+        ipv6: 2064:100::5/128
+      Port-Channel1:
+        ipv4: 10.0.0.9/31
+        ipv6: fc00::12/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.5/24
+      ipv6: fc0a::6/64
+
+  VM06T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.10
+        - fc00::15
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.6/32
+        ipv6: 2064:100::6/128
+      Port-Channel1:
+        ipv4: 10.0.0.11/31
+        ipv6: fc00::16/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.6/24
+      ipv6: fc0a::7/64
+
+  VM07T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.12
+        - fc00::19
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.7/32
+        ipv6: 2064:100::7/128
+      Port-Channel1:
+        ipv4: 10.0.0.13/31
+        ipv6: fc00::1a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.7/24
+      ipv6: fc0a::8/64
+
+  VM08T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.14
+        - fc00::1d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.8/32
+        ipv6: 2064:100::8/128
+      Port-Channel1:
+        ipv4: 10.0.0.15/31
+        ipv6: fc00::1e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.8/24
+      ipv6: fc0a::9/64
+
+  VM09T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.16
+        - fc00::21
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.9/32
+        ipv6: 2064:100::9/128
+      Port-Channel1:
+        ipv4: 10.0.0.17/31
+        ipv6: fc00::22/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.9/24
+      ipv6: fc0a::a/64
+
+  VM10T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.18
+        - fc00::25
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.10/32
+        ipv6: 2064:100::a/128
+      Port-Channel1:
+        ipv4: 10.0.0.19/31
+        ipv6: fc00::26/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.10/24
+      ipv6: fc0a::b/64
+
+  VM11T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.20
+        - fc00::29
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.11/32
+        ipv6: 2064:100::b/128
+      Port-Channel1:
+        ipv4: 10.0.0.21/31
+        ipv6: fc00::2a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.11/24
+      ipv6: fc0a::c/64
+
+  VM12T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.22
+        - fc00::2d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.12/32
+        ipv6: 2064:100::c/128
+      Port-Channel1:
+        ipv4: 10.0.0.23/31
+        ipv6: fc00::2e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.12/24
+      ipv6: fc0a::d/64
+
+  VM13T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.24
+        - fc00::31
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.13/32
+        ipv6: 2064:100::d/128
+      Port-Channel1:
+        ipv4: 10.0.0.25/31
+        ipv6: fc00::32/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.13/24
+      ipv6: fc0a::e/64
+
+  VM14T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.26
+        - fc00::35
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.14/32
+        ipv6: 2064:100::e/128
+      Port-Channel1:
+        ipv4: 10.0.0.27/31
+        ipv6: fc00::36/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.14/24
+      ipv6: fc0a::f/64
+
+  VM15T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.28
+        - fc00::39
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.15/32
+        ipv6: 2064:100::f/128
+      Port-Channel1:
+        ipv4: 10.0.0.29/31
+        ipv6: fc00::3a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.15/24
+      ipv6: fc0a::10/64
+
+  VM16T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.30
+        - fc00::3d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.16/32
+        ipv6: 2064:100::10/128
+      Port-Channel1:
+        ipv4: 10.0.0.31/31
+        ipv6: fc00::3e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.16/24
+      ipv6: fc0a::11/64
+
+  VM17T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.32
+        - fc00::41
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.17/32
+        ipv6: 2064:100::11/128
+      Port-Channel1:
+        ipv4: 10.0.0.33/31
+        ipv6: fc00::42/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.17/24
+      ipv6: fc0a::12/64
+
+  VM18T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.34
+        - fc00::45
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.18/32
+        ipv6: 2064:100::12/128
+      Port-Channel1:
+        ipv4: 10.0.0.35/31
+        ipv6: fc00::46/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.18/24
+      ipv6: fc0a::13/64
+
+  VM19T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.36
+        - fc00::49
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.19/32
+        ipv6: 2064:100::13/128
+      Port-Channel1:
+        ipv4: 10.0.0.37/31
+        ipv6: fc00::4a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.19/24
+      ipv6: fc0a::14/64
+
+  VM20T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.38
+        - fc00::4d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.20/32
+        ipv6: 2064:100::14/128
+      Port-Channel1:
+        ipv4: 10.0.0.39/31
+        ipv6: fc00::4e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.20/24
+      ipv6: fc0a::15/64
+
+  VM21T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.40
+        - fc00::51
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.21/32
+        ipv6: 2064:100::15/128
+      Port-Channel1:
+        ipv4: 10.0.0.41/31
+        ipv6: fc00::52/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.21/24
+      ipv6: fc0a::16/64
+
+  VM22T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.42
+        - fc00::55
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.22/32
+        ipv6: 2064:100::16/128
+      Port-Channel1:
+        ipv4: 10.0.0.43/31
+        ipv6: fc00::56/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.22/24
+      ipv6: fc0a::17/64
+
+  VM23T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.44
+        - fc00::59
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.23/32
+        ipv6: 2064:100::17/128
+      Port-Channel1:
+        ipv4: 10.0.0.45/31
+        ipv6: fc00::5a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.23/24
+      ipv6: fc0a::18/64
+
+  VM24T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.46
+        - fc00::5d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.24/32
+        ipv6: 2064:100::18/128
+      Port-Channel1:
+        ipv4: 10.0.0.47/31
+        ipv6: fc00::5e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.24/24
+      ipv6: fc0a::19/64
+
+  VM25T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.48
+        - fc00::61
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.25/32
+        ipv6: 2064:100::19/128
+      Port-Channel1:
+        ipv4: 10.0.0.49/31
+        ipv6: fc00::62/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.25/24
+      ipv6: fc0a::1a/64
+
+  VM26T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.50
+        - fc00::65
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.26/32
+        ipv6: 2064:100::1a/128
+      Port-Channel1:
+        ipv4: 10.0.0.51/31
+        ipv6: fc00::66/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.26/24
+      ipv6: fc0a::1b/64
+
+  VM27T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.52
+        - fc00::69
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.27/32
+        ipv6: 2064:100::1b/128
+      Port-Channel1:
+        ipv4: 10.0.0.53/31
+        ipv6: fc00::6a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.27/24
+      ipv6: fc0a::1c/64
+
+  VM28T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.54
+        - fc00::6d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.28/32
+        ipv6: 2064:100::1c/128
+      Port-Channel1:
+        ipv4: 10.0.0.55/31
+        ipv6: fc00::6e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.28/24
+      ipv6: fc0a::1d/64
+
+  VM29T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.56
+        - fc00::71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Port-Channel1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::1e/64
+
+  VM30T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.58
+        - fc00::75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Port-Channel1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::1f/64
+
+  VM31T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.60
+        - fc00::79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Port-Channel1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::20/64
+
+  VM32T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.62
+        - fc00::7d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Port-Channel1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::21/64
+
+  VM01LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.128
+        - fc00::101
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.65/32
+        ipv6: 2064:100::41/128
+      Ethernet1:
+        ipv4: 10.0.0.129/31
+        ipv6: fc00::102/126
+    bp_interface:
+      ipv4: 10.10.246.65/24
+      ipv6: fc0a::42/64
+
+  VM02LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64610
+      peers:
+        65100:
+        - 10.0.0.130
+        - fc00::105
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.66/32
+        ipv6: 2064:100::42/128
+      Ethernet1:
+        ipv4: 10.0.0.131/31
+        ipv6: fc00::106/126
+    bp_interface:
+      ipv4: 10.10.246.66/24
+      ipv6: fc0a::43/64
+
+  VM03LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64620
+      peers:
+        65100:
+        - 10.0.0.132
+        - fc00::109
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.67/32
+        ipv6: 2064:100::43/128
+      Ethernet1:
+        ipv4: 10.0.0.133/31
+        ipv6: fc00::10a/126
+    bp_interface:
+      ipv4: 10.10.246.67/24
+      ipv6: fc0a::44/64
+
+  VM04LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64630
+      peers:
+        65100:
+        - 10.0.0.134
+        - fc00::10d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.68/32
+        ipv6: 2064:100::44/128
+      Ethernet1:
+        ipv4: 10.0.0.135/31
+        ipv6: fc00::10e/126
+    bp_interface:
+      ipv4: 10.10.246.68/24
+      ipv6: fc0a::45/64
+
+  VM05LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64640
+      peers:
+        65100:
+        - 10.0.0.136
+        - fc00::111
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.69/32
+        ipv6: 2064:100::45/128
+      Ethernet1:
+        ipv4: 10.0.0.137/31
+        ipv6: fc00::112/126
+    bp_interface:
+      ipv4: 10.10.246.69/24
+      ipv6: fc0a::46/64
+
+  VM06LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64650
+      peers:
+        65100:
+        - 10.0.0.138
+        - fc00::115
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.70/32
+        ipv6: 2064:100::46/128
+      Ethernet1:
+        ipv4: 10.0.0.139/31
+        ipv6: fc00::116/126
+    bp_interface:
+      ipv4: 10.10.246.70/24
+      ipv6: fc0a::47/64
+
+  VM07LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64660
+      peers:
+        65100:
+        - 10.0.0.140
+        - fc00::119
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.71/32
+        ipv6: 2064:100::47/128
+      Ethernet1:
+        ipv4: 10.0.0.141/31
+        ipv6: fc00::11a/126
+    bp_interface:
+      ipv4: 10.10.246.71/24
+      ipv6: fc0a::48/64
+
+  VM08LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64670
+      peers:
+        65100:
+        - 10.0.0.142
+        - fc00::11d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.72/32
+        ipv6: 2064:100::48/128
+      Ethernet1:
+        ipv4: 10.0.0.143/31
+        ipv6: fc00::11e/126
+    bp_interface:
+      ipv4: 10.10.246.72/24
+      ipv6: fc0a::49/64
+
+  VM09LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64680
+      peers:
+        65100:
+        - 10.0.0.144
+        - fc00::121
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.73/32
+        ipv6: 2064:100::49/128
+      Ethernet1:
+        ipv4: 10.0.0.145/31
+        ipv6: fc00::122/126
+    bp_interface:
+      ipv4: 10.10.246.73/24
+      ipv6: fc0a::4a/64
+
+  VM10LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64690
+      peers:
+        65100:
+        - 10.0.0.146
+        - fc00::125
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.74/32
+        ipv6: 2064:100::4a/128
+      Ethernet1:
+        ipv4: 10.0.0.147/31
+        ipv6: fc00::126/126
+    bp_interface:
+      ipv4: 10.10.246.74/24
+      ipv6: fc0a::4b/64
+
+  VM11LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64700
+      peers:
+        65100:
+        - 10.0.0.148
+        - fc00::129
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.75/32
+        ipv6: 2064:100::4b/128
+      Ethernet1:
+        ipv4: 10.0.0.149/31
+        ipv6: fc00::12a/126
+    bp_interface:
+      ipv4: 10.10.246.75/24
+      ipv6: fc0a::4c/64
+
+  VM12LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64710
+      peers:
+        65100:
+        - 10.0.0.150
+        - fc00::12d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.76/32
+        ipv6: 2064:100::4c/128
+      Ethernet1:
+        ipv4: 10.0.0.151/31
+        ipv6: fc00::12e/126
+    bp_interface:
+      ipv4: 10.10.246.76/24
+      ipv6: fc0a::4d/64
+
+  VM13LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64720
+      peers:
+        65100:
+        - 10.0.0.152
+        - fc00::131
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.77/32
+        ipv6: 2064:100::4d/128
+      Ethernet1:
+        ipv4: 10.0.0.153/31
+        ipv6: fc00::132/126
+    bp_interface:
+      ipv4: 10.10.246.77/24
+      ipv6: fc0a::4e/64
+
+  VM14LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64730
+      peers:
+        65100:
+        - 10.0.0.154
+        - fc00::135
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.78/32
+        ipv6: 2064:100::4e/128
+      Ethernet1:
+        ipv4: 10.0.0.155/31
+        ipv6: fc00::136/126
+    bp_interface:
+      ipv4: 10.10.246.78/24
+      ipv6: fc0a::4f/64
+
+  VM15LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64740
+      peers:
+        65100:
+        - 10.0.0.156
+        - fc00::139
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.79/32
+        ipv6: 2064:100::4f/128
+      Ethernet1:
+        ipv4: 10.0.0.157/31
+        ipv6: fc00::13a/126
+    bp_interface:
+      ipv4: 10.10.246.79/24
+      ipv6: fc0a::50/64
+
+  VM16LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64750
+      peers:
+        65100:
+        - 10.0.0.158
+        - fc00::13d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.80/32
+        ipv6: 2064:100::50/128
+      Ethernet1:
+        ipv4: 10.0.0.159/31
+        ipv6: fc00::13e/126
+    bp_interface:
+      ipv4: 10.10.246.80/24
+      ipv6: fc0a::51/64
+
+  VM17LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64760
+      peers:
+        65100:
+        - 10.0.0.160
+        - fc00::141
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.81/32
+        ipv6: 2064:100::51/128
+      Ethernet1:
+        ipv4: 10.0.0.161/31
+        ipv6: fc00::142/126
+    bp_interface:
+      ipv4: 10.10.246.81/24
+      ipv6: fc0a::52/64
+
+  VM18LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64770
+      peers:
+        65100:
+        - 10.0.0.162
+        - fc00::145
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.82/32
+        ipv6: 2064:100::52/128
+      Ethernet1:
+        ipv4: 10.0.0.163/31
+        ipv6: fc00::146/126
+    bp_interface:
+      ipv4: 10.10.246.82/24
+      ipv6: fc0a::53/64
+
+  VM19LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64780
+      peers:
+        65100:
+        - 10.0.0.164
+        - fc00::149
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.83/32
+        ipv6: 2064:100::53/128
+      Ethernet1:
+        ipv4: 10.0.0.165/31
+        ipv6: fc00::14a/126
+    bp_interface:
+      ipv4: 10.10.246.83/24
+      ipv6: fc0a::54/64
+
+  VM20LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64790
+      peers:
+        65100:
+        - 10.0.0.166
+        - fc00::14d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.84/32
+        ipv6: 2064:100::54/128
+      Ethernet1:
+        ipv4: 10.0.0.167/31
+        ipv6: fc00::14e/126
+    bp_interface:
+      ipv4: 10.10.246.84/24
+      ipv6: fc0a::55/64
+
+  VM21LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64800
+      peers:
+        65100:
+        - 10.0.0.168
+        - fc00::151
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.85/32
+        ipv6: 2064:100::55/128
+      Ethernet1:
+        ipv4: 10.0.0.169/31
+        ipv6: fc00::152/126
+    bp_interface:
+      ipv4: 10.10.246.85/24
+      ipv6: fc0a::56/64
+
+  VM22LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64810
+      peers:
+        65100:
+        - 10.0.0.170
+        - fc00::155
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.86/32
+        ipv6: 2064:100::56/128
+      Ethernet1:
+        ipv4: 10.0.0.171/31
+        ipv6: fc00::156/126
+    bp_interface:
+      ipv4: 10.10.246.86/24
+      ipv6: fc0a::57/64
+
+  VM23LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64820
+      peers:
+        65100:
+        - 10.0.0.172
+        - fc00::159
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.87/32
+        ipv6: 2064:100::57/128
+      Ethernet1:
+        ipv4: 10.0.0.173/31
+        ipv6: fc00::15a/126
+    bp_interface:
+      ipv4: 10.10.246.87/24
+      ipv6: fc0a::58/64
+
+  VM24LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64830
+      peers:
+        65100:
+        - 10.0.0.174
+        - fc00::15d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.88/32
+        ipv6: 2064:100::58/128
+      Ethernet1:
+        ipv4: 10.0.0.175/31
+        ipv6: fc00::15e/126
+    bp_interface:
+      ipv4: 10.10.246.88/24
+      ipv6: fc0a::59/64
+
+  VM25LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64840
+      peers:
+        65100:
+        - 10.0.0.176
+        - fc00::161
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.89/32
+        ipv6: 2064:100::59/128
+      Ethernet1:
+        ipv4: 10.0.0.177/31
+        ipv6: fc00::162/126
+    bp_interface:
+      ipv4: 10.10.246.89/24
+      ipv6: fc0a::5a/64
+
+  VM26LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64850
+      peers:
+        65100:
+        - 10.0.0.178
+        - fc00::165
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.90/32
+        ipv6: 2064:100::5a/128
+      Ethernet1:
+        ipv4: 10.0.0.179/31
+        ipv6: fc00::166/126
+    bp_interface:
+      ipv4: 10.10.246.90/24
+      ipv6: fc0a::5b/64
+
+  VM27LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64860
+      peers:
+        65100:
+        - 10.0.0.180
+        - fc00::169
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.91/32
+        ipv6: 2064:100::5b/128
+      Ethernet1:
+        ipv4: 10.0.0.181/31
+        ipv6: fc00::16a/126
+    bp_interface:
+      ipv4: 10.10.246.91/24
+      ipv6: fc0a::5c/64
+
+  VM28LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64870
+      peers:
+        65100:
+        - 10.0.0.182
+        - fc00::16d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.92/32
+        ipv6: 2064:100::5c/128
+      Ethernet1:
+        ipv4: 10.0.0.183/31
+        ipv6: fc00::16e/126
+    bp_interface:
+      ipv4: 10.10.246.92/24
+      ipv6: fc0a::5d/64
+
+  VM29LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64880
+      peers:
+        65100:
+        - 10.0.0.184
+        - fc00::171
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.93/32
+        ipv6: 2064:100::5d/128
+      Ethernet1:
+        ipv4: 10.0.0.185/31
+        ipv6: fc00::172/126
+    bp_interface:
+      ipv4: 10.10.246.93/24
+      ipv6: fc0a::5e/64
+
+  VM30LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64890
+      peers:
+        65100:
+        - 10.0.0.186
+        - fc00::175
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.94/32
+        ipv6: 2064:100::5e/128
+      Ethernet1:
+        ipv4: 10.0.0.187/31
+        ipv6: fc00::176/126
+    bp_interface:
+      ipv4: 10.10.246.94/24
+      ipv6: fc0a::5f/64
+
+  VM31LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64900
+      peers:
+        65100:
+        - 10.0.0.188
+        - fc00::179
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.95/32
+        ipv6: 2064:100::5f/128
+      Ethernet1:
+        ipv4: 10.0.0.189/31
+        ipv6: fc00::17a/126
+    bp_interface:
+      ipv4: 10.10.246.95/24
+      ipv6: fc0a::60/64
+
+  VM32LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64910
+      peers:
+        65100:
+        - 10.0.0.190
+        - fc00::17d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.96/32
+        ipv6: 2064:100::60/128
+      Ethernet1:
+        ipv4: 10.0.0.191/31
+        ipv6: fc00::17e/126
+    bp_interface:
+      ipv4: 10.10.246.96/24
+      ipv6: fc0a::61/64

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -555,14 +555,26 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     critical_proceses, bgp_check = postcheck_critical_processes_status(
         duthost, feature_autorestart_states, up_bgp_neighbors
     )
+    if not critical_proceses:
+        processes_status = duthost.all_critical_process_status()
+        for cname, procs in list(processes_status.items()):
+            if procs["status"] is False or len(procs["exited_critical_process"]) > 0:
+                logger.info("Post-check: container '{}' has exited critical processes: {}"
+                            .format(cname, procs["exited_critical_process"]))
+    if not bgp_check:
+        bgp_neigh = duthost.get_bgp_neighbors()
+        down_sessions = {ip: info['state'] for ip, info in list(bgp_neigh.items()) if info['state'] != 'established'}
+        logger.info("Post-check: BGP sessions not established: {}".format(down_sessions))
     if not (critical_proceses and bgp_check):
-        config_reload(duthost, safe_reload=True)
-        # after config reload, the feature autorestart config is reset,
-        # so, before next test, enable again
-        enable_autorestart(duthost)
-
+        # Capture diagnostic state BEFORE config_reload, otherwise all sessions
+        # will appear established in the error message after recovery.
         failed_check = "[Critical Process] " if not critical_proceses else ""
         failed_check += "[BGP] " if not bgp_check else ""
+        bgp_failures = [
+            {x: v['state']}
+            for x, v in list(duthost.get_bgp_neighbors().items())
+            if v['state'] != 'established'
+        ]
         processes_status = duthost.all_critical_process_status()
         pstatus = [
             {
@@ -574,6 +586,11 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
                 "status"
             ] is False and len(v["exited_critical_process"]) > 0
         ]
+
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+        # after config reload, the feature autorestart config is reset,
+        # so, before next test, enable again
+        enable_autorestart(duthost)
 
         if (duthost.get_facts().get("modular_chassis") and
                 duthost.facts["asic_type"] == "cisco-8000" and
@@ -591,11 +608,7 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
                 ("{}check failed, testing feature {}, \nBGP:{}, \nNeighbors:{}"
                  "\nProcess status {}").format(
                     failed_check, container_name,
-                    [
-                        {x: v['state']}
-                        for x, v in list(duthost.get_bgp_neighbors().items())
-                        if v['state'] != 'established'
-                    ],
+                    bgp_failures,
                     up_bgp_neighbors, pstatus
                 )
             )

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -247,6 +247,25 @@ def setup_bgp_graceful_restart(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo
         pytest.fail("not all bgp sessions are up after disable graceful restart")
 
 
+def _setup_arp_responder(duthost, ptfhost, tbinfo, is_v6_topo):
+    """Setup arp_responder on PTF with per-port server IP config for dualtor."""
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    minigraph_ptf_indices = mg_facts['minigraph_ptf_indices']
+    mux_config = mux_cable_server_ip(duthost)
+    ip_type = "server_ipv6" if is_v6_topo else "server_ipv4"
+    arp_responder_conf = {
+        "eth%s" % minigraph_ptf_indices[port]: [config[ip_type].split("/")[0]]
+        for port, config in list(mux_config.items())
+    }
+    ptfhost.copy(content=json.dumps(arp_responder_conf, indent=4), dest="/tmp/from_t1.json")
+    ptfhost.copy(src="scripts/arp_responder.py", dest="/opt")
+    ptfhost.host.options["variable_manager"].extra_vars.update({"arp_responder_args": ""})
+    ptfhost.template(src="templates/arp_responder.conf.j2",
+                     dest="/etc/supervisor/conf.d/arp_responder.conf")
+    ptfhost.shell("supervisorctl reread && supervisorctl update")
+    ptfhost.shell("supervisorctl start arp_responder")
+
+
 @pytest.fixture(scope="module")
 def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhost, request, tbinfo, topo_scenario):
     """Setup interfaces for the new BGP peers on PTF."""
@@ -328,6 +347,20 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
 
     @contextlib.contextmanager
     def _setup_interfaces_dualtor(mg_facts, peer_count):
+        # Each server IP is assigned to its own correct PTF port (matching the
+        # MUX_CABLE Ethernet port) so that the dualtor forwarding works naturally:
+        # active ports use the direct path, standby ports use the IPinIP tunnel.
+        # Source-based policy routing on PTF ensures responses egress via the
+        # correct port despite all IPs sharing the same VLAN subnet.
+
+        # Pick a policy route table base that doesn't conflict with existing tables.
+        # Resolved before try/finally so cleanup never touches tables we didn't create.
+        used_tables = ptfhost.shell("ip rule show | grep -oP 'lookup \\K[0-9]+'",
+                                    module_ignore_errors=True)['stdout'].splitlines()
+        used_table_ids = {int(t) for t in used_tables if t.isdigit()}
+        POLICY_ROUTE_TABLE_BASE = 100
+        while any((POLICY_ROUTE_TABLE_BASE + i) in used_table_ids for i in range(peer_count)):
+            POLICY_ROUTE_TABLE_BASE += peer_count
         try:
             connections = []
             vlan_intf = _find_vlan_intferface(mg_facts)
@@ -345,47 +378,46 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                     {
                         "local_intf": loopback_intf["name"],
                         "local_addr": "%s/%s" % (loopback_intf_addr, loopback_intf_prefixlen),
-                        # Note: Config same subnets on PTF will generate two connect routes on PTF.
-                        # This may lead different IPs has same FDB entry on DUT even they are on different
-                        # interface and cause layer3 packet drop on PTF, so here same interface for different
-                        # neighbor.
-                        "neighbor_intf": "eth%s" % mg_facts["minigraph_port_indices"][local_interfaces[0]],
+                        "neighbor_intf": "eth%s" % mg_facts["minigraph_port_indices"][local_interface],
                         "neighbor_addr": "%s/%s" % (mux_configs[local_interface][server_ip_key].split("/")[0],
                                                     vlan_intf_prefixlen)
                     }
                 )
 
             ptfhost.remove_ip_addresses()
-            # let's stop arp_responder and garp_service as they could pollute
-            # devices' arp tables.
-            ptfhost.shell("supervisorctl stop garp_service", module_ignore_errors=True)
-            ptfhost.shell("supervisorctl stop arp_responder", module_ignore_errors=True)
+            _setup_arp_responder(duthost, ptfhost, tbinfo, is_v6_topo)
 
-            first_neighbor_port = None
             for conn in connections:
                 ptfhost.shell("ip address add %s dev %s" % (conn["neighbor_addr"], conn["neighbor_intf"]))
-                if not first_neighbor_port:
-                    first_neighbor_port = conn["neighbor_intf"]
-                # NOTE: this enables the standby ToR to passively learn
-                # all the neighbors configured on the ptf interfaces.
-                # As the ptf is a multihomed environment, the packets to the
-                # vlan gateway will always egress the first ptf port that has
-                # vlan subnet address assigned, so let's use the first
-                # ptf port to announce the neigbors.
-                ptfhost.shell(
-                    "arping %s -S %s -i %s -C 5" % (
-                        vlan_intf_addr, conn["neighbor_addr"].split("/")[0], first_neighbor_port
-                    ),
-                    module_ignore_errors=True
-                )
+
+            # Source-based policy routing: ensure each ExaBGP peer's responses
+            # egress via its own PTF port. Without this, duplicate connected
+            # routes from the same VLAN subnet cause all responses to egress
+            # one port, breaking peers on other ports.
+            for i, conn in enumerate(connections):
+                table_id = POLICY_ROUTE_TABLE_BASE + i
+                neighbor_ip = conn["neighbor_addr"].split("/")[0]
+                ptfhost.shell("ip rule add from %s table %d" % (neighbor_ip, table_id))
+                ptfhost.shell("ip route add default via %s dev %s table %d" % (
+                    vlan_intf_addr, conn["neighbor_intf"], table_id
+                ))
+
             ptfhost.shell("ip route add {}{} via {}".format(
                 loopback_intf_addr, "/128" if is_v6_topo else "/32", vlan_intf_addr
             ))
             yield connections
 
         finally:
-            ptfhost.shell("ip route delete {}{}".format(loopback_intf_addr, "/128" if is_v6_topo else "/32"))
-            for conn in connections:
+            ptfhost.shell("supervisorctl stop arp_responder", module_ignore_errors=True)
+            ptfhost.shell("ip route delete {}{}".format(loopback_intf_addr, "/128" if is_v6_topo else "/32"),
+                          module_ignore_errors=True)
+            for i, conn in enumerate(connections):
+                table_id = POLICY_ROUTE_TABLE_BASE + i
+                neighbor_ip = conn["neighbor_addr"].split("/")[0]
+                ptfhost.shell("ip rule del from %s table %d" % (neighbor_ip, table_id),
+                              module_ignore_errors=True)
+                ptfhost.shell("ip route flush table %d" % table_id,
+                              module_ignore_errors=True)
                 ptfhost.shell("ip address flush %s scope global" % conn["neighbor_intf"])
 
     @contextlib.contextmanager

--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -7,6 +7,7 @@ import time
 import pytest
 from scapy.all import sniff, IP, IPv6
 from scapy.contrib import bgp
+from scapy.layers.l2 import CookedLinux
 
 from tests.bgp.bgp_helpers import capture_bgp_packages_to_file, fetch_and_delete_pcap_file
 from tests.common.errors import RunAnsibleModuleFail
@@ -135,11 +136,20 @@ def is_neighbor_session_established(duthost, neighbor):
 
 
 def bgp_notification_packets(pcap_file, is_v6_topo):
-    """Get bgp notification packets from pcap file."""
+    """Get incoming bgp notification packets from pcap file.
+
+    When tcpdump captures on the 'any' interface with LINUX_SLL link type,
+    each packet has a CookedLinux header with a pkttype field indicating
+    direction. Filter out outgoing packets (pkttype == 4, 'sent-by-us')
+    so only incoming notifications are validated.
+    """
     ip_ver = IPv6 if is_v6_topo else IP
     packets = sniff(
         offline=pcap_file,
-        lfilter=lambda p: ip_ver in p and bgp.BGPHeader in p and p[bgp.BGPHeader].type == 3,
+        lfilter=lambda p: (ip_ver in p and
+                           bgp.BGPHeader in p and
+                           p[bgp.BGPHeader].type == 3 and
+                           not (CookedLinux in p and p[CookedLinux].pkttype == 4)),
     )
     return packets
 

--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -12,6 +12,8 @@ import time
 from collections import defaultdict
 from natsort import natsorted
 from .transceiver_utils import all_transceivers_detected
+import ast
+from tests.common.mellanox_data import is_mellanox_device
 
 
 def parse_intf_status(lines):
@@ -335,3 +337,44 @@ def get_lport_to_first_subport_mapping(duthost, logical_intfs=None):
     first_subport_dict = {k: pport_to_lport_mapping[v][0] for k, v in physical_port_indices.items()}
     logging.debug("First subports mapping: {}".format(first_subport_dict))
     return first_subport_dict
+
+
+def get_ports_with_flat_memory(dut, conn_graph_facts):
+    """
+    This method is to get ports with flat memory
+    """
+    port_indexes_with_flat_memory = []
+    if is_mellanox_device(dut):
+        port_indexes_with_flat_memory = get_port_indexes_with_flat_memory(dut)
+
+    physical_intfs = conn_graph_facts["device_conn"][dut.hostname]
+    physical_port_index_map = get_physical_port_indices(dut, physical_intfs)
+    ports_with_flat_memory = []
+    for port, index in physical_port_index_map.items():
+        if index in port_indexes_with_flat_memory:
+            ports_with_flat_memory.append(port)
+    logging.info(f"Ports with flat memory: {ports_with_flat_memory}")
+    return ports_with_flat_memory
+
+
+def get_port_indexes_with_flat_memory(dut):
+    """
+    This method is to get port indexes with flat memory
+    """
+    cmd = """
+cat << EOF > get_port_indexes_with_flat_memory.py
+import sonic_platform.platform as P
+num_sfps = P.Platform().get_chassis().get_num_sfps()
+port_indexes_with_flat_memory = []
+for i in range(1, num_sfps + 1):
+    is_flat_memory = P.Platform().get_chassis().get_sfp(i).get_xcvr_api().is_flat_memory()
+    if is_flat_memory:
+        port_indexes_with_flat_memory.append(i)
+print(port_indexes_with_flat_memory)
+EOF
+"""
+    dut.shell(cmd)
+    port_indexes_with_flat_memory = dut.shell("python3 get_port_indexes_with_flat_memory.py")["stdout"]
+    port_indexes_with_flat_memory = ast.literal_eval(port_indexes_with_flat_memory)
+    logging.info(f"Port indexes with flat memory: {port_indexes_with_flat_memory}")
+    return port_indexes_with_flat_memory

--- a/tests/common/platform/transceiver_utils.py
+++ b/tests/common/platform/transceiver_utils.py
@@ -207,19 +207,6 @@ def get_sfp_eeprom_map_per_port(eeprom_infos):
     return sfp_eeprom_map_per_port
 
 
-def get_ports_with_flat_memory(dut):
-    ports_with_flat_memory = []
-    cmd_show_eeprom = "sudo sfputil show eeprom -d"
-
-    eeprom_infos = dut.command(cmd_show_eeprom, module_ignore_errors=True)['stdout']
-    sfp_eerpom_map_per_port = get_sfp_eeprom_map_per_port(eeprom_infos)
-    for port_name, sfp_eeprom in sfp_eerpom_map_per_port.items():
-        if "DOM values not supported for flat memory module" in " ".join(sfp_eeprom):
-            ports_with_flat_memory.append(port_name)
-    logging.info(f"Ports with flat memory: {ports_with_flat_memory}")
-    return ports_with_flat_memory
-
-
 def parse_one_sfp_eeprom_info(sfp_eeprom_info):
     """
     Parse the one sfp eeprom info, return top_key, sfp_eeprom_info_dict

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1478,6 +1478,14 @@ platform_tests/test_service_warm_restart.py:
 #######################################
 #####   test_xcvr_info_in_db.py   #####
 #######################################
+
+platform_tests/test_xcvr_info_in_db.py:
+  skip:
+    reason: 'Transceiver info tests require SFP hardware, not available on VS platform'
+    conditions_logical_operator: or
+    conditions:
+      - "asic_type in ['vs']"
+
 platform_tests/test_xcvr_info_in_db.py::test_xcvr_info_in_db:
   xfail:
     reason: "CLI Utility sfpshow not working correctly"

--- a/tests/common/plugins/memory_utilization/__init__.py
+++ b/tests/common/plugins/memory_utilization/__init__.py
@@ -52,6 +52,10 @@ def pytest_runtest_setup(item):
         if duthost.topo_type == 't2':
             continue
 
+        # Trigger monit to refresh its cache so subsequent collection reads fresh data
+        logger.info("Triggering monit refresh on {} before collecting memory data".format(duthost.hostname))
+        memory_monitors[duthost.hostname].execute_command("sudo monit validate")
+
         # Initial memory check for all registered commands
         for name, cmd, memory_params, memory_check in memory_monitors[duthost.hostname].commands:
             try:
@@ -90,6 +94,10 @@ def pytest_runtest_teardown(item, nextitem):
     for duthost in duthosts:
         if duthost.topo_type == 't2':
             continue
+
+        # Trigger monit to refresh its cache so subsequent collection reads fresh data
+        logger.info("Triggering monit refresh on {} before collecting memory data".format(duthost.hostname))
+        memory_monitors[duthost.hostname].execute_command("sudo monit validate")
 
         # memory check for all registered commands
         for name, cmd, memory_params, memory_check in memory_monitors[duthost.hostname].commands:

--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -388,7 +388,8 @@ class MemoryMonitor:
                     'name': name,
                     'cmd': command,
                     'memory_params': memory_params,
-                    'memory_check_fn': memory_check_fn
+                    'memory_check_fn': memory_check_fn,
+                    'order': item.get('order', 0)
                 }
 
         with open(MEMORY_UTILIZATION_DEPENDENCE_JSON_FILE, 'r') as file:
@@ -403,7 +404,8 @@ class MemoryMonitor:
                     'name': name,
                     'cmd': command,
                     'memory_params': memory_params,
-                    'memory_check_fn': memory_check_fn
+                    'memory_check_fn': memory_check_fn,
+                    'order': item.get('order', parameter_dict.get(name, {}).get('order', 0))
                 }
 
             if hwsku:
@@ -435,10 +437,11 @@ class MemoryMonitor:
                                         'name': name,
                                         'cmd': command,
                                         'memory_params': memory_params,
-                                        'memory_check_fn': memory_check_fn
+                                        'memory_check_fn': memory_check_fn,
+                                        'order': item.get('order', 0)
                                     }
 
-        for param in parameter_dict.values():
+        for param in sorted(parameter_dict.values(), key=lambda x: x.get('order', 0)):
             # Normalize thresholds in memory_params to ensure consistent behavior
             for mem_item, thresholds in param['memory_params'].items():
                 param['memory_params'][mem_item] = self._normalize_thresholds(thresholds)

--- a/tests/common/plugins/memory_utilization/memory_utilization_common.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_common.json
@@ -2,7 +2,8 @@
   "COMMON": [
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "order": 100,
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {

--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -44,7 +44,8 @@
     },
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "order": 100,
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {
@@ -206,7 +207,7 @@
   "Arista-7050QX": [
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {
@@ -225,7 +226,7 @@
   "Mellanox-SN4600C": [
     {
       "name": "monit",
-      "cmd": "sudo monit validate",
+      "cmd": "sudo monit status",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -169,6 +169,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                             exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
                             exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
                             exp_pkt.set_do_not_care_packet(scapy.IPv6, "hlim")
+                            exp_pkt.set_do_not_care_packet(scapy.IPv6, "tc")
+                            exp_pkt.set_do_not_care_packet(scapy.IPv6, "fl")
                             testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=ptfadapter.ptf_port_set,
                                                              timeout=5)
                     count += 1

--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -7,8 +7,8 @@ from tests.common.mellanox_data import is_mellanox_device
 from .args.counterpoll_cpu_usage_args import add_counterpoll_cpu_usage_args
 from tests.common.helpers.mellanox_thermal_control_test_helper import suspend_hw_tc_service, resume_hw_tc_service
 from tests.common.platform.device_utils import MGFX_HWSKU, MGFX_XCVR_INTF
-from tests.common.platform.transceiver_utils import get_ports_with_flat_memory, \
-    get_passive_cable_port_list, get_cmis_cable_ports_and_ver
+from tests.common.platform.transceiver_utils import get_passive_cable_port_list, get_cmis_cable_ports_and_ver
+from tests.common.platform.interface_utils import get_ports_with_flat_memory
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -229,10 +229,10 @@ def dpu_npu_port_list(duthosts):
 
 
 @pytest.fixture(scope="module")
-def port_list_with_flat_memory(duthosts):
+def port_list_with_flat_memory(duthosts, conn_graph_facts):
     ports_with_flat_memory = {}
     for dut in duthosts:
-        ports_with_flat_memory.update({dut.hostname: get_ports_with_flat_memory(dut)})
+        ports_with_flat_memory.update({dut.hostname: get_ports_with_flat_memory(dut, conn_graph_facts)})
     logging.info(f"port list with flat memory: {ports_with_flat_memory}")
     return ports_with_flat_memory
 

--- a/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
@@ -2,11 +2,12 @@ import pytest
 import allure
 
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts  # noqa: F401
-from .util import check_sfp_eeprom_info, is_support_dom, get_pci_cr0_path, get_pciconf0_path
+from .util import check_sfp_eeprom_info
 from tests.common.platform.transceiver_utils import parse_sfp_eeprom_infos
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.platform_tests.conftest import check_pmon_uptime_minutes
+import logging
 
 pytestmark = [
     pytest.mark.asic('mellanox', 'nvidia-bluefield'),
@@ -19,16 +20,11 @@ SHOW_EEPOMR_CMDS = ["show interface transceiver eeprom -d",
 
 @pytest.fixture(scope="module", autouse=True)
 def sfp_test_intfs_to_dom_map(duthosts, rand_one_dut_hostname, conn_graph_facts, xcvr_skip_list,  # noqa: F811
-                              get_sw_control_ports):
+                              get_sw_control_ports, port_list_with_flat_memory):  # noqa: F811
     '''
     This fixture is to get map sfp test intfs to dom
     '''
     duthost = duthosts[rand_one_dut_hostname]
-
-    ports_map = duthost.config_facts(host=duthost.hostname, source="running")[
-        'ansible_facts']["PORT"]
-    port_name_to_index_map = dict(
-        [(port, value["index"]) for port, value in list(ports_map.items())])
 
     sfp_test_intf_list = list(
         conn_graph_facts["device_conn"][duthost.hostname].keys())
@@ -37,28 +33,13 @@ def sfp_test_intfs_to_dom_map(duthosts, rand_one_dut_hostname, conn_graph_facts,
         # Exclude get_sw_control_ports from sfp_test_intf_list
         sfp_test_intf_list = [port for port in sfp_test_intf_list if port not in get_sw_control_ports]
 
-    intf_with_dom_dict = {}
-
     sfp_test_intfs_to_dom_map_dict = {}
-    platform = duthost.facts['platform']
-    dpu_platform_list = ["arm64-nvda_bf-9009d3b600cvaa", "arm64-nvda_bf-9009d3b600svaa"]
-    pci_path = get_pciconf0_path(duthost) if platform in dpu_platform_list else get_pci_cr0_path(duthost)
 
     for intf in sfp_test_intf_list:
         if intf not in xcvr_skip_list[duthost.hostname]:
-            port_index = port_name_to_index_map[intf]
-            original_port_index = port_index
-            if port_index in intf_with_dom_dict:
-                inft_support_dom = intf_with_dom_dict[port_index]
-            else:
-                if platform in dpu_platform_list and port_index == '2':
-                    pci_path = "{}.1".format(pci_path)
-                    port_index = '1'
-                inft_support_dom = is_support_dom(
-                    duthost, port_index, pci_path)
-                intf_with_dom_dict[original_port_index] = inft_support_dom
+            inft_support_dom = False if intf in port_list_with_flat_memory[duthost.hostname] else True
             sfp_test_intfs_to_dom_map_dict[intf] = inft_support_dom
-
+    logging.info(f"sfp_test_intfs_to_dom_map_dict: {sfp_test_intfs_to_dom_map_dict}")
     return sfp_test_intfs_to_dom_map_dict
 
 


### PR DESCRIPTION
```
* 0703fefd2c - Merge branch '202511' into '202603' (2026-04-28) [Zhijian Li]
* bd88483ce9 - [202511] Fix false memory alarm caused by monit stale cache (#24235) (2026-04-28) [Liping Xu]
* 8aeab7dd6a - [action] [PR:24121] Improve autorestart postcheck: capture diagnostics before config_reload (#24237) (2026-04-28) [mssonicbld]
* f53e101463 - [action] [PR:24129] Fix background_traffic mask to ignore IPv6 TC and FL fields (#24224) (2026-04-27) [mssonicbld]
* 76d9229697 - [action] [PR:23952] [dualtor] Fix BGP peer setup in `_setup_interfaces_dualtor` to use per-port design (#24223) (2026-04-27) [mssonicbld]
* f30cf2d71e - [action] [PR:21950] Infra changes for using vsonic as neighbor VM (#24213) (2026-04-26) [mssonicbld]
* 1b11702412 - [Mellanox] Update the test_check_sfp_eeprom due to design change  (#24116) (2026-04-26) [Jibin Bao]
* 79a3585b99 - [DT2] Cherry-pick #23527: Add 64 port T2 topology topo_t2_single_node_max_64p.yml to 202511 (#24131) (2026-04-24) [Yatish]
* dfac6151e6 - [action] [PR:24144] [bgp] Fix test_bgp_peer_shutdown to filter outgoing notification packets (#24180) (2026-04-24) [mssonicbld]
```
