### PR TITLE
[Nokia-IXR7220-H6-O256] Increase frr_bgp memory high threshold to 512 MB

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -317,5 +317,25 @@
       },
       "memory_check": "parse_docker_stats_output"
     }
+  ],
+  "Nokia-IXR7220": [
+    {
+      "name": "frr_bgp",
+      "cmd": "vtysh -c \"show memory bgp\"",
+      "memory_params": {
+        "used": {
+          "memory_increase_threshold": [
+            {"type": "percentage", "value": "50%"},
+            {"type": "value", "value": 64},
+            {"type": "comparison", "value": "max"}
+          ],
+          "memory_high_threshold": {
+            "type": "value",
+            "value": 512
+          }
+        }
+      },
+      "memory_check": "parse_frr_memory_output"
+    }
   ]
 }


### PR DESCRIPTION
### Description of PR
Summary:
Cherry-pick of sonic-net/sonic-mgmt#24953 to 202512 branch.

Nokia-IXR7220-H6-O256 has 256 ports and significantly more BGP sessions than other variants, resulting in higher FRR BGP memory usage. Observed steady-state usage is ~368 MB with peaks up to ~389 MB. Raise the `memory_high_threshold` from 384 MB to 512 MB to avoid false alarms.

Note: Applied manually (not a clean cherry-pick) because the upstream commit also included platform entries for Cisco-C8220TG and Mellanox-SN6600 which are not yet present in 202512. Only the Nokia-IXR7220 change is included here.

### Type of change
- [x] Bug fix

### Approach
#### What is the motivation for this PR?
The Nokia-IXR7220-H6-O256 (256-port variant) has significantly more BGP sessions than other IXR7220 variants, leading to higher steady-state FRR BGP memory (~368 MB, peaks ~389 MB). The previous threshold of 384 MB was too low and caused false alarms.

#### How did you do it?
Added a Nokia-IXR7220 platform entry in `memory_utilization_dependence.json` with `memory_high_threshold` set to 512 MB.

#### How did you verify/test it?
Verified in sonic-net/sonic-mgmt#24953.

#### Any platform specific information?
Nokia-IXR7220-H6-O256 (256-port variant)

#### Supported testbed topology if it is a new test case?
N/A

### Documentation