### PR TITLE
[202412 backport] Enforce apply-patch timeout in GCU shared test utility (sonic-mgmt#23848)

### DIFF
--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -2,7 +2,6 @@ import json
 import logging
 import pytest
 import os
-import time
 import re
 from jsonpointer import JsonPointer
 from tests.common.helpers.assertions import pytest_assert
@@ -127,13 +126,30 @@ def apply_patch(duthost, json_data, dest_file):
     cmds = 'config apply-patch {}'.format(dest_file)
 
     logger.info("Commands: {}".format(cmds))
-    start_time = time.time()
-    output = duthost.shell(cmds, module_ignore_errors=True)
-    elapsed_time = time.time() - start_time
     gcu_timeout = get_gcu_timeout(duthost)
-    if elapsed_time > gcu_timeout:
-        logger.error("Command took too long: {} seconds".format(elapsed_time))
-        raise TimeoutError("Command execution timeout: {} seconds".format(elapsed_time))
+
+    # Run the command asynchronously so we can poll for completion and
+    # time out without blocking the test runner indefinitely.  This
+    # uses wait_until (the standard polling helper used across the repo)
+    # instead of an ad-hoc bash 'timeout' wrapper, giving us periodic
+    # logging and Python-level control over the thread.
+    pool, async_result = duthost.shell(cmds, module_ignore_errors=True,
+                                       module_async=True)
+    try:
+        completed = wait_until(gcu_timeout, 10, 0,
+                               lambda: async_result.ready())
+        if not completed:
+            logger.error("apply-patch did not complete within {} seconds, "
+                         "terminating".format(gcu_timeout))
+            raise TimeoutError(
+                "Command execution timeout: {} seconds".format(gcu_timeout))
+
+        # .get() returns the result on success or re-raises the
+        # original exception from the worker thread on failure.
+        output = async_result.get()
+    finally:
+        pool.terminate()
+        pool.join()
 
     return output
 
@@ -643,4 +659,9 @@ def get_bgp_speaker_runningconfig(duthost):
 
 
 def get_gcu_timeout(duthost):
+    """Return the GCU apply-patch timeout (in seconds) for this platform.
+
+    Platforms listed in GCUTIMEOUT_MAP get a custom value; everything
+    else defaults to 600 s.
+    """
     return GCUTIMEOUT_MAP.get(duthost.facts['platform'], 600)


### PR DESCRIPTION
# [202412 backport] Enforce apply-patch timeout in GCU shared test utility

Backport of upstream sonic-net/sonic-mgmt#23848 (merged 2026-04-30, commit `ae9ac39b`) to `Azure/sonic-mgmt.msft:202412`.

## Why

`apply_patch()` in `tests/common/gu_utils.py` is the shared helper used by ~35 test files across `tests/generic_config_updater/` and `tests/bgp/`. The original implementation measured elapsed time *after* `duthost.shell()` returned synchronously - a hung GCU would block the test runner indefinitely with no mechanism to pre-empt it.

This is the framework prerequisite for the GCU performance smoke test backport (sibling PR for sonic-mgmt#24092) - that test is specifically designed to catch GCU sort-step regressions, so without effective timeout enforcement a real regression would hang nightly CI rather than failing cleanly.

## What

Single-file change. `apply_patch()` now runs the shell command via `module_async=True` + `wait_until()` polling, then `pool.terminate()` / `pool.join()` in a `finally` block to guarantee cleanup. `async_result.get()` returns the same Ansible result dict (rc, stdout, stderr) as the synchronous form, so all ~35 callers (expect_op_success, expect_op_failure, direct rc checks) are fully compatible.

Platform timeouts are unchanged: Nokia IXS7215 = 1200 s, Nvidia SN5640 = 3600 s, default = 600 s (via the existing GCUTIMEOUT_MAP).

## Cherry-pick provenance

- Upstream PR: https://github.com/sonic-net/sonic-mgmt/pull/23848
- Upstream merge SHA: `ae9ac39b329bfee17589e6cbae6ace19e9454125`
- Diff size on 202412: identical to upstream (+28/-7, single file)
- Conflicts: none - `wait_until` import already present, all context lines matched

## Validation

- Pre-cherry-pick drift analysis: gu_utils.py on 202412 is within 1.4% of the upstream parent it was applied against (314 byte difference); every removed/context line in the patch was verified present on 202412 before cherry-pick.
- Post-cherry-pick: zero conflict markers, async pattern landed at the expected call site, old start_time / elapsed_time lines fully removed.

## Backport ordering

This PR is prerequisite #1 of two for delivering 202412 GCU smoke-test coverage. The sibling PR (cherry-pick of sonic-mgmt#24092) adds the actual performance smoke test that consumes this timeout-enforced helper, and should land after this PR.
