### PR TITLE
[code sync] Merge code from sonic-net/sonic-mgmt:202511 to 202603

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -73,6 +73,10 @@
       set_fact:
         is_ixia_testbed: "{{ true if ptf_image == 'docker-keysight-api-server' else false }}"
 
+    - name: check if testbed has L1 switches
+      set_fact:
+        is_l1_testbed: "{{ testbed_facts.l1s is defined and (testbed_facts.l1s | length > 0) }}"
+
     - block:
         - name: Set L1 connection script path
           set_fact:
@@ -115,10 +119,10 @@
   - topo_facts: topo={{ topo }} hwsku={{ hwsku }} testbed_name={{ testbed_name | default(None) }} asics_present={{ asics_present | default([]) }} card_type={{ card_type | default('fixed') }}
     delegate_to: localhost
 
-  - name: override group_file for route-conv
+  - name: override group_file for snappi testbed
     set_fact:
       conn_graph_group: "{{ testbed_facts['inv_name'] }}"
-    when: is_ixia_testbed
+    when: is_ixia_testbed or is_l1_testbed
 
   - name: get connection graph if defined for dut (ignore any errors)
     conn_graph_facts:

--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -56,8 +56,10 @@ class DHCPStressTest(DHCPTest):
     def client_send_packet_stress(self):
         server_ports = "|".join(["eth{}".format(idx) for idx in self.receive_port_indices])
         tcpdump_cmd = (
-            "tcpdump -i any -n -q -l 'inbound and udp and (port 67 or port 68) and (udp[249:2] = 0x01{})' "
-            "| grep -w -E '{}' > /tmp/dhcp_stress_test_{}.log"
+            "tcpdump --buffer-size=102400 --immediate-mode -U "
+            "-i any -n -q -l "
+            "'inbound and udp and (port 67 or port 68) and (udp[249:2] = 0x01{})' "
+            "| grep --line-buffered -w -E '{}' > /tmp/dhcp_stress_test_{}.log"
         ).format(self.packet_type_hex, server_ports, self.packet_type)
         tcpdump_proc = subprocess.Popen(tcpdump_cmd, shell=True)
         if self.packet_type == "discover" or self.packet_type == "request":
@@ -67,20 +69,34 @@ class DHCPStressTest(DHCPTest):
         end_time = time.time() + self.packets_send_duration
         xid = 0
         while time.time() < end_time:
-            # Set a unique transaction ID for each DHCPOFFER packet for making sure no packet miss
             dhcp_packet[scapy.BOOTP].xid = xid
             xid += 1
             testutils.send_packet(self, self.send_port_indices[0], dhcp_packet)
             time.sleep(1/self.client_packets_per_sec)
 
-        time.sleep(15)
+        # Wait until tcpdump stops receiving packets (idle for 5s, max 120s)
+        log_file = "/tmp/dhcp_stress_test_{}.log".format(self.packet_type)
+        last_size = 0
+        idle_count = 0
+        deadline = time.time() + 120
+        while idle_count < 5 and time.time() < deadline:
+            time.sleep(1)
+            try:
+                current_size = os.path.getsize(log_file)
+            except OSError:
+                current_size = 0
+            if current_size == last_size:
+                idle_count += 1
+            else:
+                idle_count = 0
+            last_size = current_size
 
         pids = subprocess.check_output("pgrep tcpdump", shell=True).split()
         for pid in pids:
             os.kill(int(pid), signal.SIGINT)
         tcpdump_proc.wait()
 
-        wc_cmd = f"wc -l /tmp/dhcp_stress_test_{self.packet_type}.log"
+        wc_cmd = "wc -l /tmp/dhcp_stress_test_{}.log".format(self.packet_type)
         wc_output = subprocess.check_output(wc_cmd, shell=True)
         line_cnt = wc_output.decode().split()[0]
         os.remove("/tmp/dhcp_stress_test_{}.log".format(self.packet_type))

--- a/ansible/roles/testbed/nut/tasks/device_prepare_config.yml
+++ b/ansible/roles/testbed/nut/tasks/device_prepare_config.yml
@@ -5,8 +5,19 @@
     dest: /tmp/config_patch.json
     remote_src: false
 
-- name: preserve key configurations from existing config_db.json using jq
-  shell: "jq '{ {{ tables_to_keep | join(',') }} }' /etc/sonic/config_db.json | sed 's/\\bnull\\b/{}/' > /tmp/config_db_keep.json"
+- name: backup config_db.json to /tmp before rebuilding it
+  copy:
+    src: /etc/sonic/config_db.json
+    dest: /tmp/config_db_old.json
+    remote_src: true
+
+- name: preserve key configurations from backed up config_db.json using jq
+  shell: |
+    set -o pipefail
+    jq '{ {{ tables_to_keep | join(',') }} }' /tmp/config_db_old.json \
+      | jq 'with_entries(if .value == null then .value = {} else . end)' > /tmp/config_db_keep.json
+  args:
+    executable: /bin/bash
   vars:
     tables_to_keep:
       - DEVICE_METADATA

--- a/ansible/roles/testbed/nut/tasks/testbed_facts.yml
+++ b/ansible/roles/testbed/nut/tasks/testbed_facts.yml
@@ -25,5 +25,4 @@
   conn_graph_facts:
     hosts: "{{ (testbed_facts.duts | default([])) + (testbed_facts.tgs | default([])) + (testbed_facts.l1s | default([])) }}"
     group: "{{ conn_graph_group if conn_graph_group is defined else omit }}"
-    forced_mgmt_routes: "{{ forced_mgmt_routes | default([]) }}"
   delegate_to: localhost

--- a/ansible/roles/testbed/nut/tasks/testbed_facts.yml
+++ b/ansible/roles/testbed/nut/tasks/testbed_facts.yml
@@ -17,7 +17,13 @@
   debug:
     var: testbed_facts
 
+- name: override group_file to use testbed specific group file
+  set_fact:
+    conn_graph_group: "{{ testbed_facts['inv_name'] }}"
+
 - name: get connection graph if defined for dut
   conn_graph_facts:
-    hosts: "{{ testbed_facts['duts'] + testbed_facts['tgs'] + testbed_facts['l1s'] }}"
+    hosts: "{{ (testbed_facts.duts | default([])) + (testbed_facts.tgs | default([])) + (testbed_facts.l1s | default([])) }}"
+    group: "{{ conn_graph_group if conn_graph_group is defined else omit }}"
+    forced_mgmt_routes: "{{ forced_mgmt_routes | default([]) }}"
   delegate_to: localhost

--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -4,9 +4,9 @@ import logging
 import ipaddress
 import random
 import re
+import json
 
 from tests.common import constants
-from datetime import datetime, timedelta
 from tests.common.utilities import skip_release
 from tests.common.utilities import wait_tcp_connection
 from tests.common.utilities import wait_until
@@ -457,21 +457,31 @@ def verify_bgp_session(duthost, bgp_neighbor):
     )
 
 
-def get_bgp_uptime(duthost, bgp_neighbor):
-    # it's a work around for show ip bgp neighbors <ipaddress>, it can not show
-    # neighbors which are not configured
+def get_bgp_connection_count(duthost, bgp_neighbor):
+    """Get the established/dropped connection counts for a dynamic BGP neighbor."""
     output = duthost.shell(
-        "show ip bgp neighbors | grep -A 10 {} | grep 'Established'".format(
-            bgp_neighbor
-        )
+        'vtysh -c "show bgp neighbors {} json"'.format(bgp_neighbor),
+        module_ignore_errors=True,
     )
-    if not output["stdout"]:
-        pytest_assert(True, "Bgp neighbor {} is not up".format(bgp_neighbor))
-    time_string = re.search(r"up for (\d{2}:\d{2}:\d{2})", output["stdout"]).group(1)
-    t = datetime.strptime(time_string, "%H:%M:%S").time()
-    return int(
-        timedelta(hours=t.hour, minutes=t.minute, seconds=t.second).total_seconds()
+    pytest_assert(
+        output["rc"] == 0 and output["stdout"],
+        "Could not find connection info for {} (rc={})".format(
+            bgp_neighbor, output["rc"]
+        ),
     )
+    bgp_info = json.loads(output["stdout"])
+    pytest_assert(
+        bgp_neighbor in bgp_info,
+        "Neighbor {} not found in vtysh JSON output".format(bgp_neighbor),
+    )
+    neighbor_info = bgp_info[bgp_neighbor]
+    established = neighbor_info.get("connectionsEstablished", 0)
+    dropped = neighbor_info.get("connectionsDropped", 0)
+    pytest_assert(
+        established > 0,
+        "connectionsEstablished is 0 for {} — session was never established".format(bgp_neighbor),
+    )
+    return established, dropped
 
 
 def check_bgp_routes_exist(duthost, prefix):
@@ -525,8 +535,7 @@ def test_bgp_dual_asn_v4(
             30, 5, 10, verify_bgp_session, duthost, dualAsn.peer_addrs[0]
         ):
             pytest.fail("bgp peer %s should up" % dualAsn.peer_addrs[0])
-        current_bgp_uptime = get_bgp_uptime(duthost, dualAsn.peer_addrs[0])
-        current_time = time.time()
+        initial_established, initial_dropped = get_bgp_connection_count(duthost, dualAsn.peer_addrs[0])
         # announce route from valid bgp peer
         announce_route(ptfhost, NEIGHBOR_PORT_LIST[0], PREFIX, dualAsn.peer_addrs[0])
         # bgp peer which is not in peer range group should not up
@@ -589,10 +598,19 @@ def test_bgp_dual_asn_v4(
         check_bgp_routes_exist(duthost, PREFIX_2)
 
         # check original bgp neighbor no flapping
-        latest_time = time.time()
-        latest_bgp_uptime = get_bgp_uptime(duthost, dualAsn.peer_addrs[0])
-        if latest_time - current_time > latest_bgp_uptime - current_bgp_uptime:
-            pytest.fail("bgp %s flapped during testing" % dualAsn.peer_addrs[0])
+        # Verify the original BGP peer did not flap by comparing FRR connection counters.
+        # Uses established/dropped counts instead of uptime to avoid false positives
+        # from wall-clock vs BGP-uptime measurement drift over SSH.
+        # Note: Any change in either counter (established or dropped) is treated as unexpected,
+        # including reconnections (e.g. graceful restart). This is intentional, during
+        # this test window, the original peer should maintain a single stable session without any flap.
+        final_established, final_dropped = get_bgp_connection_count(duthost, dualAsn.peer_addrs[0])
+        if final_established != initial_established or final_dropped != initial_dropped:
+            pytest.fail(
+                "bgp %s flapped during testing (established: %d->%d, dropped: %d->%d)"
+                % (dualAsn.peer_addrs[0], initial_established, final_established,
+                   initial_dropped, final_dropped)
+            )
 
         # remove first peer range group configuration, check it's neighbor's bgp state
         bgp_peer_range_delete_config(

--- a/tests/common/constants.py
+++ b/tests/common/constants.py
@@ -37,6 +37,8 @@ class CounterpollConstants:
     QUEUE = 'queue'
     PORT_STAT_TYPE = 'PORT_STAT'
     PORT = 'port'
+    PORT_PHY_ATTR_TYPE = 'PHY'
+    PORT_PHY_ATTR = 'phy'
     PORT_BUFFER_DROP_TYPE = 'PORT_BUFFER_DROP'
     PORT_BUFFER_DROP = 'port-buffer-drop'
     RIF_STAT_TYPE = 'RIF_STAT'
@@ -52,6 +54,7 @@ class CounterpollConstants:
     COUNTERPOLL_MAPPING = {PG_DROP_STAT_TYPE: PG_DROP,
                            QUEUE_STAT_TYPE: QUEUE,
                            PORT_STAT_TYPE: PORT,
+                           PORT_PHY_ATTR_TYPE: PORT_PHY_ATTR,
                            PORT_BUFFER_DROP_TYPE: PORT_BUFFER_DROP,
                            RIF_STAT_TYPE: RIF,
                            BUFFER_POOL_WATERMARK_STAT_TYPE: WATERMARK,

--- a/tests/common/constants.py
+++ b/tests/common/constants.py
@@ -47,6 +47,8 @@ class CounterpollConstants:
     BUFFER_POOL_WATERMARK_STAT_TYPE = 'BUFFER_POOL_WATERMARK_STAT'
     ACL = 'acl'
     ACL_TYPE = "ACL"
+    PHY_TYPE = 'PHY'
+    PHY = 'phy'
     COUNTERPOLL_MAPPING = {PG_DROP_STAT_TYPE: PG_DROP,
                            QUEUE_STAT_TYPE: QUEUE,
                            PORT_STAT_TYPE: PORT,
@@ -55,7 +57,8 @@ class CounterpollConstants:
                            BUFFER_POOL_WATERMARK_STAT_TYPE: WATERMARK,
                            QUEUE_WATERMARK_STAT_TYPE: WATERMARK,
                            PG_WATERMARK_STAT_TYPE: WATERMARK,
-                           ACL_TYPE: ACL}
+                           ACL_TYPE: ACL,
+                           PHY_TYPE: PHY}
     PORT_BUFFER_DROP_INTERVAL = '10000'
     COUNTERPOLL_INTERVAL = {PORT_BUFFER_DROP: 10000}
     SX_SDK = 'sx_sdk'

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -37,7 +37,7 @@ UPSTREAM_ALL_NEIGHBOR_MAP = {
     "m0_vlan": ["m1"],
     "m0_l3": ["m1"],
     'lt2': ['ut2'],
-    'ft2': ['ut2']
+    'ft2': ['lt2']
 }
 
 # Describe downstream neighbor of dut in different topos

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -28,7 +28,8 @@ MARK_CONDITIONS_CONSTANTS = {
                      't1-lag', 't1-28-lag', 't1-48-lag', 't1-64-lag', 't1-56-lag',
                      't1-backend', 't1-isolated-d128', 't1-isolated-d32',
                      't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic',
-                     'lt2-p32o64', 'lt2-o128', 'ft2-64', 't2-single-node-min']
+                     'lt2-p32o64', 'lt2-o128', 'ft2-64', 't2-single-node-min',
+                     't2_single_node_max', 't2_single_node_max_64p', 'topo_t2_single_node_max_64p_v2']
 }
 
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3847,7 +3847,7 @@ qos/test_qos_sai.py::TestQosSai:
     conditions_logical_operator: or
     conditions:
       - "topo_type in ['m0', 'mx', 'm1']"
-      - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox','marvell-teralynx']"
+      - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox','marvell-teralynx']"
 
 qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping:
   skip:
@@ -3912,7 +3912,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:
     conditions:
       - "'backend' in topo_name"
       - "topo_type in ['m0', 'mx', 'm1']"
-      - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox']"
+      - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping:
   skip:
@@ -3921,7 +3921,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping:
     conditions:
       - "'backend' in topo_name"
       - "topo_type in ['m0', 'mx', 'm1']"
-      - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox']"
+      - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr:
   skip:
@@ -3937,7 +3937,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange:
     conditions:
       - "asic_type in ['mellanox']"
       - "topo_type in ['m0', 'mx', 'm1']"
-      - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox']"
+      - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
       - "asic_type in ['cisco-8000'] and platform.startswith('x86_64-8122_')"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiFullMeshTrafficSanity:
@@ -3958,7 +3958,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
        and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32C-C32', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32C-C28S4', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
        and asic_type in ['cisco-8000']"
       - "topo_type in ['m0', 'mx', 'm1']"
-      - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox','marvell-teralynx']"
+      - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox','marvell-teralynx']"
       - "asic_type in ['vs']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
@@ -4021,7 +4021,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
       - "asic_type in ['marvell-teralynx'] and platform in ['x86_64-wistron_6512_32r-r0', 'x86_64-wistron_sw_to3200k-r0']"
       - "asic_type in ['cisco-8000'] and not platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx', 'm1']"
-      - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox']"
+      - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPgMinThreshold:
   skip:
@@ -4042,7 +4042,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts:
     conditions:
       - "asic_type not in ['cisco-8000']"
       - "topo_type in ['m0', 'mx', 'm1']"
-      - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox']"
+      - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3546,7 +3546,7 @@ pc/test_po_voq.py:
   skip:
     reason: "Skip for non t2 or Skip since there is no portchannel configured or no portchannel member exists in current topology."
     conditions:
-      - "'t2' not in topo_name or num_asic == 0 or len(minigraph_portchannels[list(minigraph_portchannels.keys())[0]]['members']) == 0 or asic_type in ['cisco-8000']"
+      - "'t2' not in topo_name or num_asic == 0 or len(minigraph_portchannels) == 0 or len(minigraph_portchannels[list(minigraph_portchannels.keys())[0]]['members']) == 0 or asic_type in ['cisco-8000']"
 
 pc/test_retry_count.py::test_retry_count:
   xfail:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -340,6 +340,12 @@ bgp/test_bgp_bbr_default_state.py::test_bbr_disabled_constants_yml_default:
     conditions:
       - "'-v6-' in topo_name"
 
+bgp/test_bgp_bounce.py:
+  xfail:
+    reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20753"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20753 and '-v6-' in topo_name"
+
 bgp/test_bgp_dual_asn.py::test_bgp_dual_asn_v4:
   skip:
     reason: "Skip for IPv6-only topologies"
@@ -446,6 +452,18 @@ bgp/test_bgp_session.py::test_bgp_session_interface_down:
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/19916 and '-v6-' in topo_name"
 
+bgp/test_bgp_session_flap.py::test_bgp_multiple_session_flaps:
+  xfail:
+    reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20755"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20755 and '-v6-' in topo_name"
+
+bgp/test_bgp_session_flap.py::test_bgp_single_session_flaps:
+  xfail:
+    reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20755"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20755 and '-v6-' in topo_name"
+
 bgp/test_bgp_slb.py:
   skip:
     reason: "Skip over topologies which doesn't support slb and this test is not run on this topology currently"
@@ -506,6 +524,10 @@ bgp/test_bgp_suppress_fib.py:
     conditions:
       - "release in ['201811', '201911', '202012', '202205', '202211', '202305', '202311', '202405', 'master']"
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/14449"
+  xfail:
+    reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20756"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20756 and '-v6-' in topo_name"
 
 bgp/test_bgp_update_replication.py:
   xfail:
@@ -524,6 +546,12 @@ bgp/test_bgpmon.py:
     reason: "Not supported on T2 topology or topology backend"
     conditions:
       - "'backend' in topo_name or topo_type in ['t2']"
+
+bgp/test_bgpmon.py::test_bgpmon:
+  xfail:
+    reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20754"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20754 and '-v6-' in topo_name"
 
 bgp/test_bgpmon_v6.py::test_bgpmon_no_ipv6_resolve_via_default:
   skip:
@@ -1103,6 +1131,7 @@ dhcp_relay/test_dhcpv6_relay.py::test_interface_binding:
       - "release in ['201911', '202106']"
 
 #######################################
+
 #####         dhcp_server        #####
 #######################################
 dhcp_server:
@@ -1110,6 +1139,14 @@ dhcp_server:
     reason: "It is skipped for '202412' for now"
     conditions:
       - "release in ['202412']"
+
+#####             disk            #####
+#######################################
+disk/test_disk_exhaustion.py:
+  xfail:
+    reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20759"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20759 and '-v6-' in topo_name"
 
 #######################################
 #####         drop_packets        #####
@@ -2302,9 +2339,9 @@ generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite:
 
 generic_config_updater/test_bgp_speaker.py::test_bgp_speaker_tc1_test_config:
   xfail:
-    reason: "xfail for IPv6-only topologies, still have IPv4 function used"
+    reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20757"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/19638 and '-v6-' in topo_name"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20757 and '-v6-' in topo_name"
 
 generic_config_updater/test_dhcp_relay.py:
   skip:
@@ -4778,6 +4815,10 @@ telemetry/test_events.py:
       - https://github.com/sonic-net/sonic-buildimage/issues/19943
 
 telemetry/test_events.py::test_events:
+  xfail:
+    reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20758"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20758 and '-v6-' in topo_name"
   skip:
     reason: "dut ipv6 mgmt ip not supported"
     conditions_logical_operator: and

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -755,9 +755,9 @@ crm/test_crm_available.py:
 #######################################
 dash:
   skip:
-    reason: "Not supported on this DUT topology."
+    reason: "Dash tests are only supported on smartswitch platforms"
     conditions:
-      - "'dpu' not in topo_name"
+      - "is_smartswitch == False"
 
 dash/crm/test_dash_crm.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3018,10 +3018,12 @@ hash/test_generic_hash.py::test_reboot[CRC_CCITT-IP_PROTOCOL-ipv4:
 #######################################
 high_frequency_telemetry:
   skip:
-    reason: "High frequency telemetry isn't supported in this platform"
+    reason: "High frequency telemetry isn't supported in this platform or on T2 topology"
     conditions_logical_operator: or
     conditions:
       - "platform not in ['x86_64-nvidia_sn5600-r0', 'x86_64-nvidia_sn5640-r0', 'x86_64-arista_7060x6_64pe_b']"
+      - "'bmc' in topo_type"
+      - "'t2' in topo_type"
 
 high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_full_counters:
   skip:

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1307,7 +1307,7 @@ def capture_and_check_packet_on_dut(
     pkts_validator_args=[],
     pkts_validator_kwargs={},
     wait_time=1,
-    tcpdump_buffer_size=102400
+    tcpdump_buffer_size=4096
 ):
     """
     Capture packets on DUT and check if the packet is expected

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1337,6 +1337,7 @@ def capture_and_check_packet_on_dut(
             duthost.fetch(src=pcap_save_path, dest=temp_pcap.name, flat=True)
             pkts_validator(scapy_sniff(offline=temp_pcap.name), *pkts_validator_args, **pkts_validator_kwargs)
     finally:
+        duthost.shell("kill -9 %s || true" % tcpdump_pid, module_ignore_errors=True)
         duthost.file(path=pcap_save_path, state="absent")
 
 

--- a/tests/cpu_shaper/test_cpu_shaper.py
+++ b/tests/cpu_shaper/test_cpu_shaper.py
@@ -24,14 +24,20 @@ logger = logging.getLogger(__name__)
 BCM_CINT_FILENAME = "get_shaper.c"
 DEST_DIR = "/tmp"
 CMD_GET_SHAPER = "bcmcmd 'cint {}'".format(BCM_CINT_FILENAME)
+EXPECTED_COS_QUEUES = {0, 7}
+EXPECTED_PPS = 600
+PPS_TOLERANCE = 0.05  # Allow 5% tolerance in PPS values
 
 
-def verify_cpu_queue_shaper(dut):
+def get_cpu_queue_shaper(dut):
     """
-    Verify cpu queue shaper configuration is as expected
+    Read cpu queue shaper PPS configuration from the ASIC.
 
     Args:
         dut (SonicHost): The target device
+
+    Returns:
+        dict: Mapping of cos queue index to PPS max value, e.g. {0: 600, 7: 600}
     """
     # Copy cint script to /tmp on the device
     dut.copy(src="cpu_shaper/scripts/{}".format(BCM_CINT_FILENAME), dest=DEST_DIR)
@@ -42,35 +48,53 @@ def verify_cpu_queue_shaper(dut):
     # Execute the cint script and parse the output
     res = dut.shell(CMD_GET_SHAPER)['stdout']
 
-    # Expected shaper PPS configuration for CPU queues 0, and 7
-    expected_pps = {0: 600, 7: 600}
     pattern = r'cos=(\d+) pps_max=(\d+)'
     matches = re.findall(pattern, res)
-    actual_pps = {int(cos): int(pps) for cos, pps in matches}
-    assert (expected_pps == actual_pps)
+    return {int(cos): int(pps) for cos, pps in matches}
 
 
 @pytest.mark.disable_loganalyzer
 def test_cpu_queue_shaper(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, request):
     """
-    Validates the cpu queue shaper configuration after reboot(reboot, warm-reboot)
-
+    Validates the cpu queue shaper configuration survives reboot by comparing
+    shaper values before and after reboot.
     """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     try:
-        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         reboot_type = request.config.getoption("--cpu_shaper_reboot_type")
+        # Read shaper config before reboot
+        before_pps = get_cpu_queue_shaper(duthost)
+        logger.info("CPU queue shaper before reboot: {}".format(before_pps))
 
-        # Perform reboot as specified via the reboot_type parameter
+        # Validate all expected queues are present with non-zero shaper values
+        missing = EXPECTED_COS_QUEUES - set(before_pps.keys())
+        assert not missing, \
+            "CPU queue shaper missing for cos queues {} before reboot. Got: {}".format(missing, before_pps)
+        assert all(before_pps[cos] > 0 for cos in EXPECTED_COS_QUEUES), \
+            "CPU queue shaper has zero PPS before reboot: {}".format(before_pps)
+        # Validate shaper values are close to original 600 PPS (allowing 5% tolerance)
+        pps_low, pps_high = int(EXPECTED_PPS * (1 - PPS_TOLERANCE)), int(EXPECTED_PPS * (1 + PPS_TOLERANCE))
+        for cos in EXPECTED_COS_QUEUES:
+            assert pps_low <= before_pps[cos] <= pps_high, \
+                "CPU queue {} shaper PPS {} is outside {}% tolerance of {} PPS".format(
+                    cos, before_pps[cos], int(PPS_TOLERANCE * 100), EXPECTED_PPS)
+
+        # Perform reboot
         logger.info("Do {} reboot".format(reboot_type))
         reboot(duthost, localhost, reboot_type=reboot_type, reboot_helper=None, reboot_kwargs=None)
 
         # Wait for critical processes to be up
         wait_critical_processes(duthost)
-        logger.info("Verify cpu queue shaper config after {} reboot".format(reboot_type))
 
-        # Verify cpu queue shaper configuration
-        verify_cpu_queue_shaper(duthost)
+        # Read shaper config after reboot
+        after_pps = get_cpu_queue_shaper(duthost)
+        logger.info("CPU queue shaper after {} reboot: {}".format(reboot_type, after_pps))
+
+        # Verify shaper config survived reboot unchanged
+        assert before_pps == after_pps, \
+            "CPU queue shaper changed after {} reboot: before={}, after={}".format(
+                reboot_type, before_pps, after_pps)
 
     finally:
-        duthost.shell("rm {}/{}".format(DEST_DIR, BCM_CINT_FILENAME))
+        duthost.shell("rm -f {}/{}".format(DEST_DIR, BCM_CINT_FILENAME))
         config_reload(duthost)

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -21,7 +21,7 @@ BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
 DEFAULT_DHCP_SERVER_PORT = 67
 DUAL_TOR_MODE = 'dual'
-BUFFER_SIZE = 1024 * 1024  # 1MB
+BUFFER_SIZE = 1024  # 1 MiB (tcpdump --buffer-size is in KiB)
 logger = logging.getLogger(__name__)
 PACKET_RATE_PER_SEC_MAP = {
     "Mellanox-SN2700": 20

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -86,7 +86,7 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
             "testing_mode": testing_mode,
             "kvm_support": True
         }
-        count_file = '/tmp/dhcp_stress_test_{}.json'.format(dhcp_type)
+        count_file = '/tmp/dhcp_stress_test_{}'.format(dhcp_type)
 
         def _check_count_file_exists():
             command = 'ls {} > /dev/null 2>&1 && echo exists || echo missing'.format(count_file)

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -825,7 +825,7 @@ class BaseEverflowTest(object):
                 command = f"sonic-db-cli CONFIG_DB HSET 'MIRROR_SESSION|{session_info['session_name']}' \
                             'dscp' '{session_info['session_dscp']}' 'dst_ip' '{session_info['session_dst_ipv6']}' \
                             'gre_type' '{session_info['session_gre']}' 'src_ip' '{session_info['session_src_ipv6']}' \
-                            'ttl' '{session_info['session_ttl']}'"
+                            'ttl' '{session_info['session_ttl']}' 'type' 'ERSPAN'"
                 if policer:
                     command += f" 'policer' {policer}"
 

--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -442,8 +442,8 @@ class SetupPfcwdFunc(object):
             ptf_port = 'eth%s' % self.pfc_wd['test_port_id']
             if self.pfc_wd['test_port_vlan_id'] is not None:
                 ptf_port += (constants.VLAN_SUB_INTERFACE_SEPARATOR + self.pfc_wd['test_port_vlan_id'])
-            self.ptf.command("ip neigh flush all")
-            self.ptf.command("ip -6 neigh flush all")
+            self.ptf.command("ip neigh flush all", module_ignore_errors=True)
+            self.ptf.command("ip -6 neigh flush all", module_ignore_errors=True)
             self.dut.command("ip neigh flush all")
             self.dut.command("ip -6 neigh flush all")
             if ip_version == "IPv4":

--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -212,7 +212,7 @@ x86_64-8102_28fh_dpu_o-r0:
     too_big_timeout: 6554
 
 # Nexthop watchdog
-x86_64-nexthop_40(1|2)0-r.*:
+x86_64-nexthop_.*:
   default:
     valid_timeout: 10
     greater_timeout: 16777

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -471,6 +471,8 @@ class QosSaiBase(QosBase):
             if dut_asic.sonichost.is_multi_asic:
                 port = "{}|{}|{}".format(
                     dut_asic.sonichost.hostname, dut_asic.namespace, port)
+            else:
+                port = "{}|Asic0|{}".format(dut_asic.sonichost.hostname, port)
         if check_qos_db_fv_reference_with_table(dut_asic):
             out = dut_asic.run_redis_cmd(
                 argv=[

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -339,12 +339,11 @@ class QosSaiBase(QosBase):
         )[0]).replace("oid:", '')
         bufferProfile.update({"bufferPoolRoid": bufferPoolRoid})
 
-    def __getBufferProfile(self, request, dut_asic, os_version, table, port, priorityGroup):
+    def __getBufferProfile(self, dut_asic, os_version, table, port, priorityGroup):
         """
             Get buffer profile attribute from Redis db
 
             Args:
-                request (Fixture): pytest request object
                 dut_asic(SonicAsic): Device Under Test (DUT)
                 table (str): Redis table name
                 port (str): DUT port alias
@@ -1712,6 +1711,27 @@ class QosSaiBase(QosBase):
                 if 'proxy_arp' in value:
                     logger.info('ARP proxy is {} on {}'.format(value['proxy_arp'], key))
 
+    def getPortSpeedCableLength(self, dut_asic, duthost, srcport, pgs):
+        profileName = self.__getBufferProfile(
+                    dut_asic,
+                    duthost.os_version,
+                    "BUFFER_PG_TABLE" if self.isBufferInApplDb(
+                        dut_asic) else "BUFFER_PG",
+                    srcport,
+                    pgs
+                )["profileName"]
+
+        if self.isBufferInApplDb(dut_asic):
+            profile_pattern = "^BUFFER_PROFILE_TABLE\\:pg_lossless_(.*)_profile$"
+        else:
+            profile_pattern = "^BUFFER_PROFILE\\|pg_lossless_(.*)_profile"
+        m = re.search(profile_pattern, profileName)
+        pytest_assert(m and m.group(1), f"Cannot find port speed/cable length for srcport {srcport} and pgs {pgs}")
+
+        portSpeedCableLength = m.group(1)
+        logger.debug(f"portSpeedCableLength of src port {srcport} is {portSpeedCableLength}")
+        return portSpeedCableLength
+
     @pytest.fixture(scope='class', autouse=True)
     def dutQosConfig(
         self, duthosts, get_src_dst_asic_and_duts,
@@ -1740,14 +1760,9 @@ class QosSaiBase(QosBase):
         logger.info(
             "Lossless Buffer profile selected is {}".format(profileName))
 
-        if self.isBufferInApplDb(dut_asic):
-            profile_pattern = "^BUFFER_PROFILE_TABLE\\:pg_lossless_(.*)_profile$"
-        else:
-            profile_pattern = "^BUFFER_PROFILE\\|pg_lossless_(.*)_profile"
-        m = re.search(profile_pattern, profileName)
-        pytest_assert(m.group(1), "Cannot find port speed/cable length")
-
-        portSpeedCableLength = m.group(1)
+        srcport = dutConfig["dutInterfaces"][dutConfig["testPorts"]["src_port_id"]]
+        portSpeedCableLength = self.getPortSpeedCableLength(dut_asic, duthost,
+                                                            srcport, "3-4")
 
         qosConfigs = dutConfig["qosConfigs"]
         dutAsic = dutConfig["dutAsic"]
@@ -2194,7 +2209,6 @@ class QosSaiBase(QosBase):
             pgs = "3-4"
 
         yield self.__getBufferProfile(
-            request,
             dut_asic,
             duthost.os_version,
             "BUFFER_PG_TABLE" if self.isBufferInApplDb(
@@ -2222,7 +2236,6 @@ class QosSaiBase(QosBase):
         duthost = get_src_dst_asic_and_duts['src_dut']
         dut_asic = get_src_dst_asic_and_duts['src_asic']
         yield self.__getBufferProfile(
-            request,
             dut_asic,
             duthost.os_version,
             "BUFFER_PG_TABLE" if self.isBufferInApplDb(
@@ -2259,7 +2272,6 @@ class QosSaiBase(QosBase):
             queues = "3-4"
 
         yield self.__getBufferProfile(
-            request,
             dut_asic,
             duthost.os_version,
             "BUFFER_QUEUE_TABLE" if self.isBufferInApplDb(
@@ -2310,7 +2322,6 @@ class QosSaiBase(QosBase):
                 queues = "0-2"
 
         egress_lossy_profile = self.__getBufferProfile(
-            request,
             dut_asic,
             duthost.os_version,
             "BUFFER_QUEUE_TABLE" if self.isBufferInApplDb(

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -509,10 +509,14 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             self._run_test(ptfadapter, duthost, tbinfo, test_params, inner_dst_ip_list, dut_qos_maps_module, dscp_mode)
 
         is_smartswitch = duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch", False)
+        # TH5 devices don't support warm reboot; only cold reboot supported during upgrades.
+        # Remove this check if TH5 warm reboot support is added in the future.
+        is_th5_device = duthost.get_asic_name() == 'th5'
         topo_name = tbinfo["topo"]["name"]
         if (
             completeness_level != "basic"
             and not is_smartswitch
+            and not is_th5_device
             and "dualtor" not in topo_name
             and "t1" not in topo_name
         ):

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -276,7 +276,7 @@ class TestQosSai(QosSaiBase):
             logger.info("Restore speed to {}".format(original_speed))
             _set_speed_and_populate_arp(fanout_host, original_speed, dut_port_list)
 
-    def replaceNonExistentPortId(self, availablePortIds, portIds):
+    def replaceNonExistentPortId(self, availablePortIds, portIds, mapDuplicatesToSameAvailable=False):
         '''
         if port id of availablePortIds/dst_port_ids is not existing in availablePortIds
         replace it with correct one, make sure all port id is valid
@@ -284,88 +284,185 @@ class TestQosSai(QosSaiBase):
             Given below parameter:
                 availablePortIds: [0, 2, 4, 6, 8, 10, 16, 18, 20, 22, 24, 26,
                                    28, 30, 32, 34, 36, 38, 44, 46, 48, 50, 52, 54]
-                portIds: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                portIds: [1, 2, 2, 3, 3, 4, 5, 6, 6, 7, 7, 8, 9]
             get result:
-                portIds: [0, 2, 16, 4, 18, 6, 20, 8, 22]
+                portIds: [0, 2, 10, 16, 18, 4, 20, 6, 22, 24, 26, 8, 28]
+        if mapDuplicatesToSameAvailable is True then the resulting portIds is allowed
+        to have duplicate entries and they will be mapped to the same available ports
+        e.g.
+            Given below parameter:
+                availablePortIds: [0, 2, 4, 6, 8, 10, 16, 18, 20, 22, 24, 26,
+                                   28, 30, 32, 34, 36, 38, 44, 46, 48, 50, 52, 54]
+                portIds: [1, 2, 2, 3, 3, 4, 5, 6, 6, 7, 7, 8, 9]
+            get result, the valid duplicates are kept and invalid are mapped to the same value:
+                portIds: [0, 2, 2, 10, 10, 4, 16, 6, 6, 18, 18, 8, 20]
         '''
-        if len(portIds) > len(availablePortIds):
-            logger.info('no enough ports for test')
+        numNeeded = len(set(portIds)) if mapDuplicatesToSameAvailable else len(portIds)
+        numAvailable = len(availablePortIds)
+        if numNeeded > numAvailable:
+            logger.info(f'not enough ports for test, {numNeeded} ports needed > {numAvailable} ports available')
+            return False
+        if numAvailable != len(set(availablePortIds)):
+            logger.warning(f"duplicate ports found in availablePortIds: {availablePortIds}")
             return False
 
         # cache available as free port pool
         freePorts = [pid for pid in availablePortIds]
+        removedPorts = set()
 
-        # record invaild port
-        # and remove valid port from free port pool
-        invalid = []
+        # record invalid port
+        # otherwise remove valid port from free port pool
+        invalid = {}
         for idx, pid in enumerate(portIds):
+            # if we removed the port from freeports then it's still valid
+            if mapDuplicatesToSameAvailable and pid in removedPorts:
+                continue
             if pid not in freePorts:
-                invalid.append(idx)
+                invalid.setdefault(pid, [])
+                invalid[pid].append(idx)
             else:
                 freePorts.remove(pid)
+                removedPorts.add(pid)
 
         # replace invalid port from free port pool
-        for idx in invalid:
-            portIds[idx] = freePorts.pop(0)
+        for pid, idxs in invalid.items():
+            # either map invalid duplicates to the same port or get a fresh one for all
+            if mapDuplicatesToSameAvailable:
+                newPid = freePorts.pop(0)
+            for idx in idxs:
+                if not mapDuplicatesToSameAvailable:
+                    newPid = freePorts.pop(0)
+                portIds[idx] = newPid
 
         return True
 
-    def updateTestPortIdIp(self, dutConfig, get_src_dst_asic_and_duts, qosParams=None):
+    def updateTestPortIdIp(self, dutConfig, get_src_dst_asic_and_duts, portSpeedCableLength=None, qosParams=None):
         src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
         dst_dut_index = get_src_dst_asic_and_duts['dst_dut_index']
         src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
         dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
         src_testPortIds = dutConfig["testPortIds"][src_dut_index][src_asic_index]
         dst_testPortIds = dutConfig["testPortIds"][dst_dut_index][dst_asic_index]
-        testPortIds = src_testPortIds + list(set(dst_testPortIds) - set(src_testPortIds))
 
-        portIdNames = []
-        portIds = []
+        # Keep src and dest ports separate so we can pick a valid replacement from the correct asic
+        src_portIdNames = []
+        src_portIds = []
+        dst_portIdNames = []
+        dst_portIds = []
 
         for idName in dutConfig["testPorts"]:
-            if re.match(r'(?:src|dst)_port\S+id', idName):
-                portIdNames.append(idName)
+            if re.match(r'src_port\S+id', idName):
+                src_portIdNames.append(idName)
                 ipName = idName.replace('id', 'ip')
                 pytest_assert(
                     ipName in dutConfig["testPorts"], 'Not find {} for {} in dutConfig'.format(ipName, idName))
-                portIds.append(dutConfig["testPorts"][idName])
-        pytest_assert(self.replaceNonExistentPortId(testPortIds, set(portIds)), "No enough test ports")
-        for idx, idName in enumerate(portIdNames):
-            dutConfig["testPorts"][idName] = portIds[idx]
-            ipName = idName.replace('id', 'ip')
-            if 'src' in ipName:
-                testPortIps = dutConfig["testPortIps"][src_dut_index][src_asic_index]
+                src_portIds.append(dutConfig["testPorts"][idName])
+            elif re.match(r'dst_port\S+id', idName):
+                dst_portIdNames.append(idName)
+                ipName = idName.replace('id', 'ip')
+                pytest_assert(
+                    ipName in dutConfig["testPorts"], 'Not find {} for {} in dutConfig'.format(ipName, idName))
+                dst_portIds.append(dutConfig["testPorts"][idName])
+
+        # replace src and dst ports with valid choices from the appropriate asic
+        # filter the source ports to those with the correct profile if provided
+        if portSpeedCableLength:
+            dut_asic = get_src_dst_asic_and_duts['src_asic']
+            duthost = get_src_dst_asic_and_duts['src_dut']
+            pgs = None
+            if qosParams and "pgs" in qosParams:
+                pgs = qosParams["pgs"]
+                maxPg = max(pgs)
+                minPg = min(pgs)
+                if minPg == maxPg:
+                    pgs = str(minPg)
+                else:
+                    # valid PG pattern "[0-7]((-)[0-7])?"
+                    expectedRange = set(range(minPg, maxPg + 1))
+                    actualPgs = set(pgs)
+                    pytest_assert(actualPgs == expectedRange,
+                                  f"Invalid PGs {pgs}, should be a continuous range."
+                                  f"Expected {sorted(expectedRange)}, got {sorted(actualPgs)}")
+                    pgs = f"{minPg}-{maxPg}"
+            elif dutConfig.get("dualTor"):
+                pgs = "2-4"
             else:
-                testPortIps = dutConfig["testPortIps"][dst_dut_index][dst_asic_index]
-            dutConfig["testPorts"][ipName] = testPortIps[portIds[idx]]['peer_addr']
+                pgs = "3-4"
+
+            logger.debug(f"src_testPortIds before portSpeedCableLength filtering: {src_testPortIds}")
+            src_testPortIds = [id for id in src_testPortIds
+                               if portSpeedCableLength == self.getPortSpeedCableLength(
+                                    dut_asic,
+                                    duthost,
+                                    dutConfig["dutInterfaces"][id],
+                                    pgs
+                                )]
+            logger.debug(f"src_testPortIds after portSpeedCableLength filtering: {src_testPortIds}")
+
+            pytest_assert(len(src_testPortIds) > 0,
+                          f"No source ports found matching portSpeedCableLength={portSpeedCableLength}")
+
+        pytest_assert(self.replaceNonExistentPortId(src_testPortIds, src_portIds), "Not enough src test ports")
+
+        # remove src ports from dst ports to avoid src and dst ports are the same on single asic
+        # if the dut or the asic is different then don't remove the src port ids
+        sameSrcDestDutAndAsic = src_dut_index == dst_dut_index and src_asic_index == dst_asic_index
+        if sameSrcDestDutAndAsic:
+            dst_testPortIds = list(set(dst_testPortIds) - set(src_portIds))
+        pytest_assert(
+            self.replaceNonExistentPortId(dst_testPortIds, dst_portIds, mapDuplicatesToSameAvailable=True),
+            "Not enough dst test ports")
+
+        # update dutConfig with corrected src ports and their IPs
+        for idx, idName in enumerate(src_portIdNames):
+            dutConfig["testPorts"][idName] = src_portIds[idx]
+            ipName = idName.replace('id', 'ip')
+            testPortIps = dutConfig["testPortIps"][src_dut_index][src_asic_index]
+            dutConfig["testPorts"][ipName] = testPortIps[src_portIds[idx]]['peer_addr']
+
+        # update dutConfig with corrected dst ports and their IPs
+        for idx, idName in enumerate(dst_portIdNames):
+            dutConfig["testPorts"][idName] = dst_portIds[idx]
+            ipName = idName.replace('id', 'ip')
+            testPortIps = dutConfig["testPortIps"][dst_dut_index][dst_asic_index]
+            dutConfig["testPorts"][ipName] = testPortIps[dst_portIds[idx]]['peer_addr']
+
+        logger.debug('updateTestPortIdIp dutConfig["testPorts"]: {}'.format(dutConfig["testPorts"]))
 
         if qosParams is not None:
-            portIdNames = []
-            portNumbers = []
-            portIds = []
-            for idName in qosParams.keys():
-                if re.match(r'(?:src|dst)_port\S+ids?', idName):
-                    portIdNames.append(idName)
-                    ids = qosParams[idName]
-                    if isinstance(ids, list):
-                        portIds += ids
-                        # if it's port list, record number of pots
-                        portNumbers.append(len(ids))
-                    else:
-                        portIds.append(ids)
-                        # record None to indicate it's just one port
-                        portNumbers.append(None)
-            pytest_assert(self.replaceNonExistentPortId(testPortIds, portIds), "No enough test ports")
-            startPos = 0
-            for idx, idName in enumerate(portIdNames):
-                if portNumbers[idx] is not None:    # port list
-                    qosParams[idName] = [
-                        portId for portId in portIds[startPos:startPos + portNumbers[idx]]]
-                    startPos += portNumbers[idx]
-                else:   # not list, just one port
-                    qosParams[idName] = portIds[startPos]
-                    startPos += 1
-        logger.debug('updateTestPortIdIp dutConfig["testPorts"]: {}'.format(dutConfig["testPorts"]))
+            for idName in list(qosParams.keys()):
+                if re.match(r'src_port\S+ids?', idName):
+                    port_list = qosParams[idName]
+                    isList = True
+                    if not isinstance(port_list, list):
+                        port_list = [port_list]
+                        isList = False
+                    pytest_assert(self.replaceNonExistentPortId(src_testPortIds, port_list),
+                                  f"Not enough src test ports in qosParams for {idName}")
+
+                    # update qosParams for this param and remove from available src ports
+                    qosParams[idName] = port_list if isList else port_list[0]
+                    src_testPortIds = list(set(src_testPortIds) - set(port_list))
+                    # if same dut and same asic, then also remove from the dest ports
+                    if sameSrcDestDutAndAsic:
+                        dst_testPortIds = list(set(dst_testPortIds) - set(port_list))
+                elif re.match(r'dst_port\S+ids?', idName):
+                    port_list = qosParams[idName]
+                    isList = True
+                    if not isinstance(port_list, list):
+                        port_list = [port_list]
+                        isList = False
+                    pytest_assert(self.replaceNonExistentPortId(dst_testPortIds, port_list),
+                                  f"Not enough dst test ports in qosParams for {idName}")
+
+                    # update qosParams for this param and remove from available dest ports
+                    qosParams[idName] = port_list if isList else port_list[0]
+                    dst_testPortIds = list(set(dst_testPortIds) - set(port_list))
+                    # if same dut and same asic, then also remove from the src ports
+                    if sameSrcDestDutAndAsic:
+                        src_testPortIds = list(set(src_testPortIds) - set(port_list))
+
+            logger.debug(f'updateTestPortIdIp qosParams: {qosParams}')
 
     def check_and_set_ecn_status(self, duthost, qosConfig, expected_status='on'):
         ecn_status = ''
@@ -829,7 +926,8 @@ class TestQosSai(QosSaiBase):
             qosConfig = dutQosConfig["param"][portSpeedCableLength]["breakout"]
         else:
             qosConfig = dutQosConfig["param"][portSpeedCableLength]
-        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig[LosslessVoqProfile])
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts,
+                                portSpeedCableLength, qosConfig[LosslessVoqProfile])
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -916,8 +1014,8 @@ class TestQosSai(QosSaiBase):
         src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
         dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
 
-        if ('platform_asic' in dutTestParams["basicParams"] and
-                dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx") and (dutConfig["dutAsic"] != 'q3d'):
+        if dutTestParams["basicParams"].get("platform_asic") == 'broadcom-dnx' \
+                and get_src_dst_asic_and_duts['src_dut'].facts.get('modular_chassis'):
             # for 100G port speed the number of ports required to fill headroom is huge,
             # hence skipping the test with speed 100G or cable length of 2k
             if portSpeedCableLength not in ['400000_120000m']:
@@ -949,7 +1047,7 @@ class TestQosSai(QosSaiBase):
             'vlan_id' in testPortIps[src_dut_index][src_asic_index][port]
             else None for port in qosConfig["hdrm_pool_size"]["src_port_ids"]]
 
-        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig["hdrm_pool_size"])
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, portSpeedCableLength, qosConfig["hdrm_pool_size"])
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -1147,7 +1245,7 @@ class TestQosSai(QosSaiBase):
                 qosConfig["hdrm_pool_size"]["dst_port_id"] = dutConfig['testPortIds'][dst_dut_index][dst_asic_index][-1]
                 qosConfig["hdrm_pool_size"]["pgs_num"] = 2 * len(qosConfig["hdrm_pool_size"]["src_port_ids"])
 
-        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig["hdrm_pool_size"])
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, portSpeedCableLength, qosConfig["hdrm_pool_size"])
 
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
@@ -1397,7 +1495,7 @@ class TestQosSai(QosSaiBase):
         assert flow_config in ["separate", "shared"], "Invalid flow config '{}'".format(
             flow_config)
 
-        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig[LossyVoq])
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, portSpeedCableLength, qosConfig[LossyVoq])
 
         dst_port_id = dutConfig["testPorts"]["dst_port_id"]
         dst_port_ip = dutConfig["testPorts"]["dst_port_ip"]
@@ -2413,7 +2511,7 @@ class TestQosSai(QosSaiBase):
         else:
             qosConfig = dutQosConfig["param"]
 
-        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig[LossyVoq])
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, portSpeedCableLength, qosConfig[LossyVoq])
 
         src_dut_index = get_src_dst_asic_and_duts['src_dut_index']
         src_asic_index = get_src_dst_asic_and_duts['src_asic_index']

--- a/tests/smartswitch/platform_tests/test_platform_dpu.py
+++ b/tests/smartswitch/platform_tests/test_platform_dpu.py
@@ -218,6 +218,11 @@ def test_dpu_console(duthosts, enum_rand_one_per_hwsku_hostname,
     @summary: To Verify `DPU console access`
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    ignore_regex = [
+        r".*ERR kernel:.*cp210x ttyUSB\d+: failed set request 0x12 status: -110.*",
+    ]
+    if duthost.loganalyzer:
+        duthost.loganalyzer.ignore_regex.extend(ignore_regex)
 
     for index in range(num_dpu_modules):
         dpu_name = module.get_name(platform_api_conn, index)

--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -262,6 +262,10 @@ def verify_rate_limit_with_log_generator(duthost, service_name, log_marker, expe
 
     with loganalyzer:
         duthost.command(run_generator_cmd)
+        # Wait for rsyslogd to forward the rate-limiting notification from the container
+        # to the host syslog. Without this, the notification may arrive after the
+        # LogAnalyzer end marker, causing intermittent test failures.
+        time.sleep(5)
 
 
 def get_host_rsyslogd_pid(duthost):

--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -8,6 +8,7 @@ import re
 from pkg_resources import parse_version
 from tests.common import config_reload
 from tests.common.utilities import wait_until
+from tests.common.mellanox_data import is_mellanox_device
 from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.helpers.thermal_control_test_helper import disable_thermal_policy     # noqa F401
@@ -460,6 +461,11 @@ def get_system_health_config(duthost, key, default):
         cmd = 'cat {}'.format(config_file)
         output = duthost.shell(cmd)
         content = output['stdout'].strip()
+
+        # For mellanox devices, both amber and red are displayed as red in the show system-health summary output
+        if is_mellanox_device(duthost):
+            content = content.replace('amber', 'red')
+
         json_obj = json.loads(content)
         return json_obj[key]
     except Exception:

--- a/tests/voq/test_voq_counter.py
+++ b/tests/voq/test_voq_counter.py
@@ -70,7 +70,7 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     else:
         cmd_bcmcmd_false = "'port enable sfi false'"
         cmd_bcmcmd_true = "'port enable sfi true'"
-        cmd = "show queue counters --voq --nonzero| grep -i 'Ethernet-IB' |grep -i 'VOQ0' |awk '{{print $7}}'"
+        cmd = "show queue counters --voq --nonzero| grep -i 'Ethernet-IB' |grep -i 'VOQ0' |awk '{print $7}'"
         try:
             bcm_changes = True
             for asic in duthost.asics:
@@ -84,7 +84,7 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
                 integers = [int(item.replace(',', '')) for item in out if item.replace(',', '').strip().isdigit()]
                 return any(num > 0 for num in integers)
 
-            pytest_assert(wait_until(300, 0, 0, queue_counter_assertion),
+            pytest_assert(wait_until(300, 5, 0, queue_counter_assertion),
                           "Credit-WD-Del/pkts is not increasing "
                           "Ref: https://github.com/sonic-net/sonic-buildimage/issues/21098")
         finally:

--- a/tests/vxlan/test_vnet_decap.py
+++ b/tests/vxlan/test_vnet_decap.py
@@ -10,7 +10,7 @@ from ptf.mask import Mask
 
 
 pytestmark = [
-    pytest.mark.topology("t1", "t1-64-lag", "t1-56-lag", "t1-lag"),
+    pytest.mark.topology("t0", "t1", "t1-64-lag", "t1-56-lag", "t1-lag"),
     pytest.mark.disable_loganalyzer
 ]
 


### PR DESCRIPTION
```
* 6d3b26032 - [action] [PR:24255] [conditional_mark] Fix IndexError in test_po_voq skip condition when minigraph_portchannels is empty (#24435) (2026-05-11) [mssonicbld]
* f718d29a6 - [action] [PR:24447] Fix flaky test_syslog_rate_limit: wait for rsyslogd rate-limit notification before LogAnalyzer end marker (#24502) (2026-05-11) [mssonicbld]
* 8c45f7cf6 - [action] [PR:24446] Running `test_vnet_decap.py` on T0 topologies (#24486) (2026-05-09) [mssonicbld]
* 8cf25ca91 - [action] [PR:23211] Ignore expected error from DPU conosle minicom session disconnection. (#24487) (2026-05-09) [mssonicbld]
* db5444532 - [action] [PR:24439] [dhcp_relay] fix: kill tcpdump in finally block to prevent memory leak on test failure (#24459) (2026-05-08) [mssonicbld]
* ebb19c8dd - [action] [PR:23944] [voq] Fix test_voq_queue_counter broken awk command on multi-ASIC (#24455) (2026-05-08) [mssonicbld]
* def3b40d5 - [action] [PR:24433] [qos]: Skip warm reboot on TH5 devices in DSCP queue mapping test (#24456) (2026-05-08) [mssonicbld]
* 98c28a696 - [action] [PR:24391] [pfcwd] Fix flaky IPv6 failures due to PTF neigh flush error (#24457) (2026-05-08) [mssonicbld]
* a6c1c7628 - [action] [PR:22876] Fix excessive tcpdump buffer size in dhcp_relay stress tests (#24461) (2026-05-08) [mssonicbld]
* 677263f6e - [action] [PR:23925] Improve DHCP stress test tcpdump reliability (#24463) (2026-05-08) [mssonicbld]
* f2cab8e47 - [202511][cpu_shaper] Fix test for TH5 platforms by capturing pps values befor… (#24451) (2026-05-07) [Priyansh]
* 242cbec9a - [202511][BGP] Fix flaky flap detection in test_bgp_dual_asn_v4 using FRR conn… (#24452) (2026-05-07) [Priyansh]
* 621346b36 - Update 'dash' test skip condition to run on smartswitch HWSKUs (#24344) (2026-05-07) [Copilot]
* ab450f48f - [action] [PR:24424] fix led color issue in mellanox (#24440) (2026-05-08) [mssonicbld]
* 128a79ed8 - [202511] Fix count_file name for test_dhcp_counter_stress.py (#24361) (2026-05-07) [Mark Xiao]
* 2673bcfee - [action] [PR:20822] Xfail tests for ipv6 only topologies. (#23682) (2026-05-07) [mssonicbld]
* 10f508aaa - [202511] Fix ft2 upstream neighbor map to use lt2 instead of ut2 (#24187) (#24411) (2026-05-06) [bingwang-ms]
* a8217a64d - Set missing mirror type for everflow v6 session (#24193) (2026-05-06) [Venu]
* 8cac93d18 - Add PORT_PHY_ATTR_TYPE and PORT_PHY_ATTR (#24381) (2026-05-05) [Sourabh Kumar]
* 07cb1e138 - [202511][conditional_mark] Skip high_frequency_telemetry on T2 topology (#24410) (2026-05-06) [Ze Gan]
* 365d4e778 - 202511 backport PR23962: Fix qos test port re-selection on multi-asic and disagg chassis (#23963) (2026-05-05) [Peter Bailey]
* b458c8c9a - [202511][Cherry-pick of PR23325] Fix QOS tests to run on 64p topo (#23884) (2026-05-04) [arista-nwolfe]
* cd3e3d837 - [202511] Fix KeyError in counterpoll restore by adding missing counter types (#24360) (2026-05-05) [LinJin23]
* c0236c997 - [202511] Fix deploy-l1 error: remove unsupported forced_mgmt_routes from conn_graph_facts (#24371) (2026-05-04) [Dashuai Zhang]
* e3b708baa - [202511] [OCS] Limit the inventory for conn_graph_facts on L1/snappi testbeds (#24294) (#24343) (2026-05-01) [Dashuai Zhang]
* 16fe9f241 - [action] [PR:21061] update watchdog test cfg for nexthop devices (#22247) (2026-05-01) [mssonicbld]
```
