### PR TITLE
[code sync] Merge code from sonic-net/sonic-mgmt:202511 to 202603

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -101,6 +101,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku == "Arista-7060CX-32S-C32" or hwsku == "Arista-7060CX-32S-Q32" \
                 or hwsku == "Arista-7060CX-32S-C32-T1" or hwsku == "Arista-7170-32CD-C32" \
                 or hwsku == "Arista-7050CX3-32S-C28S4" \
+                or hwsku == "Arista-7050CX3-32C-C28S4" \
                 or hwsku == "Arista-7050CX3-32S-C32" \
                 or hwsku == "Arista-7050CX3-32C-C32":
             for i in range(1, 33):
@@ -327,6 +328,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             for i in range(27, 33):
                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 4)
             port_alias_to_name_map["Ethernet33"] = "Ethernet128"
+            port_alias_to_name_map["Ethernet34"] = "Ethernet132"
         elif hwsku in ["Arista-7050CX3-32S-C28S16", "Arista-7050CX3-32C-C28S16"]:
             for i in range(1, 5):
                 for j in range(1, 5):

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -1,8 +1,10 @@
 import time
 import logging
+import subprocess
+import signal
+import os
 import ptf.testutils as testutils
 import ptf.packet as scapy
-from ptf.mask import Mask
 from dhcp_relay_test import DHCPTest
 
 logger = logging.getLogger(__name__)
@@ -44,263 +46,85 @@ class DHCPContinuousStressTest(DHCPTest):
                 self.send_packet_with_interval(dhcp_ack, server_port)
 
 
-class DHCPStressDiscoverTest(DHCPTest):
-    def __init__(self):
-        DHCPTest.__init__(self)
-
+class DHCPStressTest(DHCPTest):
     def setUp(self):
         DHCPTest.setUp(self)
         self.packets_send_duration = self.test_params["packets_send_duration"]
         self.client_packets_per_sec = self.test_params["client_packets_per_sec"]
 
     # Simulate client coming on VLAN and broadcasting a DHCPDISCOVER message
-    def client_send_discover_stress(self, dst_mac, src_port):
-        # Form and send DHCPDISCOVER packet
-        dhcp_discover = self.create_dhcp_discover_packet(dst_mac, src_port)
+    def client_send_packet_stress(self):
+        server_ports = "|".join(["eth{}".format(idx) for idx in self.receive_port_indices])
+        tcpdump_cmd = (
+            "tcpdump -i any -n -q -l 'inbound and udp and (port 67 or port 68) and (udp[249:2] = 0x01{})' "
+            "| grep -w -E '{}' > /tmp/dhcp_stress_test_{}.log"
+        ).format(self.packet_type_hex, server_ports, self.packet_type)
+        tcpdump_proc = subprocess.Popen(tcpdump_cmd, shell=True)
+        if self.packet_type == "discover" or self.packet_type == "request":
+            dhcp_packet = self.create_packet(self.dest_mac_address, self.client_udp_src_port)
+        else:
+            dhcp_packet = self.create_packet()
         end_time = time.time() + self.packets_send_duration
         xid = 0
         while time.time() < end_time:
             # Set a unique transaction ID for each DHCPOFFER packet for making sure no packet miss
-            dhcp_discover[scapy.BOOTP].xid = xid
+            dhcp_packet[scapy.BOOTP].xid = xid
             xid += 1
-            testutils.send_packet(self, self.client_port_index, dhcp_discover)
+            testutils.send_packet(self, self.send_port_indices[0], dhcp_packet)
             time.sleep(1/self.client_packets_per_sec)
 
-    def count_relayed_discover(self):
-        # Create a packet resembling a relayed DCHPDISCOVER packet
-        dhcp_discover_relayed = self.create_dhcp_discover_relayed_packet()
+        time.sleep(15)
 
-        # Mask off fields we don't care about matching
-        masked_discover = Mask(dhcp_discover_relayed)
-        masked_discover.set_do_not_care_scapy(scapy.Ether, "dst")
+        pids = subprocess.check_output("pgrep tcpdump", shell=True).split()
+        for pid in pids:
+            os.kill(int(pid), signal.SIGINT)
+        tcpdump_proc.wait()
 
-        masked_discover.set_do_not_care_scapy(scapy.IP, "version")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "ihl")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "tos")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "len")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "id")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "flags")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "frag")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "ttl")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "proto")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "chksum")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "src")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "dst")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "options")
-
-        masked_discover.set_do_not_care_scapy(scapy.UDP, "chksum")
-        masked_discover.set_do_not_care_scapy(scapy.UDP, "len")
-
-        masked_discover.set_do_not_care_scapy(scapy.BOOTP, "sname")
-        masked_discover.set_do_not_care_scapy(scapy.BOOTP, "file")
-        masked_discover.set_do_not_care_scapy(scapy.BOOTP, "xid")
-
-        discover_count = testutils.count_matched_packets_all_ports(
-            self, masked_discover, self.server_port_indices)
-        return discover_count
+        wc_cmd = f"wc -l /tmp/dhcp_stress_test_{self.packet_type}.log"
+        wc_output = subprocess.check_output(wc_cmd, shell=True)
+        line_cnt = wc_output.decode().split()[0]
+        os.remove("/tmp/dhcp_stress_test_{}.log".format(self.packet_type))
+        subprocess.check_output("echo {} > /tmp/dhcp_stress_test_{}".format(line_cnt, self.packet_type), shell=True)
 
     def runTest(self):
-        self.client_send_discover_stress(self.dest_mac_address, self.client_udp_src_port)
-        discover_cnt = self.count_relayed_discover()
-
-        # At the end of the test, overwrite the file with discover count.
-        try:
-            with open('/tmp/dhcp_stress_test_discover.json', 'w') as result_file:
-                result_file.write(str(discover_cnt))
-        except Exception as e:
-            logger.error("Failed to write to the discover file: %s", repr(e))
+        self.client_send_packet_stress()
 
 
-class DHCPStressOfferTest(DHCPTest):
-    def __init__(self):
-        DHCPTest.__init__(self)
-
+class DHCPStressDiscoverTest(DHCPStressTest):
     def setUp(self):
-        DHCPTest.setUp(self)
-        self.packets_send_duration = self.test_params["packets_send_duration"]
-        self.client_packets_per_sec = self.test_params["client_packets_per_sec"]
-
-    # Simulate client coming on VLAN and broadcasting a DHCPOFFER message
-    def client_send_offer_stress(self):
-        dhcp_offer = self.create_dhcp_offer_packet()
-        end_time = time.time() + self.packets_send_duration
-        xid = 0
-        while time.time() < end_time:
-            # Set a unique transaction ID for each DHCPOFFER packet for making sure no packet miss
-            dhcp_offer[scapy.BOOTP].xid = xid
-            xid += 1
-            testutils.send_packet(self, self.server_port_indices[0], dhcp_offer)
-            time.sleep(1/self.client_packets_per_sec)
-
-    def count_relayed_offer(self):
-        # Create a packet resembling a relayed DCHPOFFER packet
-        dhcp_offer_relayed = self.create_dhcp_offer_relayed_packet()
-
-        # Mask off fields we don't care about matching
-        masked_offer = Mask(dhcp_offer_relayed)
-
-        masked_offer.set_do_not_care_scapy(scapy.IP, "version")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "ihl")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "tos")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "len")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "id")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "flags")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "frag")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "ttl")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "proto")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "chksum")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "options")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "src")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "dst")
-
-        masked_offer.set_do_not_care_scapy(scapy.UDP, "len")
-        masked_offer.set_do_not_care_scapy(scapy.UDP, "chksum")
-
-        masked_offer.set_do_not_care_scapy(scapy.BOOTP, "sname")
-        masked_offer.set_do_not_care_scapy(scapy.BOOTP, "file")
-        masked_offer.set_do_not_care_scapy(scapy.BOOTP, "xid")
-
-        offer_count = testutils.count_matched_packets(self, masked_offer, self.client_port_index)
-        return offer_count
-
-    def runTest(self):
-        self.client_send_offer_stress()
-        offer_cnt = self.count_relayed_offer()
-
-        # At the end of the test, overwrite the file with offer count.
-        try:
-            with open('/tmp/dhcp_stress_test_offer.json', 'w') as result_file:
-                result_file.write(str(offer_cnt))
-        except Exception as e:
-            logger.error("Failed to write to the offer file: %s", repr(e))
+        DHCPStressTest.setUp(self)
+        self.receive_port_indices = self.server_port_indices
+        self.send_port_indices = [self.client_port_index]
+        self.create_packet = self.create_dhcp_discover_packet
+        self.packet_type = "discover"
+        self.packet_type_hex = "01"
 
 
-class DHCPStressRequestTest(DHCPTest):
-    def __init__(self):
-        DHCPTest.__init__(self)
-
+class DHCPStressOfferTest(DHCPStressTest):
     def setUp(self):
-        DHCPTest.setUp(self)
-        self.packets_send_duration = self.test_params["packets_send_duration"]
-        self.client_packets_per_sec = self.test_params["client_packets_per_sec"]
-
-    # Simulate client coming on VLAN and broadcasting a DHCPREQUEST message
-    def client_send_request_stress(self, dst_mac, src_port):
-        # Form and send DHCPREQUEST packet
-        dhcp_request = self.create_dhcp_request_packet(dst_mac, src_port)
-        end_time = time.time() + self.packets_send_duration
-        xid = 0
-        while time.time() < end_time:
-            # Set a unique transaction ID for each DHCPACK packet for making sure no packet miss
-            dhcp_request[scapy.BOOTP].xid = xid
-            xid += 1
-            testutils.send_packet(self, self.client_port_index, dhcp_request)
-            time.sleep(1/self.client_packets_per_sec)
-
-    def count_relayed_request(self):
-        # Create a packet resembling a relayed DCHPREQUEST packet
-        dhcp_request_relayed = self.create_dhcp_request_relayed_packet()
-
-        # Mask off fields we don't care about matching
-        masked_request = Mask(dhcp_request_relayed)
-        masked_request.set_do_not_care_scapy(scapy.Ether, "dst")
-
-        masked_request.set_do_not_care_scapy(scapy.IP, "version")
-        masked_request.set_do_not_care_scapy(scapy.IP, "ihl")
-        masked_request.set_do_not_care_scapy(scapy.IP, "tos")
-        masked_request.set_do_not_care_scapy(scapy.IP, "len")
-        masked_request.set_do_not_care_scapy(scapy.IP, "id")
-        masked_request.set_do_not_care_scapy(scapy.IP, "flags")
-        masked_request.set_do_not_care_scapy(scapy.IP, "frag")
-        masked_request.set_do_not_care_scapy(scapy.IP, "ttl")
-        masked_request.set_do_not_care_scapy(scapy.IP, "proto")
-        masked_request.set_do_not_care_scapy(scapy.IP, "chksum")
-        masked_request.set_do_not_care_scapy(scapy.IP, "src")
-        masked_request.set_do_not_care_scapy(scapy.IP, "dst")
-        masked_request.set_do_not_care_scapy(scapy.IP, "options")
-
-        masked_request.set_do_not_care_scapy(scapy.UDP, "chksum")
-        masked_request.set_do_not_care_scapy(scapy.UDP, "len")
-
-        masked_request.set_do_not_care_scapy(scapy.BOOTP, "sname")
-        masked_request.set_do_not_care_scapy(scapy.BOOTP, "file")
-        masked_request.set_do_not_care_scapy(scapy.BOOTP, "xid")
-
-        request_count = testutils.count_matched_packets_all_ports(
-            self, masked_request, self.server_port_indices)
-        return request_count
-
-    def runTest(self):
-        self.client_send_request_stress(self.dest_mac_address, self.client_udp_src_port)
-        request_cnt = self.count_relayed_request()
-
-        # At the end of the test, overwrite the file with request count.
-        try:
-            with open('/tmp/dhcp_stress_test_request.json', 'w') as result_file:
-                result_file.write(str(request_cnt))
-        except Exception as e:
-            logger.error("Failed to write to the request file: %s", repr(e))
+        DHCPStressTest.setUp(self)
+        self.receive_port_indices = [self.client_port_index]
+        self.send_port_indices = self.server_port_indices
+        self.create_packet = self.create_dhcp_offer_packet
+        self.packet_type = "offer"
+        self.packet_type_hex = "02"
 
 
-class DHCPStressAckTest(DHCPTest):
-    def __init__(self):
-        DHCPTest.__init__(self)
-
+class DHCPStressRequestTest(DHCPStressTest):
     def setUp(self):
-        DHCPTest.setUp(self)
-        self.packets_send_duration = self.test_params["packets_send_duration"]
-        self.client_packets_per_sec = self.test_params["client_packets_per_sec"]
+        DHCPStressTest.setUp(self)
+        self.receive_port_indices = self.server_port_indices
+        self.send_port_indices = [self.client_port_index]
+        self.create_packet = self.create_dhcp_request_packet
+        self.packet_type = "request"
+        self.packet_type_hex = "03"
 
-    # Simulate client coming on VLAN and broadcasting a DHCPACK message
-    def client_send_ack_stress(self):
-        dhcp_ack = self.create_dhcp_ack_packet()
-        end_time = time.time() + self.packets_send_duration
-        xid = 0
-        while time.time() < end_time:
-            # Set a unique transaction ID for each DHCPACK packet for making sure no packet miss
-            dhcp_ack[scapy.BOOTP].xid = xid
-            xid += 1
-            testutils.send_packet(self, self.server_port_indices[0], dhcp_ack)
-            time.sleep(1/self.client_packets_per_sec)
 
-    def count_relayed_ack(self):
-        # Create a packet resembling a relayed DCHPACK packet
-        dhcp_ack_relayed = self.create_dhcp_ack_relayed_packet()
-
-        # Mask off fields we don't care about matching
-        masked_ack = Mask(dhcp_ack_relayed)
-
-        masked_ack.set_do_not_care_scapy(scapy.IP, "version")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "ihl")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "tos")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "len")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "id")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "flags")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "frag")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "ttl")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "proto")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "chksum")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "options")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "src")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "dst")
-
-        masked_ack.set_do_not_care_scapy(scapy.UDP, "len")
-        masked_ack.set_do_not_care_scapy(scapy.UDP, "chksum")
-
-        masked_ack.set_do_not_care_scapy(scapy.BOOTP, "sname")
-        masked_ack.set_do_not_care_scapy(scapy.BOOTP, "file")
-        masked_ack.set_do_not_care_scapy(scapy.BOOTP, "xid")
-
-        ack_count = testutils.count_matched_packets(self, masked_ack, self.client_port_index)
-        return ack_count
-
-    def runTest(self):
-        self.client_send_ack_stress()
-        ack_cnt = self.count_relayed_ack()
-
-        # At the end of the test, overwrite the file with ack count.
-        try:
-            with open('/tmp/dhcp_stress_test_ack.json', 'w') as result_file:
-                result_file.write(str(ack_cnt))
-        except Exception as e:
-            logger.error("Failed to write to the ack file: %s", repr(e))
+class DHCPStressAckTest(DHCPStressTest):
+    def setUp(self):
+        DHCPStressTest.setUp(self)
+        self.receive_port_indices = [self.client_port_index]
+        self.send_port_indices = self.server_port_indices
+        self.create_packet = self.create_dhcp_ack_packet
+        self.packet_type = "ack"
+        self.packet_type_hex = "05"

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -1033,27 +1033,6 @@ class DHCPTest(DataplaneBaseTest):
                 self.dest_mac_address, self.client_udp_src_port)
 
 
-class DHCPPacketsServerToClientTest(DHCPTest):
-    """
-    Only Test DHCP packets from server to client, including offer, ack, nak and unknown.
-    """
-    def runTest(self):
-        # Start sniffer process for each server port to capture DHCP packet
-        for interface_index in self.server_port_indices:
-            t1 = Thread(target=self.Sniffer, args=(
-                "eth"+str(interface_index),))
-            t1.start()
-
-        self.server_send_offer()
-        self.verify_offer_received()
-        self.server_send_ack()
-        self.verify_ack_received()
-        self.server_send_unknown()
-        self.verify_relayed_unknown_on_client_side()
-        self.server_send_nak()
-        self.verify_relayed_nak()
-
-
 class DHCPInvalidChecksumTest(DHCPTest):
     """
     Test DHCP packets with invalid checksum.

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -46,6 +46,15 @@ r, ".* ERR swss#orchagent: :- queryHashNativeHashFieldListAttrCapabilities: Fail
 r, ".* ERR swss#orchagent: :- querySwitchEcmpHashAlgorithmEnumCapabilities: Failed to get attribute.*"
 r, ".* ERR swss#orchagent: :- querySwitchLagHashAlgorithmEnumCapabilities: Failed to get attribute.*"
 r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.* failed with error Feature unavailable.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters_acc.*Get Port Phy Control FEC Symbol Error Count.*failed with error Operation disabled \(0xfffffff4\).*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.*port info data get failed with error -2.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn.*Fec Alignment lock status failed.*with error -8.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_port_get_fec_alignment_lock_status.*FEC AM is not supported.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn.*Fec Alignment lock status failed.*with error -327680.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.*Get Port Phy Control FEC RS Bit Error Count failed - port:.*rc: -16.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.*Get Port Phy Control FEC Uncorrected Block Count failed - port:.*rc: -16.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.*Get Port Phy Control FEC Corrected Block Count failed - port:.*rc: -16.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.*Get Port Phy Control FEC Symbol Error Count failed - port:.*rc: -16.*"
 
 # Errors for config reload on broadcom platform on 202511
 r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.* failed - port: \d+, rc: -16.*"

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -7,7 +7,7 @@
 # By using this practice, we suggest to add different tags for different PTF image versions in docker registry.
 - name: Set default value for ptf_imagetag
   set_fact:
-    ptf_imagetag: "202511"
+    ptf_imagetag: "latest"
   when: ptf_imagetag is not defined
 
 - name: set "PTF" container type, by default

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -2,6 +2,18 @@
 
 set -e
 
+function restore_topo_if_needed
+ {
+     if [[ -n "$backup_file" && -f "$backup_file" ]]; then
+         echo "Backup exists, restore backup file"
+         rm -f "$topo_file"
+         mv "$backup_file" "$topo_file"
+         echo "Original topo file restored"
+     fi
+ }
+
+ trap restore_topo_if_needed EXIT
+
 function usage
 {
   echo "testbed-cli. Interface to testbeds"
@@ -190,13 +202,14 @@ function converge_topo_if_needed
 
         if [[ -f "$backup_file" ]];then
             echo "Backup file exists, recover..."
-            sudo cp "$backup_file" "$topo_file"
+            cp "$backup_file" "$topo_file"
         elif [[ -f "$topo_file" ]]; then
             echo "Back up topo file"
-            sudo cp "$topo_file" "$backup_file"
+            cp "$topo_file" "$backup_file"
         fi
 
-        sudo python -m ceos_topo_converger "$backup_file" "$topo_file"
+        python -m ceos_topo_converger "$backup_file" "$topo_file"
+
     fi
 }
 
@@ -1110,9 +1123,3 @@ case "${subcmd}" in
   *)           usage
                ;;
 esac
-
-if [[ -f "$backup_file" ]];then
-    echo "Backup exists, restore backup file"
-    sudo rm -f "$topo_file"
-    sudo mv "$backup_file" "$topo_file"
-fi

--- a/ansible/vars/topo_t2_single_node_max_64p_v2.yml
+++ b/ansible/vars/topo_t2_single_node_max_64p_v2.yml
@@ -1,0 +1,1753 @@
+topology:
+  VMs:
+    ARISTA01T3:
+      vlans:
+        - 0
+      vm_offset: 0
+
+    ARISTA02T3:
+      vlans:
+        - 1
+      vm_offset: 1
+
+    ARISTA03T3:
+      vlans:
+        - 2
+      vm_offset: 2
+
+    ARISTA04T3:
+      vlans:
+        - 3
+      vm_offset: 3
+
+    ARISTA05T3:
+      vlans:
+        - 4
+      vm_offset: 4
+
+    ARISTA06T3:
+      vlans:
+        - 5
+      vm_offset: 5
+
+    ARISTA07T3:
+      vlans:
+        - 6
+      vm_offset: 6
+
+    ARISTA08T3:
+      vlans:
+        - 7
+      vm_offset: 7
+
+    ARISTA09T3:
+      vlans:
+        - 8
+      vm_offset: 8
+
+    ARISTA10T3:
+      vlans:
+        - 9
+      vm_offset: 9
+
+    ARISTA11T3:
+      vlans:
+        - 10
+      vm_offset: 10
+
+    ARISTA12T3:
+      vlans:
+        - 11
+      vm_offset: 11
+
+    ARISTA13T3:
+      vlans:
+        - 12
+      vm_offset: 12
+
+    ARISTA14T3:
+      vlans:
+        - 13
+      vm_offset: 13
+
+    ARISTA15T3:
+      vlans:
+        - 14
+      vm_offset: 14
+
+    ARISTA16T3:
+      vlans:
+        - 15
+      vm_offset: 15
+
+    ARISTA01LT2:
+      vlans:
+        - 16
+      vm_offset: 16
+
+    ARISTA02LT2:
+      vlans:
+        - 17
+      vm_offset: 17
+
+    ARISTA03LT2:
+      vlans:
+        - 18
+      vm_offset: 18
+
+    ARISTA04LT2:
+      vlans:
+        - 19
+      vm_offset: 19
+
+    ARISTA05LT2:
+      vlans:
+        - 20
+      vm_offset: 20
+
+    ARISTA06LT2:
+      vlans:
+        - 21
+      vm_offset: 21
+
+    ARISTA07LT2:
+      vlans:
+        - 22
+      vm_offset: 22
+
+    ARISTA08LT2:
+      vlans:
+        - 23
+      vm_offset: 23
+
+    ARISTA09LT2:
+      vlans:
+        - 24
+      vm_offset: 24
+
+    ARISTA10LT2:
+      vlans:
+        - 25
+      vm_offset: 25
+
+    ARISTA11LT2:
+      vlans:
+        - 26
+      vm_offset: 26
+
+    ARISTA12LT2:
+      vlans:
+        - 27
+      vm_offset: 27
+
+    ARISTA13LT2:
+      vlans:
+        - 28
+      vm_offset: 28
+
+    ARISTA14LT2:
+      vlans:
+        - 29
+      vm_offset: 29
+
+    ARISTA15LT2:
+      vlans:
+        - 30
+      vm_offset: 30
+
+    ARISTA16LT2:
+      vlans:
+        - 31
+      vm_offset: 31
+
+    ARISTA17LT2:
+      vlans:
+        - 32
+      vm_offset: 32
+
+    ARISTA18LT2:
+      vlans:
+        - 33
+      vm_offset: 33
+
+    ARISTA19LT2:
+      vlans:
+        - 34
+      vm_offset: 34
+
+    ARISTA20LT2:
+      vlans:
+        - 35
+      vm_offset: 35
+
+    ARISTA21LT2:
+      vlans:
+        - 36
+      vm_offset: 36
+
+    ARISTA22LT2:
+      vlans:
+        - 37
+      vm_offset: 37
+
+    ARISTA23LT2:
+      vlans:
+        - 38
+      vm_offset: 38
+
+    ARISTA24LT2:
+      vlans:
+        - 39
+      vm_offset: 39
+
+    ARISTA25LT2:
+      vlans:
+        - 40
+      vm_offset: 40
+
+    ARISTA26LT2:
+      vlans:
+        - 41
+      vm_offset: 41
+
+    ARISTA27LT2:
+      vlans:
+        - 42
+      vm_offset: 42
+
+    ARISTA28LT2:
+      vlans:
+        - 43
+      vm_offset: 43
+
+    ARISTA29LT2:
+      vlans:
+        - 44
+      vm_offset: 44
+
+    ARISTA30LT2:
+      vlans:
+        - 45
+      vm_offset: 45
+
+    ARISTA31LT2:
+      vlans:
+        - 46
+      vm_offset: 46
+
+    ARISTA32LT2:
+      vlans:
+        - 47
+      vm_offset: 47
+
+    ARISTA17T3:
+      vlans:
+        - 48
+      vm_offset: 48
+
+    ARISTA18T3:
+      vlans:
+        - 49
+      vm_offset: 49
+
+    ARISTA19T3:
+      vlans:
+        - 50
+      vm_offset: 50
+
+    ARISTA20T3:
+      vlans:
+        - 51
+      vm_offset: 51
+
+    ARISTA21T3:
+      vlans:
+        - 52
+      vm_offset: 52
+
+    ARISTA22T3:
+      vlans:
+        - 53
+      vm_offset: 53
+
+    ARISTA23T3:
+      vlans:
+        - 54
+      vm_offset: 54
+
+    ARISTA24T3:
+      vlans:
+        - 55
+      vm_offset: 55
+
+    ARISTA25T3:
+      vlans:
+        - 56
+      vm_offset: 56
+
+    ARISTA26T3:
+      vlans:
+        - 57
+      vm_offset: 57
+
+    ARISTA27T3:
+      vlans:
+        - 58
+      vm_offset: 58
+
+    ARISTA28T3:
+      vlans:
+        - 59
+      vm_offset: 59
+
+    ARISTA29T3:
+      vlans:
+        - 60
+      vm_offset: 60
+
+    ARISTA30T3:
+      vlans:
+        - 61
+      vm_offset: 61
+
+    ARISTA31T3:
+      vlans:
+        - 62
+      vm_offset: 62
+
+    ARISTA32T3:
+      vlans:
+        - 63
+      vm_offset: 63
+
+  DUT:
+    loopback:
+      ipv4:
+        - 10.1.0.1/32
+      ipv6:
+        - fc00:10::1/128
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: UpperSpineRouter
+    podset_number: 400
+    tor_number: 16
+    tor_subnet_number: 8
+    max_tor_subnet_number: 32
+    tor_subnet_size: 128
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+  core:
+    swrole: core
+  leaf:
+    swrole: leaf
+
+configuration:
+  ARISTA01T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.0
+        - fc00::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Port-Channel1:
+        ipv4: 10.0.0.1/31
+        ipv6: fc00::2/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+
+  ARISTA02T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.2
+        - fc00::5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.2/32
+        ipv6: 2064:100::2/128
+      Port-Channel1:
+        ipv4: 10.0.0.3/31
+        ipv6: fc00::6/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.2/24
+      ipv6: fc0a::3/64
+
+  ARISTA03T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.4
+        - fc00::9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.3/32
+        ipv6: 2064:100::3/128
+      Port-Channel1:
+        ipv4: 10.0.0.5/31
+        ipv6: fc00::a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::4/64
+
+  ARISTA04T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.6
+        - fc00::d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.4/32
+        ipv6: 2064:100::4/128
+      Port-Channel1:
+        ipv4: 10.0.0.7/31
+        ipv6: fc00::e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.4/24
+      ipv6: fc0a::5/64
+
+  ARISTA05T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.8
+        - fc00::11
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.5/32
+        ipv6: 2064:100::5/128
+      Port-Channel1:
+        ipv4: 10.0.0.9/31
+        ipv6: fc00::12/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.5/24
+      ipv6: fc0a::6/64
+
+  ARISTA06T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.10
+        - fc00::15
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.6/32
+        ipv6: 2064:100::6/128
+      Port-Channel1:
+        ipv4: 10.0.0.11/31
+        ipv6: fc00::16/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.6/24
+      ipv6: fc0a::7/64
+
+  ARISTA07T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.12
+        - fc00::19
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.7/32
+        ipv6: 2064:100::7/128
+      Port-Channel1:
+        ipv4: 10.0.0.13/31
+        ipv6: fc00::1a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.7/24
+      ipv6: fc0a::8/64
+
+  ARISTA08T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.14
+        - fc00::1d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.8/32
+        ipv6: 2064:100::8/128
+      Port-Channel1:
+        ipv4: 10.0.0.15/31
+        ipv6: fc00::1e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.8/24
+      ipv6: fc0a::9/64
+
+  ARISTA09T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.16
+        - fc00::21
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.9/32
+        ipv6: 2064:100::9/128
+      Port-Channel1:
+        ipv4: 10.0.0.17/31
+        ipv6: fc00::22/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.9/24
+      ipv6: fc0a::a/64
+
+  ARISTA10T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.18
+        - fc00::25
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.10/32
+        ipv6: 2064:100::a/128
+      Port-Channel1:
+        ipv4: 10.0.0.19/31
+        ipv6: fc00::26/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.10/24
+      ipv6: fc0a::b/64
+
+  ARISTA11T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.20
+        - fc00::29
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.11/32
+        ipv6: 2064:100::b/128
+      Port-Channel1:
+        ipv4: 10.0.0.21/31
+        ipv6: fc00::2a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.11/24
+      ipv6: fc0a::c/64
+
+  ARISTA12T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.22
+        - fc00::2d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.12/32
+        ipv6: 2064:100::c/128
+      Port-Channel1:
+        ipv4: 10.0.0.23/31
+        ipv6: fc00::2e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.12/24
+      ipv6: fc0a::d/64
+
+  ARISTA13T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.24
+        - fc00::31
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.13/32
+        ipv6: 2064:100::d/128
+      Port-Channel1:
+        ipv4: 10.0.0.25/31
+        ipv6: fc00::32/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.13/24
+      ipv6: fc0a::e/64
+
+  ARISTA14T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.26
+        - fc00::35
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.14/32
+        ipv6: 2064:100::e/128
+      Port-Channel1:
+        ipv4: 10.0.0.27/31
+        ipv6: fc00::36/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.14/24
+      ipv6: fc0a::f/64
+
+  ARISTA15T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.28
+        - fc00::39
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.15/32
+        ipv6: 2064:100::f/128
+      Port-Channel1:
+        ipv4: 10.0.0.29/31
+        ipv6: fc00::3a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.15/24
+      ipv6: fc0a::10/64
+
+  ARISTA16T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.30
+        - fc00::3d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.16/32
+        ipv6: 2064:100::10/128
+      Port-Channel1:
+        ipv4: 10.0.0.31/31
+        ipv6: fc00::3e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.16/24
+      ipv6: fc0a::11/64
+
+  ARISTA17T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.32
+        - fc00::41
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.17/32
+        ipv6: 2064:100::11/128
+      Port-Channel1:
+        ipv4: 10.0.0.33/31
+        ipv6: fc00::42/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.17/24
+      ipv6: fc0a::12/64
+
+  ARISTA18T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.34
+        - fc00::45
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.18/32
+        ipv6: 2064:100::12/128
+      Port-Channel1:
+        ipv4: 10.0.0.35/31
+        ipv6: fc00::46/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.18/24
+      ipv6: fc0a::13/64
+
+  ARISTA19T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.36
+        - fc00::49
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.19/32
+        ipv6: 2064:100::13/128
+      Port-Channel1:
+        ipv4: 10.0.0.37/31
+        ipv6: fc00::4a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.19/24
+      ipv6: fc0a::14/64
+
+  ARISTA20T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.38
+        - fc00::4d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.20/32
+        ipv6: 2064:100::14/128
+      Port-Channel1:
+        ipv4: 10.0.0.39/31
+        ipv6: fc00::4e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.20/24
+      ipv6: fc0a::15/64
+
+  ARISTA21T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.40
+        - fc00::51
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.21/32
+        ipv6: 2064:100::15/128
+      Port-Channel1:
+        ipv4: 10.0.0.41/31
+        ipv6: fc00::52/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.21/24
+      ipv6: fc0a::16/64
+
+  ARISTA22T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.42
+        - fc00::55
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.22/32
+        ipv6: 2064:100::16/128
+      Port-Channel1:
+        ipv4: 10.0.0.43/31
+        ipv6: fc00::56/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.22/24
+      ipv6: fc0a::17/64
+
+  ARISTA23T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.44
+        - fc00::59
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.23/32
+        ipv6: 2064:100::17/128
+      Port-Channel1:
+        ipv4: 10.0.0.45/31
+        ipv6: fc00::5a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.23/24
+      ipv6: fc0a::18/64
+
+  ARISTA24T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.46
+        - fc00::5d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.24/32
+        ipv6: 2064:100::18/128
+      Port-Channel1:
+        ipv4: 10.0.0.47/31
+        ipv6: fc00::5e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.24/24
+      ipv6: fc0a::19/64
+
+  ARISTA25T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.48
+        - fc00::61
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.25/32
+        ipv6: 2064:100::19/128
+      Port-Channel1:
+        ipv4: 10.0.0.49/31
+        ipv6: fc00::62/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.25/24
+      ipv6: fc0a::1a/64
+
+  ARISTA26T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.50
+        - fc00::65
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.26/32
+        ipv6: 2064:100::1a/128
+      Port-Channel1:
+        ipv4: 10.0.0.51/31
+        ipv6: fc00::66/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.26/24
+      ipv6: fc0a::1b/64
+
+  ARISTA27T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.52
+        - fc00::69
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.27/32
+        ipv6: 2064:100::1b/128
+      Port-Channel1:
+        ipv4: 10.0.0.53/31
+        ipv6: fc00::6a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.27/24
+      ipv6: fc0a::1c/64
+
+  ARISTA28T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.54
+        - fc00::6d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.28/32
+        ipv6: 2064:100::1c/128
+      Port-Channel1:
+        ipv4: 10.0.0.55/31
+        ipv6: fc00::6e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.28/24
+      ipv6: fc0a::1d/64
+
+  ARISTA29T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.56
+        - fc00::71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Port-Channel1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::1e/64
+
+  ARISTA30T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.58
+        - fc00::75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Port-Channel1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::1f/64
+
+  ARISTA31T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.60
+        - fc00::79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Port-Channel1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::20/64
+
+  ARISTA32T3:
+    properties:
+    - common
+    - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.62
+        - fc00::7d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Port-Channel1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+      Ethernet1:
+        lacp: 1
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::21/64
+
+  ARISTA01LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64600
+      peers:
+        65100:
+        - 10.0.0.128
+        - fc00::101
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.65/32
+        ipv6: 2064:100::41/128
+      Ethernet1:
+        ipv4: 10.0.0.129/31
+        ipv6: fc00::102/126
+    bp_interface:
+      ipv4: 10.10.246.65/24
+      ipv6: fc0a::42/64
+
+  ARISTA02LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64610
+      peers:
+        65100:
+        - 10.0.0.130
+        - fc00::105
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.66/32
+        ipv6: 2064:100::42/128
+      Ethernet1:
+        ipv4: 10.0.0.131/31
+        ipv6: fc00::106/126
+    bp_interface:
+      ipv4: 10.10.246.66/24
+      ipv6: fc0a::43/64
+
+  ARISTA03LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64620
+      peers:
+        65100:
+        - 10.0.0.132
+        - fc00::109
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.67/32
+        ipv6: 2064:100::43/128
+      Ethernet1:
+        ipv4: 10.0.0.133/31
+        ipv6: fc00::10a/126
+    bp_interface:
+      ipv4: 10.10.246.67/24
+      ipv6: fc0a::44/64
+
+  ARISTA04LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64630
+      peers:
+        65100:
+        - 10.0.0.134
+        - fc00::10d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.68/32
+        ipv6: 2064:100::44/128
+      Ethernet1:
+        ipv4: 10.0.0.135/31
+        ipv6: fc00::10e/126
+    bp_interface:
+      ipv4: 10.10.246.68/24
+      ipv6: fc0a::45/64
+
+  ARISTA05LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64640
+      peers:
+        65100:
+        - 10.0.0.136
+        - fc00::111
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.69/32
+        ipv6: 2064:100::45/128
+      Ethernet1:
+        ipv4: 10.0.0.137/31
+        ipv6: fc00::112/126
+    bp_interface:
+      ipv4: 10.10.246.69/24
+      ipv6: fc0a::46/64
+
+  ARISTA06LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64650
+      peers:
+        65100:
+        - 10.0.0.138
+        - fc00::115
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.70/32
+        ipv6: 2064:100::46/128
+      Ethernet1:
+        ipv4: 10.0.0.139/31
+        ipv6: fc00::116/126
+    bp_interface:
+      ipv4: 10.10.246.70/24
+      ipv6: fc0a::47/64
+
+  ARISTA07LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64660
+      peers:
+        65100:
+        - 10.0.0.140
+        - fc00::119
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.71/32
+        ipv6: 2064:100::47/128
+      Ethernet1:
+        ipv4: 10.0.0.141/31
+        ipv6: fc00::11a/126
+    bp_interface:
+      ipv4: 10.10.246.71/24
+      ipv6: fc0a::48/64
+
+  ARISTA08LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64670
+      peers:
+        65100:
+        - 10.0.0.142
+        - fc00::11d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.72/32
+        ipv6: 2064:100::48/128
+      Ethernet1:
+        ipv4: 10.0.0.143/31
+        ipv6: fc00::11e/126
+    bp_interface:
+      ipv4: 10.10.246.72/24
+      ipv6: fc0a::49/64
+
+  ARISTA09LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64680
+      peers:
+        65100:
+        - 10.0.0.144
+        - fc00::121
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.73/32
+        ipv6: 2064:100::49/128
+      Ethernet1:
+        ipv4: 10.0.0.145/31
+        ipv6: fc00::122/126
+    bp_interface:
+      ipv4: 10.10.246.73/24
+      ipv6: fc0a::4a/64
+
+  ARISTA10LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64690
+      peers:
+        65100:
+        - 10.0.0.146
+        - fc00::125
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.74/32
+        ipv6: 2064:100::4a/128
+      Ethernet1:
+        ipv4: 10.0.0.147/31
+        ipv6: fc00::126/126
+    bp_interface:
+      ipv4: 10.10.246.74/24
+      ipv6: fc0a::4b/64
+
+  ARISTA11LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64700
+      peers:
+        65100:
+        - 10.0.0.148
+        - fc00::129
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.75/32
+        ipv6: 2064:100::4b/128
+      Ethernet1:
+        ipv4: 10.0.0.149/31
+        ipv6: fc00::12a/126
+    bp_interface:
+      ipv4: 10.10.246.75/24
+      ipv6: fc0a::4c/64
+
+  ARISTA12LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64710
+      peers:
+        65100:
+        - 10.0.0.150
+        - fc00::12d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.76/32
+        ipv6: 2064:100::4c/128
+      Ethernet1:
+        ipv4: 10.0.0.151/31
+        ipv6: fc00::12e/126
+    bp_interface:
+      ipv4: 10.10.246.76/24
+      ipv6: fc0a::4d/64
+
+  ARISTA13LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64720
+      peers:
+        65100:
+        - 10.0.0.152
+        - fc00::131
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.77/32
+        ipv6: 2064:100::4d/128
+      Ethernet1:
+        ipv4: 10.0.0.153/31
+        ipv6: fc00::132/126
+    bp_interface:
+      ipv4: 10.10.246.77/24
+      ipv6: fc0a::4e/64
+
+  ARISTA14LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64730
+      peers:
+        65100:
+        - 10.0.0.154
+        - fc00::135
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.78/32
+        ipv6: 2064:100::4e/128
+      Ethernet1:
+        ipv4: 10.0.0.155/31
+        ipv6: fc00::136/126
+    bp_interface:
+      ipv4: 10.10.246.78/24
+      ipv6: fc0a::4f/64
+
+  ARISTA15LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64740
+      peers:
+        65100:
+        - 10.0.0.156
+        - fc00::139
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.79/32
+        ipv6: 2064:100::4f/128
+      Ethernet1:
+        ipv4: 10.0.0.157/31
+        ipv6: fc00::13a/126
+    bp_interface:
+      ipv4: 10.10.246.79/24
+      ipv6: fc0a::50/64
+
+  ARISTA16LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64750
+      peers:
+        65100:
+        - 10.0.0.158
+        - fc00::13d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.80/32
+        ipv6: 2064:100::50/128
+      Ethernet1:
+        ipv4: 10.0.0.159/31
+        ipv6: fc00::13e/126
+    bp_interface:
+      ipv4: 10.10.246.80/24
+      ipv6: fc0a::51/64
+
+  ARISTA17LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64760
+      peers:
+        65100:
+        - 10.0.0.160
+        - fc00::141
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.81/32
+        ipv6: 2064:100::51/128
+      Ethernet1:
+        ipv4: 10.0.0.161/31
+        ipv6: fc00::142/126
+    bp_interface:
+      ipv4: 10.10.246.81/24
+      ipv6: fc0a::52/64
+
+  ARISTA18LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64770
+      peers:
+        65100:
+        - 10.0.0.162
+        - fc00::145
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.82/32
+        ipv6: 2064:100::52/128
+      Ethernet1:
+        ipv4: 10.0.0.163/31
+        ipv6: fc00::146/126
+    bp_interface:
+      ipv4: 10.10.246.82/24
+      ipv6: fc0a::53/64
+
+  ARISTA19LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64780
+      peers:
+        65100:
+        - 10.0.0.164
+        - fc00::149
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.83/32
+        ipv6: 2064:100::53/128
+      Ethernet1:
+        ipv4: 10.0.0.165/31
+        ipv6: fc00::14a/126
+    bp_interface:
+      ipv4: 10.10.246.83/24
+      ipv6: fc0a::54/64
+
+  ARISTA20LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64790
+      peers:
+        65100:
+        - 10.0.0.166
+        - fc00::14d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.84/32
+        ipv6: 2064:100::54/128
+      Ethernet1:
+        ipv4: 10.0.0.167/31
+        ipv6: fc00::14e/126
+    bp_interface:
+      ipv4: 10.10.246.84/24
+      ipv6: fc0a::55/64
+
+  ARISTA21LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64800
+      peers:
+        65100:
+        - 10.0.0.168
+        - fc00::151
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.85/32
+        ipv6: 2064:100::55/128
+      Ethernet1:
+        ipv4: 10.0.0.169/31
+        ipv6: fc00::152/126
+    bp_interface:
+      ipv4: 10.10.246.85/24
+      ipv6: fc0a::56/64
+
+  ARISTA22LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64810
+      peers:
+        65100:
+        - 10.0.0.170
+        - fc00::155
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.86/32
+        ipv6: 2064:100::56/128
+      Ethernet1:
+        ipv4: 10.0.0.171/31
+        ipv6: fc00::156/126
+    bp_interface:
+      ipv4: 10.10.246.86/24
+      ipv6: fc0a::57/64
+
+  ARISTA23LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64820
+      peers:
+        65100:
+        - 10.0.0.172
+        - fc00::159
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.87/32
+        ipv6: 2064:100::57/128
+      Ethernet1:
+        ipv4: 10.0.0.173/31
+        ipv6: fc00::15a/126
+    bp_interface:
+      ipv4: 10.10.246.87/24
+      ipv6: fc0a::58/64
+
+  ARISTA24LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64830
+      peers:
+        65100:
+        - 10.0.0.174
+        - fc00::15d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.88/32
+        ipv6: 2064:100::58/128
+      Ethernet1:
+        ipv4: 10.0.0.175/31
+        ipv6: fc00::15e/126
+    bp_interface:
+      ipv4: 10.10.246.88/24
+      ipv6: fc0a::59/64
+
+  ARISTA25LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64840
+      peers:
+        65100:
+        - 10.0.0.176
+        - fc00::161
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.89/32
+        ipv6: 2064:100::59/128
+      Ethernet1:
+        ipv4: 10.0.0.177/31
+        ipv6: fc00::162/126
+    bp_interface:
+      ipv4: 10.10.246.89/24
+      ipv6: fc0a::5a/64
+
+  ARISTA26LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64850
+      peers:
+        65100:
+        - 10.0.0.178
+        - fc00::165
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.90/32
+        ipv6: 2064:100::5a/128
+      Ethernet1:
+        ipv4: 10.0.0.179/31
+        ipv6: fc00::166/126
+    bp_interface:
+      ipv4: 10.10.246.90/24
+      ipv6: fc0a::5b/64
+
+  ARISTA27LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64860
+      peers:
+        65100:
+        - 10.0.0.180
+        - fc00::169
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.91/32
+        ipv6: 2064:100::5b/128
+      Ethernet1:
+        ipv4: 10.0.0.181/31
+        ipv6: fc00::16a/126
+    bp_interface:
+      ipv4: 10.10.246.91/24
+      ipv6: fc0a::5c/64
+
+  ARISTA28LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64870
+      peers:
+        65100:
+        - 10.0.0.182
+        - fc00::16d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.92/32
+        ipv6: 2064:100::5c/128
+      Ethernet1:
+        ipv4: 10.0.0.183/31
+        ipv6: fc00::16e/126
+    bp_interface:
+      ipv4: 10.10.246.92/24
+      ipv6: fc0a::5d/64
+
+  ARISTA29LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64880
+      peers:
+        65100:
+        - 10.0.0.184
+        - fc00::171
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.93/32
+        ipv6: 2064:100::5d/128
+      Ethernet1:
+        ipv4: 10.0.0.185/31
+        ipv6: fc00::172/126
+    bp_interface:
+      ipv4: 10.10.246.93/24
+      ipv6: fc0a::5e/64
+
+  ARISTA30LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64890
+      peers:
+        65100:
+        - 10.0.0.186
+        - fc00::175
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.94/32
+        ipv6: 2064:100::5e/128
+      Ethernet1:
+        ipv4: 10.0.0.187/31
+        ipv6: fc00::176/126
+    bp_interface:
+      ipv4: 10.10.246.94/24
+      ipv6: fc0a::5f/64
+
+  ARISTA31LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64900
+      peers:
+        65100:
+        - 10.0.0.188
+        - fc00::179
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.95/32
+        ipv6: 2064:100::5f/128
+      Ethernet1:
+        ipv4: 10.0.0.189/31
+        ipv6: fc00::17a/126
+    bp_interface:
+      ipv4: 10.10.246.95/24
+      ipv6: fc0a::60/64
+
+  ARISTA32LT2:
+    properties:
+    - common
+    - leaf
+    bgp:
+      asn: 64910
+      peers:
+        65100:
+        - 10.0.0.190
+        - fc00::17d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.96/32
+        ipv6: 2064:100::60/128
+      Ethernet1:
+        ipv4: 10.0.0.191/31
+        ipv6: fc00::17e/126
+    bp_interface:
+      ipv4: 10.10.246.96/24
+      ipv6: fc0a::61/64

--- a/tests/arp/arp_utils.py
+++ b/tests/arp/arp_utils.py
@@ -2,6 +2,7 @@ import re
 import logging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
+from ipaddress import ip_interface
 
 
 logger = logging.getLogger(__name__)
@@ -71,3 +72,37 @@ def fdb_cleanup(duthost):
         duthost.command('fdbclear')
         pytest_assert(wait_until(200, 2, 0, lambda: fdb_table_has_no_dynamic_macs(duthost) is True),
                       "FDB Table Cleanup failed")
+
+
+def get_dut_mac(duthost, config_facts, tbinfo):
+    """
+    Get DUT MAC address
+    """
+    if 'dualtor' in tbinfo['topo']['name']:
+        for vlan_details in list(config_facts['VLAN'].values()):
+            return vlan_details['mac'].lower()
+    return duthost.shell("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'")["stdout_lines"][0]
+
+
+def fdb_has_mac(duthost, mac):
+    """
+    Check if FDB has specific MAC address
+    """
+    mac = mac.lower()
+    logger.info(f"Checking if FDB has MAC address {mac}")
+    mac_lines = [line for line in duthost.command("show mac")["stdout_lines"] if mac in line.lower()]
+    logger.info("Matched MAC entries:\n{}".format("\n".join(mac_lines) if mac_lines else "<none>"))
+    return any(mac in line.lower() for line in duthost.command("show mac")["stdout_lines"])
+
+
+def get_first_vlan_ipv4(config_facts):
+    """
+    Get first VLAN interface and its IPv4 address
+    """
+    vlan_intfs = config_facts.get("VLAN_INTERFACE", {})
+    for intf, addrs in vlan_intfs.items():
+        for addr in addrs:
+            if ":" in addr:
+                continue
+            return intf, ip_interface(addr).ip
+    return None, None

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -1,12 +1,15 @@
 # Test cases to validate functionality of the arp_update script
 
 import logging
+import ptf.testutils as testutils
 import pytest
 import random
 
+from tests.arp.arp_utils import clear_dut_arp_cache, fdb_cleanup, get_dut_mac, fdb_has_mac, get_first_vlan_ipv4
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
-from tests.common.fixtures.ptfhost_utils import setup_vlan_arp_responder  # noqa: F401
+from tests.common.fixtures.ptfhost_utils import setup_vlan_arp_responder, run_icmp_responder  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert as pt_assert
+from tests.common.helpers.constants import PTF_TIMEOUT
 from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 
@@ -27,6 +30,78 @@ def pause_arp_update(rand_selected_dut):
     yield
     cmds[0] = "docker exec swss supervisorctl start arp_update"
     rand_selected_dut.shell_cmds(cmds=cmds)
+
+
+@pytest.fixture
+def ptf_interface_info(ip_and_intf_info, ptfadapter):
+    """
+    Get PTF interface information
+    """
+    ptf_intf_ipv4_addr, _, _, _, ptf_intf_index = ip_and_intf_info
+    ptf_intf_mac = ptfadapter.dataplane.get_mac(0, ptf_intf_index)
+    if isinstance(ptf_intf_mac, (bytes, bytearray)):
+        ptf_intf_mac = ptf_intf_mac.decode()
+
+    ptf_iface = f"eth{ptf_intf_index}"
+    ptf_ip = str(ptf_intf_ipv4_addr)
+
+    return {
+        'ip': ptf_ip,
+        'ipv4_addr': ptf_intf_ipv4_addr,
+        'mac': ptf_intf_mac,
+        'index': ptf_intf_index,
+        'interface': ptf_iface
+    }
+
+
+@pytest.fixture
+def dut_interface_info(rand_selected_dut, config_facts, tbinfo):
+    """
+    Get DUT interface information
+    """
+    duthost = rand_selected_dut
+    dut_mac = get_dut_mac(duthost, config_facts, tbinfo)
+    vlan_name, dut_ipv4 = get_first_vlan_ipv4(config_facts)
+
+    return {
+        'host': duthost,
+        'mac': dut_mac,
+        'vlan_name': vlan_name,
+        'ipv4': dut_ipv4
+    }
+
+
+@pytest.fixture
+def clean_environment(rand_selected_dut, ptfadapter):
+    """
+    Cleanup FDB and DUT ARP cache before and after test run
+    """
+    duthost = rand_selected_dut
+
+    logger.info("Setting up clean environment: clearing FDB and ARP cache")
+    fdb_cleanup(duthost)
+    clear_dut_arp_cache(duthost)
+    ptfadapter.dataplane.flush()
+
+    yield
+
+    logger.info("Test completed, environment cleanup done")
+
+
+@pytest.fixture
+def ptf_with_ip_config(ptf_interface_info, ptfhost):
+    """
+    Configure IP on PTF interface and cleanup afterwards
+    """
+    ptf_info = ptf_interface_info
+
+    # Configure IP on PTF interface
+    ptfhost.shell(f"ip addr add {ptf_info['ip']}/21 dev {ptf_info['interface']}", module_ignore_errors=True)
+
+    yield ptf_info
+
+    # Cleanup: remove IP from PTF interface
+    ptfhost.shell(f"ip addr del {ptf_info['ip']}/21 dev {ptf_info['interface']}", module_ignore_errors=True)
 
 
 def neighbor_learned(dut, target_ip):
@@ -93,3 +168,122 @@ def test_kernel_asic_mac_mismatch(
     rand_selected_dut.shell("docker exec swss supervisorctl start arp_update")
 
     wait_until(10, 1, 0, lambda dut, ip: not neighbor_learned(dut, ip), rand_selected_dut, target_ip)
+
+
+def test_ptf_arp_learns_mac(
+    ptf_interface_info,
+    dut_interface_info,
+    clean_environment,
+    ptfadapter,
+    tbinfo
+):
+    """
+    After fdb_cleanup and clearing DUT ARP cache,
+    simulate ARP request from PTF to DUT,
+    verify DUT replies and learns PTF MAC in FDB
+    """
+    # Setup PTF and DUT info
+    ptf_info = ptf_interface_info
+    dut_info = dut_interface_info
+
+    logger.info("DUT VLAN IPv4: {}".format(dut_info['ipv4']))
+
+    # Simulate ARP request from PTF to DUT
+    arp_req = testutils.simple_arp_packet(
+        pktlen=60,
+        eth_dst='ff:ff:ff:ff:ff:ff',
+        eth_src=ptf_info['mac'],
+        vlan_pcp=0,
+        arp_op=1,
+        ip_snd=ptf_info['ip'],
+        ip_tgt=str(dut_info['ipv4']),
+        hw_snd=ptf_info['mac'],
+        hw_tgt='ff:ff:ff:ff:ff:ff'
+    )
+
+    # Expected ARP reply packet from DUT
+    arp_reply = testutils.simple_arp_packet(
+        eth_dst=ptf_info['mac'],
+        eth_src=dut_info['mac'],
+        arp_op=2,
+        ip_snd=str(dut_info['ipv4']),
+        ip_tgt=ptf_info['ip'],
+        hw_snd=dut_info['mac'],
+        hw_tgt=ptf_info['mac']
+    )
+
+    logger.info("Sending ARP request for target {} from PTF interface {}".format(
+        dut_info['ipv4'], ptf_info['index']))
+
+    # Send ARP request and verify ARP reply
+    testutils.send_packet(ptfadapter, ptf_info['index'], arp_req)
+    testutils.verify_packet(ptfadapter, arp_reply, ptf_info['index'], timeout=PTF_TIMEOUT)
+
+    # Confirm MAC is learned on DUT FDB
+    pt_assert(
+        wait_until(10, 1, 0, fdb_has_mac, dut_info['host'], ptf_info['mac']),
+        "FDB did not learn PTF MAC after ARP request"
+    )
+
+
+def test_dut_arping_learns_mac(
+    ptf_interface_info,
+    dut_interface_info,
+    clean_environment,
+    setup_vlan_arp_responder  # noqa: F811
+):
+    """
+    After fdb_cleanup and clearing DUT ARP cache,
+    enable PTF to respond to arping,
+    simulate arping from DUT to PTF,
+    verify DUT learns PTF MAC in FDB
+    """
+    # Setup PTF and DUT info
+    ptf_info = ptf_interface_info
+    dut_info = dut_interface_info
+
+    # Setup PTF responder info
+    vlan_name, ipv4_base, _, ip_offset = setup_vlan_arp_responder
+    ptf_responder_ip = str(ipv4_base.ip + ip_offset)
+    logger.info("PTF responder IP (setup_vlan_arp_responder): {}".format(ptf_responder_ip))
+    logger.info("DUT VLAN IPv4: {}".format(dut_info['ipv4']))
+
+    # Simulate arping from DUT to PTF interface
+    dut_info['host'].shell(f"arping -c 1 -I {dut_info['vlan_name']} {ptf_responder_ip}")
+
+    # Confirm MAC is learned on DUT FDB
+    pt_assert(
+        wait_until(10, 1, 0, fdb_has_mac, dut_info['host'], ptf_info['mac']),
+        "FDB did not learn PTF MAC after DUT arping"
+    )
+
+
+def test_dut_ping_learns_mac(
+    ptf_with_ip_config,
+    dut_interface_info,
+    clean_environment,
+    ptfhost
+):
+    """
+    Configure IP on PTF interface,
+    ping DUT from PTF,
+    then verify both sides learned MAC address
+    """
+    # Setup PTF and DUT info
+    ptf_info = ptf_with_ip_config
+    dut_info = dut_interface_info
+
+    # Ping DUT from PTF (3 times)
+    ping_res = ptfhost.shell(f"ping -c 3 {dut_info['ipv4']}", module_ignore_errors=True)
+    pt_assert(ping_res["rc"] == 0, f"PTF ping to DUT failed: {ping_res['stdout']}")
+
+    # DUT learns PTF MAC
+    pt_assert(
+        wait_until(10, 1, 0, fdb_has_mac, dut_info['host'], ptf_info['mac']),
+        "FDB did not learn PTF MAC after PTF ping"
+    )
+
+    # PTF learns DUT MAC
+    ptf_neigh = ptfhost.shell(f"ip neigh show {dut_info['ipv4']}")["stdout"]
+    pt_assert(dut_info['mac'].lower() in ptf_neigh.lower(),
+              f"PTF did not learn DUT MAC, ip neigh: {ptf_neigh}")

--- a/tests/bgp/test_bgp_vnet.py
+++ b/tests/bgp/test_bgp_vnet.py
@@ -1,3 +1,4 @@
+import ipaddress
 import sys
 import time
 from copy import deepcopy
@@ -11,6 +12,7 @@ import pytest
 
 from tests.common.reboot import reboot
 from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies     # noqa F401
+from tests.common.utilities import wait_until
 import ptf.testutils as testutils
 from ptf.mask import Mask
 from scapy.all import IP, Ether
@@ -101,6 +103,14 @@ def setup_vnet_cfg(duthost, localhost, cfg_facts):
     duthost.shell("cp /tmp/config_db_vnet.json /etc/sonic/config_db.json")
 
     reboot(duthost, localhost)
+
+    bgp_asn = cfg_facts.get('DEVICE_METADATA', {}).get('localhost', {}).get('bgp_asn', '')
+    duthost.shell(
+        "vtysh "
+        "-c 'configure terminal' "
+        "-c 'router bgp {} vrf Vnet2' "
+        "-c 'address-family ipv4 unicast' "
+        "-c 'neighbor BGPSLBPassive allowas-in 1'".format(bgp_asn))
 
 
 # fixtures
@@ -323,6 +333,11 @@ def dynamic_range_add_delete(duthost, template):
         duthost, static_peers, dynamic_peer)
 
     for static_peer in static_peers:
+        # The assertion delta (2 × 10 s) matches the minimum wall-clock time
+        # that elapses between the two uptime snapshots: one time.sleep(10)
+        # before this point plus the time.sleep(10) inside
+        # modify_dynamic_peer_cfg.  If either peer restarts its uptime resets
+        # to near zero, making uptime_after < uptime_before + delta.
         assert static_peer_uptime_after[static_peer] >= static_peer_uptime_before[static_peer] + 2*10*1000, \
             f"Static peer {static_peer} should not flap when a different dynamic range is added/deleted!"
     assert dynamic_peer_uptime_after >= dynamic_peer_uptime_before + 2*10*1000, \
@@ -342,6 +357,107 @@ def get_core_dumps(duthost):
 
     # If result is empty, no core dumps exist, otherwise core dumps are present
     return result.split('\n') if result else []
+
+
+BGP_VNET_PEER_WAIT_TIMEOUT = 60
+BGP_VNET_PEER_WAIT_INTERVAL = 10
+
+
+def _check_vnet_bgp_peers_established(duthost, cfg_facts, route_count):
+    """
+    Return True when every IPv4 BGP peer in every VNET VRF has received at
+    least route_count prefixes (i.e. is Established and has learned routes).
+    Used with wait_until() to absorb the transient period right after reboot
+    while VRF-scoped BGP sessions come up.
+    """
+    try:
+        for vnet in cfg_facts.get('VNET', {}):
+            summary_str = duthost.shell(
+                "vtysh -c 'show bgp vrf {} summary json'".format(vnet))['stdout']
+            bgp_summary = json.loads(summary_str)
+            for info, info_data in bgp_summary.items():
+                for peer, attr in info_data.get('peers', {}).items():
+                    if ((info == "ipv4Unicast" and attr.get('idType') == 'ipv6') or
+                            (info == "ipv6Unicast" and attr.get('idType') == 'ipv4')):
+                        continue
+                    if int(attr.get('pfxRcd', 0)) < route_count:
+                        return False
+        return True
+    except Exception:
+        return False
+
+
+def _check_vnet1_routes_installed(duthost):
+    """
+    Return True when at least one BGP route has been installed in the Linux
+    kernel FIB for the Vnet1 VRF.  Used with wait_until() to gate traffic
+    tests until the BGP → Zebra → kernel FIB pipeline has completed.
+    """
+    try:
+        result = duthost.shell(
+            "ip route show vrf Vnet1 proto bgp | wc -l",
+            module_ignore_errors=True)
+        return result['rc'] == 0 and int(result['stdout'].strip()) > 0
+    except Exception:
+        return False
+
+
+def _get_vnet1_bgp_dst_ip(duthost):
+    """
+    Return a usable host IP derived from the first BGP prefix installed in
+    the Vnet1 kernel FIB.  Called after wait_until(_check_vnet1_routes_installed)
+    has confirmed that routes are present, so the returned IP is guaranteed
+    to be reachable via the data plane.
+
+    This avoids the need for a topology-hardcoded destination IP constant.
+    """
+    result = duthost.shell(
+        "ip route show vrf Vnet1 proto bgp | grep -E '^[0-9]' | head -1 | awk '{print $1}'")
+    prefix = result['stdout'].strip()
+    if not prefix:
+        raise RuntimeError("No usable BGP prefix found in Vnet1 kernel FIB")
+    net = ipaddress.ip_network(prefix, strict=False)
+    hosts = list(net.hosts())
+    return str(hosts[0]) if hosts else str(net.network_address)
+
+
+def _check_vnet2_dynamic_peer_established(duthost, dynamic_peer):
+    """
+    Return True when the given dynamic peer IP is present in Vnet2's BGP
+    summary and is in the Established state.
+    """
+    try:
+        summary_str = duthost.shell(
+            "vtysh -c 'show bgp vrf Vnet2 summary json'")['stdout']
+        bgp_summary = json.loads(summary_str)
+        peers = bgp_summary.get('ipv4Unicast', {}).get('peers', {})
+        return (dynamic_peer in peers and
+                peers[dynamic_peer].get('state') == 'Established')
+    except Exception:
+        return False
+
+
+def _check_vnet2_all_dynamic_peers_established(duthost):
+    """
+    Return True when every dynamic peer IP configured in Vnet2 is present
+    in the BGP summary and in the Established state.  Used with wait_until()
+    in stress tests after re-adding the peer range to ensure all peers have
+    fully reconnected before taking uptime snapshots or moving to the next
+    iteration.
+    """
+    try:
+        summary_str = duthost.shell(
+            "vtysh -c 'show bgp vrf Vnet2 summary json'")['stdout']
+        bgp_summary = json.loads(summary_str)
+        peers = bgp_summary.get('ipv4Unicast', {}).get('peers', {})
+        for peer_ip in g_vars["vnet2"]["dynamic"].values():
+            if not peer_ip:
+                continue
+            if peer_ip not in peers or peers[peer_ip].get('state') != 'Established':
+                return False
+        return True
+    except Exception:
+        return False
 
 
 def get_ptf_port_index(interface_name):
@@ -401,6 +517,21 @@ def test_dynamic_peer_vnet(duthosts, rand_one_dut_hostname, cfg_facts):
         route_count = props['podset_number'] * \
             props['tor_number'] * props['tor_subnet_number']
 
+        # After the post-reboot setup the VRF-scoped BGP sessions need extra
+        # time to reach Established and learn routes.  Poll until all peers
+        # across every VNET VRF report the expected prefix count before
+        # running the assertions.
+        assert wait_until(
+            BGP_VNET_PEER_WAIT_TIMEOUT,
+            BGP_VNET_PEER_WAIT_INTERVAL,
+            0,
+            _check_vnet_bgp_peers_established,
+            duthost,
+            cfg_facts,
+            route_count,
+        ), "Timed out waiting for VRF BGP peers to reach {} prefixes".format(
+            route_count)
+
         # Validate static and dynamic peers are established and have correct route counts inside VNET.
         for vnet in cfg_facts['VNET']:
             bgp_summary_string = duthost.shell(
@@ -415,7 +546,7 @@ def test_dynamic_peer_vnet(duthosts, rand_one_dut_hostname, cfg_facts):
                             (info == "ipv6Unicast" and attr['idType'] == 'ipv4')):
                         continue
                     else:
-                        assert int(prefix_count) >= 6000, "%s should received %s route prefixes!" % (
+                        assert int(prefix_count) >= route_count, "%s should received %s route prefixes!" % (
                             peer, route_count)
                         if 'dynamicPeer' in attr:
                             validate_state_db_entry(duthost, peer, vnet, True)
@@ -434,8 +565,8 @@ def test_dynamic_peer_vnet(duthosts, rand_one_dut_hostname, cfg_facts):
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
     except Exception as e:
         logger.error("Exception raised in test_setup_vnet: {}".format(repr(e)))
-        pytest.fail("Vnet testing setup failed")
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        pytest.fail("Vnet testing setup failed: {}".format(repr(e)))
 
 
 def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, cfg_facts):
@@ -447,10 +578,28 @@ def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, 
     '''
     try:
         duthost = duthosts[rand_one_dut_hostname]
+
+        # Wait for BGP routes to be installed in the Vnet1 kernel FIB before
+        # sending traffic.  Checking the BGP RIB (pfxRcd) is not sufficient;
+        # routes must have propagated through BGP → Zebra → FIB before the
+        # data plane can forward packets.
+        assert wait_until(
+            BGP_VNET_PEER_WAIT_TIMEOUT,
+            BGP_VNET_PEER_WAIT_INTERVAL,
+            0,
+            _check_vnet1_routes_installed,
+            duthost,
+        ), "Timed out waiting for Vnet1 BGP routes to be installed in kernel FIB"
+
         router_mac = duthost.facts["router_mac"]
-        # Destination IP is one of the routes learned via bgp in Vnet1
-        dst_ip = "193.11.248.129"
+        # Discover the destination IP from the live FIB so the test is not
+        # tied to a topology-specific hardcoded address.
+        dst_ip = _get_vnet1_bgp_dst_ip(duthost)
         expected_ports, unexpected_ports = get_expected_unexpected_ptf_ports(cfg_facts, "Vnet1", "Vnet2")
+        assert expected_ports, \
+            "No PTF ports found for Vnet1; check PORTCHANNEL_INTERFACE vnet_name in cfg_facts"
+        assert unexpected_ports, \
+            "No PTF ports found for Vnet2; check PORTCHANNEL_INTERFACE vnet_name in cfg_facts"
         send_port = expected_ports[0]
         src_mac = ptfadapter.dataplane.get_mac(0, send_port)
 
@@ -479,8 +628,8 @@ def test_bgp_vnet_route_forwarding(ptfadapter, duthosts, rand_one_dut_hostname, 
         testutils.verify_no_packet_any(ptfadapter, expected_pkt, unexpected_ports)
     except Exception as e:
         logger.error("Exception raised in test_bgp_vnet_route_forwarding: {}".format(repr(e)))
-        pytest.fail("Packet test for per vnet BGP failed")
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        pytest.fail("Packet test for per vnet BGP failed: {}".format(repr(e)))
 
 
 def test_add_delete_ip_range(duthosts, rand_one_dut_hostname):
@@ -492,7 +641,18 @@ def test_add_delete_ip_range(duthosts, rand_one_dut_hostname):
         # Prepare initial config
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_del')
 
-        # Verify adding a new dynamic range
+        # Verify adding a new dynamic range.  Wait for the dynamic peer to be
+        # Established before measuring uptime / checking prefix counts so that
+        # a slow post-reboot convergence does not cause a spurious KeyError.
+        dynamic_peer = g_vars["vnet2"]["dynamic"]["ARISTA03T1"]
+        assert wait_until(
+            BGP_VNET_PEER_WAIT_TIMEOUT,
+            BGP_VNET_PEER_WAIT_INTERVAL,
+            0,
+            _check_vnet2_dynamic_peer_established,
+            duthost,
+            dynamic_peer,
+        ), "Timed out waiting for Vnet2 dynamic peer {} to establish".format(dynamic_peer)
         dynamic_range_add_delete(duthost, 'vnet_dynamic_peer_add')
 
         # Verify deleting a dynamic range
@@ -502,8 +662,8 @@ def test_add_delete_ip_range(duthosts, rand_one_dut_hostname):
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
     except Exception as e:
         logger.error("Exception raised in test_add_delete_ip_range: {}".format(repr(e)))
-        pytest.fail("Adding/deleting IP range for dynamic peers failed")
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        pytest.fail("Adding/deleting IP range for dynamic peers failed: {}".format(repr(e)))
 
 
 def test_dynamic_peer_group_delete(duthosts, rand_one_dut_hostname):
@@ -532,8 +692,8 @@ def test_dynamic_peer_group_delete(duthosts, rand_one_dut_hostname):
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
     except Exception as e:
         logger.error("Exception raised in test_dynamic_peer_group_delete: {}".format(repr(e)))
-        pytest.fail("Dynamic peer group deletion test failed")
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        pytest.fail("Dynamic peer group deletion test failed: {}".format(repr(e)))
 
 
 def test_dynamic_peer_modify_stress(duthosts, rand_one_dut_hostname):
@@ -554,6 +714,17 @@ def test_dynamic_peer_modify_stress(duthosts, rand_one_dut_hostname):
             modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_del')
             modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
 
+        # After rapid del/add cycling the dynamic peer may not yet be
+        # Established.  Wait before snapshotting uptime to avoid a KeyError
+        # from get_bgp_peer_uptime if the peer is absent from the summary.
+        assert wait_until(
+            BGP_VNET_PEER_WAIT_TIMEOUT,
+            BGP_VNET_PEER_WAIT_INTERVAL,
+            0,
+            _check_vnet2_all_dynamic_peers_established,
+            duthost,
+        ), "Timed out waiting for Vnet2 dynamic peers to re-establish after stress loop"
+
         static_peer_uptime_after, dynamic_peer_uptime_after = get_bgp_peer_uptime(
             duthost, static_peers, dynamic_peer)
 
@@ -569,8 +740,8 @@ def test_dynamic_peer_modify_stress(duthosts, rand_one_dut_hostname):
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
     except Exception as e:
         logger.error("Exception raised in test_dynamic_peer_modify_stress: {}".format(repr(e)))
-        pytest.fail("Stress test for dynamic peer group modification failed")
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        pytest.fail("Stress test for dynamic peer group modification failed: {}".format(repr(e)))
 
 
 def test_dynamic_peer_delete_stress(duthosts, rand_one_dut_hostname):
@@ -590,9 +761,17 @@ def test_dynamic_peer_delete_stress(duthosts, rand_one_dut_hostname):
             duthost.shell(redis_cmd)
             time.sleep(10)
             modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
-            bgp_summary_string = duthost.shell("vtysh -c 'show bgp vrf Vnet2 summary json'")['stdout']
-            bgp_summary = json.loads(bgp_summary_string)
-            validate_dynamic_peer_established(bgp_summary, 'vnet_dynamic_peer_add')
+            # After re-adding the peer range give FRR time to re-establish all
+            # dynamic peers before the next del/add iteration.  A fixed 10 s
+            # sleep (inside modify_dynamic_peer_cfg) is not enough; use
+            # wait_until to poll until both peers are back in Established state.
+            assert wait_until(
+                BGP_VNET_PEER_WAIT_TIMEOUT,
+                BGP_VNET_PEER_WAIT_INTERVAL,
+                0,
+                _check_vnet2_all_dynamic_peers_established,
+                duthost,
+            ), "Timed out waiting for Vnet2 dynamic peers to re-establish (iteration {})".format(i)
 
         static_peer_uptime_after = get_bgp_peer_uptime(duthost, static_peers)
         for static_peer in static_peers:
@@ -604,5 +783,5 @@ def test_dynamic_peer_delete_stress(duthosts, rand_one_dut_hostname):
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
     except Exception as e:
         logger.error("Exception raised in test_dynamic_peer_delete_stress: {}".format(repr(e)))
-        pytest.fail("Stress test for dynamic peer group deletion failed")
         modify_dynamic_peer_cfg(duthost, 'vnet_dynamic_peer_add')
+        pytest.fail("Stress test for dynamic peer group deletion failed: {}".format(repr(e)))

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -8,6 +8,7 @@ ASICS_PRESENT = 'asics_present'
 RANDOM_SEED = 'random_seed'
 CUSTOM_MSG_PREFIX = "sonic_custom_msg"
 DUT_CHECK_NAMESPACE = "dut_check_result"
+PTF_TIMEOUT = 60
 
 # Describe upstream neighbor of dut in different topos
 UPSTREAM_NEIGHBOR_MAP = {

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -34,6 +34,7 @@ LOGS_ON_TMPFS_PLATFORMS = [
     "x86_64-arista_7060_cx32s",
     "x86_64-arista_7260cx3_64",
     "x86_64-arista_7050cx3_32s",
+    "x86_64-arista_7050cx3_32c",
     "x86_64-mlnx_msn2700-r0",
     "x86_64-dell_s6100_c2538-r0",
     "armhf-nokia_ixs7215_52x-r0"

--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -63,16 +63,18 @@ def check_critical_processes(dut, watch_secs=0):
         watch_secs = watch_secs - 5
 
 
-def wait_critical_processes(dut):
+def wait_critical_processes(dut, timeout=None):
     """
     @summary: wait until all critical processes are healthy.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
+    @param timeout: customized timeout value in seconds. If specified, overwrites inventory value.
     """
-    timeout = reset_timeout(dut)
-    # No matter what we set in inventory file, we always set sup timeout to 900
-    # because most SUPs have 10+ dockers that need to come up
-    if dut.is_supervisor_node():
-        timeout = 900
+    if timeout is None:
+        timeout = reset_timeout(dut)
+        # No matter what we set in inventory file, we always set sup timeout to 900
+        # because most SUPs have 10+ dockers that need to come up
+        if dut.is_supervisor_node():
+            timeout = 900
     logging.info("Wait until all critical processes are healthy in {} sec"
                  .format(timeout))
     pytest_assert(wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut),

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -160,12 +160,30 @@ arp/test_arp_extended.py::test_proxy_arp[v4-:
     conditions:
       - "'-v6-' in topo_name"
 
+arp/test_arp_update.py::test_dut_arping_learns_mac:
+  skip:
+    reason: "Skip test_dut_arping_learns_mac on dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
+
+arp/test_arp_update.py::test_dut_ping_learns_mac:
+  skip:
+    reason: "Skip test_dut_ping_learns_mac on dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
+
 arp/test_arp_update.py::test_kernel_asic_mac_mismatch\[.*ipv4.*\]:
   regex: true
   skip:
     reason: "skip for IPv6-only topologies"
     conditions:
       - "'-v6-' in topo_name"
+
+arp/test_arp_update.py::test_ptf_arp_learns_mac:
+  skip:
+    reason: "Skip test_ptf_arp_learns_mac on dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
 
 arp/test_neighbor_mac_noptf.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4564,12 +4564,15 @@ srv6/test_srv6_basic_sanity.py::test_traffic_check_normal:
 
 srv6/test_srv6_dataplane.py:
   skip:
-    reason: "Only target mellanox and brcm platform with 202412 image at this time. Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32, t1-isolated-d32/128. Or test case has issue on the t0-isolated-d256u256s2 topo."
+    reason: "Only target mellanox SPC4+ and brcm platform with 202412 or 202511+ image. Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32, t1-isolated-d32/128."
     conditions_logical_operator: or
     conditions:
       - "asic_type not in ['mellanox', 'broadcom'] or release not in ['202412']"
       - "'Arista-7060X6-64PE' in hwsku and 'Arista-7060X6-64PE-B' not in hwsku"
       - "topo_name in ['t0-isolated-d96u32s2', 't1-isolated-d128', 't1-isolated-d32']"
+  xfail:
+    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
+    conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
 
 srv6/test_srv6_dataplane.py::TestSRv6DataPlaneBase::test_srv6_full_func:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2280,6 +2280,7 @@ generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite:
     conditions:
       - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/18445"
+      - "'isolated' in topo_name"
 
 generic_config_updater/test_bgp_speaker.py::test_bgp_speaker_tc1_test_config:
   xfail:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3781,7 +3781,7 @@ qos/test_qos_dscp_mapping.py:
       - "asic_type in ['cisco-8000'] and platform.startswith('x86_64-8122_')"
       - "asic_type in ['vs']"
 
-qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to_queue_mapping[pipe]:
+qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to_queue_mapping[pipe:
   skip:
     reason: "Pipe decap mode not supported due to either SAI or platform limitation / M* topo does not support qos"
     conditions_logical_operator: or
@@ -3790,7 +3790,7 @@ qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to
       - https://github.com/sonic-net/sonic-mgmt/issues/12906
       - "topo_type in ['m0', 'mx', 'm1']"
 
-qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to_queue_mapping[uniform]:
+qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to_queue_mapping[uniform:
   skip:
     reason: "Uniform decap mode is not supported on Mellanox dualtor testbed due to the mode is pipe to support dscp remapping / Test case unsupported in the default profile configuration."
     conditions_logical_operator: or

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -963,6 +963,12 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_monitor_checksum_validation:
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/24402 and asic_type in ['mellanox', 'nvidia']"
 
+dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_on_dualtor_standby:
+  skip:
+    reason: "Test requires dualtor topology (uses rand_unselected_dut which returns None on non-dualtor)"
+    conditions:
+      - "'dualtor' not in topo_name"
+
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport:
   skip:
     reason: "Skip test_dhcp_relay_random_sport on dualtor in 201811 and 201911 or platform x86_64-8111_32eh_o-r0"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1485,7 +1485,7 @@ ecmp/test_ecmp_sai_value.py:
       - "topo_type not in ['t1', 't0']"
       - "asic_type not in ['broadcom']"
       - "release in ['201911', '202012', '202205', '202211']"
-      - "topo_type in ['t1'] and hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-C28S4']"
+      - "topo_type in ['t1'] and hwsku in ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32C-C32']"
 
 ecmp/test_fgnhg.py:
   skip:
@@ -3955,7 +3955,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
     conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100']
-       and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
+       and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32C-C32', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32C-C28S4', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
        and asic_type in ['cisco-8000']"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox','marvell-teralynx']"
@@ -3975,7 +3975,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
   xfail:
     reason: "Headroom pool size not supported."
     conditions:
-      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32S-D48C8', 'Arista-7060X6-16PE-384C-B-O128S2', 'Arista-7060X6-64PE-B-O128'] and asic_type not in ['marvell-teralynx']"
+      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32C-C32', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32C-C28S4', 'Arista-7050CX3-32S-D48C8', 'Arista-7060X6-16PE-384C-B-O128S2', 'Arista-7060X6-64PE-B-O128'] and asic_type not in ['marvell-teralynx']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
   skip:
@@ -4034,12 +4034,6 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark:
     reason: "PG Shared Watermark not supported."
     conditions:
       - "asic_type in ['marvell-teralynx'] and platform in ['x86_64-wistron_6512_32r-r0', 'x86_64-wistron_sw_to3200k-r0']"
-
-qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[None-wm_pg_shared_lossy]:
-  xfail:
-    reason: "Image issue on Arista platforms / Unsupported testbed type."
-    conditions:
-      - "platform in ['x86_64-arista_7050cx3_32s']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts:
   skip:

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -140,7 +140,7 @@ def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_du
             "testing_mode": testing_mode,
             "kvm_support": True
         }
-        count_file = '/tmp/dhcp_stress_test_{}.json'.format(dhcp_type)
+        count_file = '/tmp/dhcp_stress_test_{}'.format(dhcp_type)
 
         def _check_count_file_exists():
             command = 'ls {} > /dev/null 2>&1 && echo exists || echo missing'.format(count_file)

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -500,6 +500,12 @@ class EverflowIPv4Tests(BaseEverflowTest):
         everflow_dut = setup_info[dest_port_type]['everflow_dut']
         remote_dut = setup_info[dest_port_type]['remote_dut']
 
+        # VOQ switches use recycle port as mirror destination. Hence there is no
+        # control on which ECMP nexthop the traffic will egress from after the packet
+        # gets recycled.
+        if everflow_dut.facts['switch_type'] == "voq":
+            pytest.skip("Skip test as is not supported on a VoQ switch.")
+
         # Create two ECMP next hops
         tx_port = setup_info[dest_port_type]["dest_port"][0]
         peer_ip_0 = everflow_utils.get_neighbor_info(remote_dut, tx_port, tbinfo, ip_version=erspan_ip_ver)

--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -22,7 +22,8 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
 
     ignore_errors = [
         r".*ERR swss#orchagent: .*update: Failed to get port by bridge port ID.*",
-        r".* ERR swss#tunnel_packet_handler.py: All portchannels failed to come up within \d+ minutes, exiting.*"
+        r".* ERR swss#tunnel_packet_handler.py: All portchannels failed to come up within \d+ minutes, exiting.*",
+        r".*ERR swss#orchagent: .*meta_sai_validate_route_entry: object key SAI_OBJECT_TYPE_ROUTE_ENTRY:.* doesn't exist.*",  # noqa: E501
         ]
     if loganalyzer:
         for duthost in duthosts:

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -86,6 +86,21 @@ def check_gnmi_status(duthost):
     return "RUNNING" in output['stdout']
 
 
+def _check_monit_container_checker(duthost):
+    """Check if monit container_checker service is healthy.
+
+    After gNMI cert config recovery, monit needs time to re-evaluate
+    container status. This function checks if container_checker has
+    returned to a healthy state (OK or Status ok).
+    """
+    monit_services = duthost.get_monit_services_status()
+    if not monit_services:
+        return False
+    container_checker = monit_services.get("container_checker", {})
+    status = container_checker.get("service_status", "")
+    return status in ("OK", "Status ok")
+
+
 def recover_cert_config(duthost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     # Kill the GNMI process
@@ -119,6 +134,13 @@ def recover_cert_config(duthost):
     if not check_container_state(duthost, "telemetry", should_be_running=True):
         logger.info("Telemetry container is not running after cert config recovery, restarting it")
         duthost.shell("sudo systemctl restart telemetry", module_ignore_errors=True)
+
+    # Wait for monit container_checker to report healthy status.
+    # After restarting processes/containers, monit needs time to re-evaluate
+    # service status. Without this wait, post-test sanity check may see stale
+    # "Status failed" from container_checker and fail the test on teardown.
+    if not wait_until(120, 10, 30, _check_monit_container_checker, duthost):
+        logger.warning("Monit container_checker did not recover to healthy status after cert config recovery")
 
 
 def check_ntp_sync_status(duthost):

--- a/tests/gnmi/test_gnoi_system_reboot.py
+++ b/tests/gnmi/test_gnoi_system_reboot.py
@@ -145,7 +145,8 @@ def test_gnoi_system_reboot_warm(duthosts, rand_one_dut_hostname, localhost):
     logging.info("System is back up after reboot")
 
     # Wait for critical processes before ending
-    wait_critical_processes(duthost)
+    # Warm reboot takes longer for containers to restart; use an extended timeout
+    wait_critical_processes(duthost, timeout=360)
 
     # Wait for gNMI container to be running
     wait_until(120, 10, 0, is_gnmi_container_running, duthost)

--- a/tests/kubesonic/test_k8s_join_disjoin.py
+++ b/tests/kubesonic/test_k8s_join_disjoin.py
@@ -375,6 +375,14 @@ def setup_and_teardown(duthost, vmhost, creds):
 
     yield
 
+    # Disable ctrmgrd k8s retry loop after a failed join. Without this,
+    # ctrmgrd retries indefinitely in the background and emits ERR log lines
+    # into subsequent tests' LogAnalyzer windows, causing false failures
+    # (e.g., test_snmp_queues sees match:2, expected:0 in teardown).
+    # This is idempotent: calling 'disable on' when already disjoined is a no-op.
+    duthost.shell("sudo config kube server disable on", module_ignore_errors=True)
+    time.sleep(5)
+
     # Clean up the k8s table in configdb
     clean_configdb_k8s_table(duthost)
 

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -27,7 +27,7 @@ pytestmark = [
 CONTAINER_STOP_THRESHOLD_SECS = 200
 CONTAINER_RESTART_THRESHOLD_SECS = 180
 CONTAINER_CHECK_INTERVAL_SECS = 1
-MONIT_RESTART_THRESHOLD_SECS = 320
+MONIT_RESTART_THRESHOLD_SECS = 400
 MONIT_CHECK_INTERVAL_SECS = 5
 WAITING_SYSLOG_MSG_SECS = 30
 MONIT_MEMORY_CHECK_TIMEOUT = 700
@@ -131,17 +131,29 @@ def restore_monit_config_files(duthost):
 
 
 def check_monit_running(duthost):
-    """Checks whether Monit is running or not.
+    """Checks whether Monit is running with all services in ready state.
 
     Args:
         duthost: The AnsibleHost object of DuT.
 
     Returns:
-        Returns True if Monit is running; Otherwist, returns False.
+        Returns True if all services are ready; Otherwise, returns False.
     """
     monit_services_status = duthost.get_monit_services_status()
     if not monit_services_status:
         return False
+
+    # Validate each service is in expected state
+    for service_name, service_info in monit_services_status.items():
+        service_type = service_info.get("service_type", "")
+        state = service_info.get("service_status", "")
+        if state in ["Not monitored", "OK"]:
+            continue
+        # Check expected states per service type
+        if ((service_type == "Filesystem" and state != "Accessible")
+                or (service_type == "Process" and state != "Running")
+                or (service_type == "Program" and state != "Status ok")):
+            return False
 
     return True
 

--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -31,8 +31,18 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
     KVMIgnoreRegex = [
         ".*queryStatsCapability: failed to find switch.*",
     ]
+    # Transient TACACS+ noise unrelated to PFCWD. On testbeds where the configured
+    # TACACS+ server is temporarily unreachable, NSS-TACACS+ lookups invoked by
+    # background processes (e.g. iptables) emit ERR-level syslog lines that get
+    # picked up by loganalyzer during teardown. Other tests (srv6, metadata-scripts)
+    # already ignore these same patterns for the same reason.
+    TacacsIgnoreRegex = [
+        r".*tac_connect_single: .*",
+        r".*nss_tacplus: .*",
+    ]
     duthost = duthosts[rand_one_dut_hostname]
     if loganalyzer:  # Skip if loganalyzer is disabled
+        loganalyzer[duthost.hostname].ignore_regex.extend(TacacsIgnoreRegex)
         if duthost.facts["asic_type"] == "vs":
             loganalyzer[duthost.hostname].ignore_regex.extend(KVMIgnoreRegex)
 

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2955,6 +2955,265 @@ class QosSaiBase(QosBase):
                         "Changing lacp timer multiplier to default for %s in %s" % (neighbor_lag_member, vm_host))
                     vm_host.no_lacp_time_multiplier(neighbor_lag_member)
 
+    @pytest.fixture(scope="function", autouse=False)
+    def permit_only_test_traffic_on_fanout(
+            self, get_src_dst_asic_and_duts, tbinfo,
+            nbrhosts, dutConfig, fanouthosts,
+            conn_graph_facts, request):
+        """
+        Block non-test L2 traffic from reaching DUT ingress ports during QoS
+        headroom pool tests to prevent false InDiscard counter increments.
+
+        Configures the EOS fanout switch to only forward IP/IPv6/ARP frames
+        toward the DUT, blocking LLDP (0x88CC), LACP (0x8809), and other
+        non-test ethertypes via an egress MAC ACL whitelist.
+
+        Steps:
+        1. Stop DUT teamd lacpd (prevents LACP timeout detection)
+        2. Set EOS neighbor LACP timer multiplier to 600 (prevents EOS-side timeout)
+        3. Disable LLDP TX/RX + apply egress MAC ACL on fanout DUT-facing ports
+
+        Note on change_lag_lacp_timer interaction: that fixture only activates
+        for broadcom-dnx platforms and operates on dst_port LAGs. This fixture
+        operates on src_port LAGs for Broadcom TH (7060CX), so there is no
+        overlap on the affected platform.
+
+        Note: Currently supports EOS fanout only. SONiC fanout support is
+        tracked in issue #24236.
+        """
+        if request.config.getoption("--neighbor_type") == "sonic":
+            yield
+            return
+
+        src_dut = get_src_dst_asic_and_duts['src_dut']
+        src_asic = get_src_dst_asic_and_duts['src_asic']
+        src_mgfacts = src_dut.get_extended_minigraph_facts(tbinfo)
+
+        # Protect ALL test ports from noise. The actual src_port_ids used by PTF
+        # come from qos.yml hdrm_pool_size (e.g., [17,18]) which differs from
+        # dutConfig.testPorts.src_port_id (e.g., 2). Apply to all dutInterfaces.
+        # TODO: optimize to only protect actual src/dst ports (tracked in #24236)
+        src_interfaces = [dutConfig['dutInterfaces'][idx]
+                          for idx in sorted(dutConfig.get('dutInterfaces', {}).keys())]
+
+        logger.debug("permit_only_test_traffic_on_fanout: testPorts = %s",
+                     dutConfig.get('testPorts', {}))
+        logger.info(
+            "permit_only_test_traffic_on_fanout: protecting %d ports: %s",
+            len(src_interfaces), src_interfaces)
+
+        # Find LAG names containing any of the protected interfaces
+        portchannels = src_mgfacts.get('minigraph_portchannels', {})
+        lag_names = []
+        for port_ch, port_intf in portchannels.items():
+            for member in port_intf.get('members', []):
+                if member in src_interfaces:
+                    if port_ch not in lag_names:
+                        lag_names.append(port_ch)
+                        logger.debug("permit_only_test_traffic_on_fanout: "
+                                     "%s is member of %s", member, port_ch)
+                    break
+
+        # State tracking for teardown
+        eos_restore_list = []
+        fanout_restore_list = []
+        acl_created_fanouts = set()
+        lacpd_stopped = False
+        acl_name = "QOS_TEST_WHITELIST"
+        teamd_docker = src_asic.get_docker_name("teamd")
+
+        try:
+            # --- Step 1 & 2: LACP-specific (only when ports are in LAG) ---
+            if lag_names:
+                logger.info(
+                    "permit_only_test_traffic_on_fanout: found %d LAGs, "
+                    "stopping lacpd and setting timer", len(lag_names))
+
+                # Step 1: Stop DUT teamd lacpd
+                result = src_dut.command(
+                    "docker exec {} supervisorctl stop lacpd".format(teamd_docker),
+                    module_ignore_errors=True)
+                if result.get('failed', False) or result.get('rc', 0) != 0:
+                    logger.warning(
+                        "permit_only_test_traffic_on_fanout: lacpd stop may have "
+                        "failed (rc=%s), proceeding anyway", result.get('rc', '?'))
+                else:
+                    lacpd_stopped = True
+                # Brief wait for any in-flight LACP PDU to drain
+                time.sleep(2)
+
+                # Step 2: Set EOS neighbor LACP timer multiplier to 600
+                lag_facts = src_dut.lag_facts(
+                    host=src_dut.hostname)['ansible_facts']['lag_facts']
+                vm_neighbors = src_mgfacts.get('minigraph_neighbors', {})
+
+                for lag_name in lag_names:
+                    if lag_name not in lag_facts.get('lags', {}):
+                        continue
+                    po_interfaces = lag_facts['lags'][lag_name]['po_config']['ports']
+                    for po_intf in po_interfaces:
+                        if po_intf not in vm_neighbors:
+                            continue
+                        peer_device = vm_neighbors[po_intf]['name']
+                        neighbor_port = vm_neighbors[po_intf]['port']
+                        if peer_device not in nbrhosts:
+                            continue
+                        vm_host = nbrhosts[peer_device]['host']
+                        if isinstance(vm_host, EosHost):
+                            logger.info(
+                                "permit_only_test_traffic_on_fanout: "
+                                "setting LACP multiplier 600 on %s %s",
+                                peer_device, neighbor_port)
+                            vm_host.set_interface_lacp_time_multiplier(
+                                neighbor_port, 600)
+                            eos_restore_list.append((vm_host, neighbor_port))
+            else:
+                logger.info("permit_only_test_traffic_on_fanout: "
+                            "no LAGs found, skipping LACP steps")
+
+            # --- Step 3: Disable LLDP + egress MAC ACL on fanout ports ---
+            # Egress MAC ACL permits only IP (0x0800), IPv6 (0x86DD), and ARP
+            # (0x0806). All other ethertypes — including LLDP (0x88CC), LACP
+            # (0x8809), and other broadcast/multicast L2 frames — are denied.
+            # PFC (0x8808) is DUT-originated and travels DUT→fanout, so the
+            # egress (fanout→DUT) ACL does not affect it.
+            dev_conn = conn_graph_facts.get('device_conn', {})
+
+            for dut_name, ethernet_ports in dev_conn.items():
+                for dut_port, fanout_rec in ethernet_ports.items():
+                    if dut_port not in src_interfaces:
+                        continue
+                    fanout_name = str(fanout_rec['peerdevice'])
+                    fanout_port = str(fanout_rec['peerport'])
+
+                    if fanout_name not in fanouthosts:
+                        continue
+
+                    fanout = fanouthosts[fanout_name]
+                    fanout_os = fanout.get_fanout_os()
+
+                    if fanout_os == 'eos':
+                        try:
+                            # Disable LLDP first; record immediately for restore
+                            fanout.host.eos_config(
+                                lines=['no lldp transmit', 'no lldp receive'],
+                                parents=['interface %s' % fanout_port])
+                            fanout_restore_list.append(
+                                (fanout, fanout_name, fanout_port))
+                        except Exception as e:
+                            logger.warning(
+                                "permit_only_test_traffic_on_fanout: "
+                                "LLDP disable failed on %s %s: %s",
+                                fanout_name, fanout_port, str(e))
+                            continue
+
+                        try:
+                            # Create MAC ACL once per fanout
+                            if fanout_name not in acl_created_fanouts:
+                                fanout.host.eos_config(
+                                    lines=[
+                                        'permit any any ip',
+                                        'permit any any ipv6',
+                                        'permit any any arp',
+                                        'deny any any',
+                                    ],
+                                    parents=['mac access-list %s' % acl_name])
+                                acl_created_fanouts.add(fanout_name)
+                            # Bind egress MAC ACL (out = fanout→DUT direction)
+                            fanout.host.eos_config(
+                                lines=['mac access-group %s out' % acl_name],
+                                parents=['interface %s' % fanout_port])
+                            logger.info(
+                                "permit_only_test_traffic_on_fanout: "
+                                "protected %s %s", fanout_name, fanout_port)
+                        except Exception as e:
+                            logger.warning(
+                                "permit_only_test_traffic_on_fanout: "
+                                "ACL config failed on %s %s: %s",
+                                fanout_name, fanout_port, str(e))
+
+                    elif fanout_os == 'sonic':
+                        # SONiC fanout support tracked in #24236
+                        logger.warning(
+                            "permit_only_test_traffic_on_fanout: "
+                            "SONiC fanout not supported, skipping %s",
+                            fanout_name)
+
+        except Exception as e:
+            # Setup failed partway — run teardown for anything already configured
+            logger.error(
+                "permit_only_test_traffic_on_fanout: setup failed: %s. "
+                "Running partial teardown.", str(e))
+            self._teardown_test_traffic_filter(
+                src_dut, teamd_docker, lacpd_stopped,
+                eos_restore_list, fanout_restore_list,
+                acl_created_fanouts, acl_name, fanouthosts)
+            raise
+
+        logger.info(
+            "permit_only_test_traffic_on_fanout: setup complete — "
+            "%d ports protected, %d LACP timers set",
+            len(fanout_restore_list), len(eos_restore_list))
+
+        yield
+
+        self._teardown_test_traffic_filter(
+            src_dut, teamd_docker, lacpd_stopped,
+            eos_restore_list, fanout_restore_list,
+            acl_created_fanouts, acl_name, fanouthosts)
+
+    def _teardown_test_traffic_filter(
+            self, src_dut, teamd_docker, lacpd_stopped,
+            eos_restore_list, fanout_restore_list,
+            acl_created_fanouts, acl_name, fanouthosts):
+        """Reverse all changes made by permit_only_test_traffic_on_fanout."""
+        # Step 1 reverse: restart DUT lacpd FIRST (before timer restore)
+        if lacpd_stopped:
+            logger.info("permit_only_test_traffic_on_fanout: "
+                        "restarting lacpd in %s", teamd_docker)
+            result = src_dut.command(
+                "docker exec {} supervisorctl start lacpd".format(teamd_docker),
+                module_ignore_errors=True)
+            if result.get('failed', False) or result.get('rc', 0) != 0:
+                logger.error(
+                    "permit_only_test_traffic_on_fanout: lacpd restart "
+                    "FAILED — DUT may be left without LACP. Output: %s",
+                    result.get('stdout', result.get('stderr', 'unknown')))
+
+        # Step 2 reverse: restore EOS LACP timer
+        for vm_host, neighbor_port in eos_restore_list:
+            try:
+                vm_host.no_lacp_time_multiplier(neighbor_port)
+            except Exception as e:
+                logger.warning(
+                    "permit_only_test_traffic_on_fanout: "
+                    "failed to restore LACP timer: %s", str(e))
+
+        # Step 3 reverse: restore LLDP + unbind ACL from all ports
+        for fanout, fanout_name, fanout_port in fanout_restore_list:
+            try:
+                fanout.host.eos_config(
+                    lines=['lldp transmit', 'lldp receive',
+                           'no mac access-group %s out' % acl_name],
+                    parents=['interface %s' % fanout_port])
+            except Exception as e:
+                logger.warning(
+                    "permit_only_test_traffic_on_fanout: "
+                    "failed to restore %s: %s", fanout_port, str(e))
+
+        # Delete ACL definition once per fanout
+        for fanout_name in acl_created_fanouts:
+            try:
+                fanout = fanouthosts[fanout_name]
+                fanout.host.eos_config(
+                    lines=['no mac access-list %s' % acl_name])
+            except Exception as e:
+                logger.warning(
+                    "permit_only_test_traffic_on_fanout: "
+                    "failed to delete ACL on %s: %s", fanout_name, str(e))
+
+        logger.info("permit_only_test_traffic_on_fanout: teardown complete")
+
     def copy_set_cir_script_cisco_8000(self, dut, ports, asic="", speed="10000000"):
         dshell_script = '''
 from common import *

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -873,7 +873,8 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiHeadroomPoolSize(
         self, duthosts, get_src_dst_asic_and_duts, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-            ingressLosslessProfile, iptables_drop_ipv6_tx, change_lag_lacp_timer):                # noqa: F811
+            ingressLosslessProfile, iptables_drop_ipv6_tx, change_lag_lacp_timer,  # noqa: F811
+            permit_only_test_traffic_on_fanout):
         # NOTE: cisco-8800 will skip this test since there are no headroom pool
         """
             Test QoS SAI Headroom pool size
@@ -1087,7 +1088,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiHeadroomPoolWatermark(
         self, duthosts, get_src_dst_asic_and_duts,  ptfhost, dutTestParams,
         dutConfig, dutQosConfig, ingressLosslessProfile, sharedHeadroomPoolSize,
-        resetWatermark
+        resetWatermark, permit_only_test_traffic_on_fanout
     ):
         # NOTE: cisco 8800 will skip this test since there is no headroom pool
         """

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -189,7 +189,8 @@ def config_sflow(duthost, sflow_status='enable'):
 
 
 @pytest.fixture(scope='module')
-def config_sflow_feature(request, duthost):
+def config_sflow_feature(request, duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
     feature_status, _ = duthost.get_feature_status()
 
     if 'sflow' not in feature_status:
@@ -381,7 +382,8 @@ def sflowbase_config(duthosts, rand_one_dut_hostname):
 # ----------------------------------------------------------------------------------
 
 @pytest.fixture
-def selected_portchannel_members(duthost, tbinfo):
+def selected_portchannel_members(duthosts, rand_one_dut_hostname, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
     """
     Get the sflow interface
 
@@ -409,7 +411,8 @@ def selected_portchannel_members(duthost, tbinfo):
 
 
 @pytest.fixture
-def restore_sflow_interface_status_and_rate(duthost, selected_portchannel_members):
+def restore_sflow_interface_status_and_rate(duthosts, rand_one_dut_hostname, selected_portchannel_members):
+    duthost = duthosts[rand_one_dut_hostname]
 
     yield
 
@@ -516,14 +519,16 @@ class TestSflowPolling():
     Disable polling and check the dut doesn't send counter samples .
     """
 
-    def testPolling(self, duthost, partial_ptf_runner):
+    def testPolling(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
+        duthost = duthosts[rand_one_dut_hostname]
         duthost.shell("config sflow polling-interval 20")
         verify_show_sflow(duthost, status='up', polling_int=20)
         partial_ptf_runner(
             polling_int=20,
             active_collectors="['collector0','collector1']")
 
-    def testDisablePolling(self, duthost, partial_ptf_runner):
+    def testDisablePolling(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
+        duthost = duthosts[rand_one_dut_hostname]
         duthost.shell("config sflow polling-interval 0")
 
         verify_show_sflow(duthost, status='up', polling_int=0)
@@ -531,7 +536,8 @@ class TestSflowPolling():
             polling_int=0,
             active_collectors="['collector0','collector1']")
 
-    def testDifferentPollingInt(self, duthost, partial_ptf_runner):
+    def testDifferentPollingInt(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
+        duthost = duthosts[rand_one_dut_hostname]
         duthost.shell("config sflow polling-interval 60")
 
         verify_show_sflow(duthost, status='up', polling_int=60)
@@ -548,8 +554,10 @@ class TestSflowInterface():
     Test interfaces with different sampling rates
     """
 
-    def testIntfRemoval(self, sflowbase_config, duthost, partial_ptf_runner, selected_portchannel_members,
+    def testIntfRemoval(self, sflowbase_config, duthosts, rand_one_dut_hostname,
+                        partial_ptf_runner, selected_portchannel_members,
                         restore_sflow_interface_status_and_rate):
+        duthost = duthosts[rand_one_dut_hostname]
         disabled_sflow_intf_list = selected_portchannel_members[0]
         enabled_sflow_intf_list = [intf for intf_list in selected_portchannel_members[1:] for intf in intf_list]
 
@@ -567,8 +575,10 @@ class TestSflowInterface():
             enabled_sflow_interfaces=enabled_sflow_intf_list,
             active_collectors="['collector0','collector1']")
 
-    def testIntfSamplingRate(self, sflowbase_config, duthost, ptfhost, partial_ptf_runner, selected_portchannel_members,
+    def testIntfSamplingRate(self, sflowbase_config, duthosts, rand_one_dut_hostname,
+                             ptfhost, partial_ptf_runner, selected_portchannel_members,
                              restore_sflow_interface_status_and_rate):
+        duthost = duthosts[rand_one_dut_hostname]
         first_portchannel_members = selected_portchannel_members[0]
         second_portchannel_members = selected_portchannel_members[1]
 
@@ -622,7 +632,8 @@ class TestAgentId():
     Add eth0 ip as the agent ip and check the samples are received with intended agent-id.
     """
 
-    def testNonDefaultAgent(self, duthost, partial_ptf_runner):
+    def testNonDefaultAgent(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
+        duthost = duthosts[rand_one_dut_hostname]
         agent_ip = var['lo_ip']
         duthost.shell(" config sflow agent-id del")
         duthost.shell(" config sflow agent-id  add Loopback0")
@@ -632,7 +643,8 @@ class TestAgentId():
             agent_id=agent_ip,
             active_collectors="['collector0','collector1']")
 
-    def testDelAgent(self, duthost, partial_ptf_runner):
+    def testDelAgent(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
+        duthost = duthosts[rand_one_dut_hostname]
         duthost.shell(" config sflow agent-id del")
         verify_show_sflow(duthost, status='up', agent_id='default')
         time.sleep(5)
@@ -643,7 +655,8 @@ class TestAgentId():
             agent_id=agent_ip,
             active_collectors="['collector0','collector1']")
 
-    def testAddAgent(self, duthost, partial_ptf_runner):
+    def testAddAgent(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
+        duthost = duthosts[rand_one_dut_hostname]
         agent_ip = var['mgmt_ip']
         duthost.shell(" config sflow agent-id  add  eth0")
         verify_show_sflow(duthost, status='up', agent_id='eth0')
@@ -658,8 +671,10 @@ class TestAgentId():
 @pytest.mark.disable_loganalyzer
 class TestReboot():
 
-    def testRebootSflowEnable(self, sflowbase_config, config_sflow_agent, duthost,
+    def testRebootSflowEnable(self, sflowbase_config, config_sflow_agent,
+                              duthosts, rand_one_dut_hostname,
                               force_active_tor, localhost, partial_ptf_runner, ptfhost):
+        duthost = duthosts[rand_one_dut_hostname]
         duthost.command("config sflow polling-interval 80")
         verify_show_sflow(duthost, status='up', polling_int=80)
         duthost.command('sudo config save -y')
@@ -685,8 +700,9 @@ class TestReboot():
             polling_int=80,
             active_collectors="['collector0','collector1']")
 
-    def testRebootSflowDisable(self, sflowbase_config, duthost, force_active_tor,
-                               localhost, partial_ptf_runner, ptfhost):
+    def testRebootSflowDisable(self, sflowbase_config, duthosts, rand_one_dut_hostname,
+                               force_active_tor, localhost, partial_ptf_runner, ptfhost):
+        duthost = duthosts[rand_one_dut_hostname]
         config_sflow(duthost, sflow_status='disable')
         verify_show_sflow(duthost, status='down')
         partial_ptf_runner(
@@ -708,7 +724,9 @@ class TestReboot():
             enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
             active_collectors="[]")
 
-    def testFastreboot(self, sflowbase_config, config_sflow_agent, duthost, localhost, partial_ptf_runner, ptfhost):
+    def testFastreboot(self, sflowbase_config, config_sflow_agent, duthosts,
+                       rand_one_dut_hostname, localhost, partial_ptf_runner, ptfhost):
+        duthost = duthosts[rand_one_dut_hostname]
 
         config_sflow(duthost, sflow_status='enable')
         verify_show_sflow(duthost, status='up', collector=[
@@ -730,7 +748,9 @@ class TestReboot():
             enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
             active_collectors="['collector0','collector1']")
 
-    def testWarmreboot(self, sflowbase_config, duthost, localhost, partial_ptf_runner, ptfhost):
+    def testWarmreboot(self, sflowbase_config, duthosts, rand_one_dut_hostname,
+                       localhost, partial_ptf_runner, ptfhost):
+        duthost = duthosts[rand_one_dut_hostname]
 
         config_sflow(duthost, sflow_status='enable')
         verify_show_sflow(duthost, status='up', collector=[


### PR DESCRIPTION
```
* 6ff0eb9b0a - [202511] chore: set ptf_imagetag to latest (#24296) (2026-04-30) [Austin (Thang Pham)]
* d5a64ab304 - [action] [PR:24232] Fix monit socket timeout after restore/restart (#24330) (2026-04-30) [mssonicbld]
* d88a73c5e6 - [202511] Add missing Arista-7050CX3 hwskus support (#24324) (2026-04-29) [Mark Xiao]
* 15392e0b8c - [ARP][test_arp_update] Verify MAC relearning after fdbclear (#22148) (#24309) (2026-04-30) [Janet Cui]
* 9a45183061 - [SN5640][xfail] xfail srv6 dataplane test cases in SN5640 full topo (#21878) (#24303) (2026-04-30) [Janet Cui]
* 54e9109441 - [action] [PR:24088] [fdb] Ignore expected cleanup ERR in testFdbMacLearning (#24314) (2026-04-29) [mssonicbld]
* 766e8d7cbd - [action] [PR:23466] Add sai FEC attribute error ignore patterns to loganalyzer (#24312) (2026-04-29) [mssonicbld]
* 3dbd1983f8 - [action] [PR:24212] fix(qos): block L2 noise on fanout during headroom pool tests (#24307) (2026-04-29) [mssonicbld]
* 41bec48c2c - [action] [PR:24159] [kubesonic]: Fix teardown not disabling ctrmgrd after failed k8s join (#24308) (2026-04-29) [mssonicbld]
* 86763a68d2 - [action] [PR:24264] tests/pfcwd: ignore transient TACACS+ syslog noise in loganalyzer (#24300) (2026-04-29) [mssonicbld]
* af470d21d4 - [action] [PR:22350] Adding another `t2_single_node_max_64p` topo (#23481) (2026-04-29) [mssonicbld]
* 8be9db664a - [gnmi][202511] Increase wait_critical_processes timeout to 360s for warm reboot test (#24275) (2026-04-29) [Liping Xu]
* 2bde89ab91 - [action] [PR:21841] Skip test_everflow_remove_unused_ecmp_next_hop for VOQ systems (#22780) (2026-04-29) [mssonicbld]
* d1ded78605 - [action] [PR:21962] skip gcu/test_bgp_prefix for isolated topo. (#23688) (2026-04-29) [mssonicbld]
* 526e88d78b - [action] [PR:24209] Cleanup leftovers from removed test_dhcp_relay_on_dualtor_standby (#24260) (2026-04-29) [mssonicbld]
* bbb0437911 - [sonic-mgmt] Fix "sflow/test_sflow.py" to use consistent fixtures (#24083) (2026-04-28) [vkjammala-arista]
* 3476626af9 - [202511] bgp: fix test_bgp_vnet failures (#24272) (2026-04-28) [nsoma-cisco]
* a90bd64561 - [action] [PR:24244] Fix bad skip condition on qos/test_qos_dscp_mapping.py test cases (#24269) (2026-04-28) [mssonicbld]
* 1ed04900ce - [action] [PR:21706] [dhcp_relay] change ptfutils to tcpdump for better result (#22040) (2026-04-28) [mssonicbld]
* f72695f09e - [action] [PR:23867] Fix file ownership in topo converge and always restore on exit. (#24055) (2026-04-28) [mssonicbld]
* 3d1812796f - [action] [PR:24158] [dhcp_relay] Skip test_dhcp_relay_on_dualtor_standby on non-dualtor t… (#24262) (2026-04-28) [mssonicbld]
* 7d5d909dbd - [action] [PR:24054] Wait for monit container_checker after gNMI cert config recovery (#24265) (2026-04-28) [mssonicbld]
```
