### PR TITLE
Fixing test failures in `test_ecn_config_update.py`

### DIFF
--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -244,9 +244,6 @@ def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, opera
         pytest.skip("All WRED profiles have zero deltas for the requested fields, skipping test.")
 
     json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
-    try:
-        output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
-        expect_op_success(duthost, output)
-        ensure_application_of_updated_config(duthost, fields, new_values)
-    finally:
-        delete_tmpfile(duthost, tmpfile)
+    output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+    expect_op_success(duthost, output)
+    ensure_application_of_updated_config(duthost, fields, new_values)

--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -227,9 +227,6 @@ def test_ecn_config_updates(duthost, ensure_dut_readiness, configdb_field, opera
         if not wred_green_enabled:
             logger.info(f"Not modifying the WRED profile {wred_profile} since 'wred_green_enable' is false.")
         delta = determine_delta_values(ecn_data, fields, wred_green_enabled)
-        if all(delta[f] == 0 for f in fields):
-            logger.info(f"Skipping WRED profile {wred_profile}: all deltas are 0, no real value change possible.")
-            continue
         new_values[wred_profile] = {}
         for field in fields:
             value = int(ecn_data[field])


### PR DESCRIPTION
### What is the motivation for this PR?
Fixing test failures in `test_ecn_config_update.py`.

### How did you do it?
WRED profiles that are not changed by the test (e.g., because `wred_green_enable` is false for them) still appear in ASIC DB. So we should add these profiles to the `new_values` dictionary. I removed the `continue` statement so that these profiles are added to `new_values` for comparison with ASIC DB profiles.

### How did you verify/test it?
Ran the tests on a Broadcom TH5 switch:
```
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_min_threshold] PASSED                                            [ 25%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_max_threshold] PASSED                                            [ 50%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_drop_probability] PASSED                                         [ 75%]
generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates[replace-green_min_threshold,green_max_threshold,green_drop_probability] PASSED [100%]
```