### PR TITLE
[code sync] Merge code from sonic-net/sonic-mgmt:202511 to 202603

### DIFF
--- a/ansible/golden_config_db/smartswitch_dpu_extra.json
+++ b/ansible/golden_config_db/smartswitch_dpu_extra.json
@@ -9,6 +9,9 @@
         }
     },
     "FEATURE": {
+        "acms": {
+            "state": "disabled"
+        },
         "lldp": {
             "state": "disabled"
         },

--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -7,7 +7,7 @@ ansible_altpassword: YourPaSsWoRd
 
 sonic_version: "v2"
 
-broadcom_hwskus: [ 'ACS-S6000', 'ACS-S6000-Q24S32', 'ACS-N3132', 'Force10-S6000', 'Force10-S6000-Q24S32', 'Nexus-3132-GE-Q32', 'Nexus-3132-GX-Q32', 'Arista-7050-QX32', 'Arista-7050-QX-32S', 'Force10-S6100', 'Accton-AS7712-32X', 'Arista-7260CX3-D108C8',  'Arista-7260CX3-C64', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-C32-T1', 'Arista-7060CX-32S-D48C8', 'Celestica-DX010-C32', 'Celestica-E1031-T48S4', "Seastone-DX010", 'Arista-7260CX3-Q64' ]
+broadcom_hwskus: [ 'ACS-S6000', 'ACS-S6000-Q24S32', 'ACS-N3132', 'Force10-S6000', 'Force10-S6000-Q24S32', 'Nexus-3132-GE-Q32', 'Nexus-3132-GX-Q32', 'Arista-7050-QX32', 'Arista-7050-QX-32S', 'Force10-S6100', 'Accton-AS7712-32X', 'Arista-7260CX3-D108C8',  'Arista-7260CX3-C64', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-C32-T1', 'Arista-7060CX-32S-D48C8', 'Celestica-DX010-C32', 'Celestica-E1031-T48S4', "Seastone-DX010", 'Arista-7260CX3-Q64' , 'Juniper-QFX5241-64-OD']
 
 broadcom_td2_hwskus: ['Force10-S6000', 'Force10-S6000-Q24S32', 'Arista-7050-QX32', 'Arista-7050-QX-32S', 'Nexus-3164', 'Arista-7050QX32S-Q32']
 broadcom_td3_hwskus: ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32S-S128', 'Arista-7050CX3-32S-C6S104', 'Arista-7050CX3-32S-C28S16',
@@ -17,7 +17,7 @@ broadcom_th_hwskus: ['Force10-S6100', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32
 broadcom_th2_hwskus: ['Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Arista-7260CX3-C64', 'Arista-7260CX3-Q64']
 broadcom_th3_hwskus: ['DellEMC-Z9332f-M-O16C64',  'DellEMC-Z9332f-O32']
 broadcom_th4_hwskus: ['Arista-7060DX5-32', 'Arista-7060DX5-64S']
-broadcom_th5_hwskus: ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16', 'Arista-7060X6-16PE-384C-O128S2', 'NH-4010', 'Arista-7060X6-64PE-P32O64', 'Arista-7060X6-64PE-P64', 'Arista-7060X6-16PE-384C-B-O128S2', 'Arista-7060X6-16PE-384C-B-O128S2-LAB', 'Arista-7060X6-16PE-384C-B-O128S2-COPPER-LAB', 'Arista-7060X6-64PE-B-O128', 'Arista-7060X6-64PE-B-P32O64', 'Arista-7060X6-64PE-B-P32V128']
+broadcom_th5_hwskus: ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16', 'Arista-7060X6-16PE-384C-O128S2', 'NH-4010', 'Arista-7060X6-64PE-P32O64', 'Arista-7060X6-64PE-P64', 'Arista-7060X6-16PE-384C-B-O128S2', 'Arista-7060X6-16PE-384C-B-O128S2-LAB', 'Arista-7060X6-16PE-384C-B-O128S2-COPPER-LAB', 'Arista-7060X6-64PE-B-O128', 'Arista-7060X6-64PE-B-P32O64', 'Arista-7060X6-64PE-B-P32V128', 'Juniper-QFX5241-64-OD']
 broadcom_j2c+_hwskus: ['Nokia-IXR7250E-36x100G', 'Nokia-IXR7250E-36x400G', 'Arista-7280DR3A-36', 'Arista-7280DR3AK-36', 'Arista-7280DR3AK-36S', 'Arista-7280DR3AM-36', 'Arista-7800R3A-36DM2-C36', 'Arista-7800R3A-36DM2-D36', 'Arista-7800R3AK-36DM2-C36', 'Arista-7800R3AK-36DM2-D36', 'Nokia-IXR7250-X3B']
 
 broadcom_jr2_hwskus: ['Arista-7800R3-48CQ2-C48', 'Arista-7800R3-48CQM2-C48']

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1789,8 +1789,6 @@ class TestMultiBindingAcl(TestBasicAcl):
 
     def setup_rules(self, dut, acl_table, ip_version, tbinfo, gnmi_connection):
         """Setup ACL rules for multi-binding ACL testing."""
-        if 'dualtor' not in tbinfo['topo']['name']:
-            pytest.skip("Not a dual-tor testbed")
 
         dut.host.options["variable_manager"].extra_vars.update(
             {"dualtor": True})

--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -519,18 +519,20 @@ def expect_acl_table_match_multiple_bindings(duthost,
 
             first_line = output[0]
             first_line_diff = set(first_line.values()) ^ set(expected_first_line_content)
-            pytest_assert(set(first_line.values()) == set(expected_first_line_content),
-                          "First line content does not match. Difference: {}".format(first_line_diff))
+            if not set(first_line.values()) == set(expected_first_line_content):
+                logger.warning(f"First line content does not match. Difference: {first_line_diff}")
+                return False
 
             table_bindings = [first_line["binding"]]
             for i in range(len(output)):
                 table_bindings.append(output[i]["binding"])
             table_bindings_diff = set(table_bindings) ^ set(expected_bindings)
-            pytest_assert(set(table_bindings) == set(expected_bindings),
-                          "ACL Table bindings don't fully match. Difference: {}".format(table_bindings_diff))
+            if not set(table_bindings) == set(expected_bindings):
+                logger.warning(f"ACL Table bindings don't fully match. Difference: {table_bindings_diff}")
+                return False
             return True
 
-        wait_until(30, 5, 0, check_table)
+        pytest_assert(wait_until(30, 5, 0, check_table), "ACL table does not contain expected bindings")
 
 
 def expect_acl_rule_match(duthost, rulename, expected_content_list, setup):

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -82,6 +82,12 @@ acl/test_acl.py:
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
 
+acl/test_acl.py::TestMultiBindingAcl:
+  skip:
+    reason: "MultiBinding only supports dualtor topo"
+    conditions:
+      - "'dualtor' not in topo_name"
+
 acl/test_acl_outer_vlan.py:
   #Outer VLAN id match support is planned for future release with SONIC on Cisco 8000
   #For the current release, will mark the related test cases as XFAIL

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3191,9 +3191,11 @@ ipfwd/test_mtu.py:
 
 ipfwd/test_nhop_group.py::test_nhop_group_interface_flap:
   xfail:
-    reason: "Testcase ignored due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/16218 on mellanox platform"
+    reason: "Testcase ignored due to GitHub issue https://github.com/sonic-net/sonic-mgmt/issues/16218 on mellanox platform or IPv6-only issue https://github.com/sonic-net/sonic-mgmt/issues/20731"
+    conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/16218 and asic_type in ['mellanox']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20731 and '-v6-' in topo_name"
 
 ipfwd/test_nhop_group.py::test_nhop_group_member_count:
   xfail:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5305,6 +5305,12 @@ vxlan/test_vxlan_decap.py:
     conditions:
       - "topo_name in ['t0-isolated-d16u16s1','t0-isolated-d32u32s2'] and https://github.com/sonic-net/sonic-buildimage/issues/22056"
 
+vxlan/test_vxlan_decap_ttl.py:
+  skip:
+    reason: "VxLAN tunnel TTL decap mode test is not supported on multi-ASIC platform. Also this test can only run and currently passes only on some platforms."
+    conditions:
+      - "(is_multi_asic == True) or (platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0'])"
+
 vxlan/test_vxlan_ecmp.py:
   skip:
     reason: "VxLAN ECMP test is not yet supported on multi-ASIC platform. Also this test can only run on some platforms."

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -323,7 +323,7 @@ def check_bgp(duthosts, tbinfo):
         if (check_result['failed']):
             # try restart bgp and verify again
             _restart_bgp(dut)
-            wait_until(60, interval, 0, _check_bgp_status_helper)
+            wait_until(300, interval, 0, _check_bgp_status_helper)
             if (check_result['failed']):
                 for a_result in list(check_result.keys()):
                     if a_result != 'failed':

--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1481,6 +1481,85 @@ def get_pfcQueueGroupSize(default=8):
     return default
 
 
+def get_queue_scheduler_weight_dict(host_ans, asic_value=None, port=None,
+                                    qos_map_profile=None):
+    """
+    Build a per-queue scheduler/weight map for an interface by joining the
+    ``QUEUE`` and ``SCHEDULER`` config-DB tables, and optionally annotating
+    each queue with one of its DSCP values via ``DSCP_TO_TC_MAP`` and
+    ``TC_TO_QUEUE_MAP``.
+
+    Args:
+        host_ans: Ansible host instance of the device.
+        asic_value: asic namespace; pass ``None`` (default) or the string
+            ``"None"`` for single-asic devices.
+        port (str, optional): interface name to read ``QUEUE`` for. Defaults
+            to the first interface present in ``QUEUE``.
+        qos_map_profile (str, optional): name of the profile inside
+            ``DSCP_TO_TC_MAP`` / ``TC_TO_QUEUE_MAP`` to use for the ``dscp``
+            field. Defaults to the first profile (typically ``"AZURE"``).
+            If the maps are missing, ``dscp`` is set to ``None``.
+
+    Returns:
+        dict[int, dict]: ``{queue: {"scheduler": <name>, "type": <DWRR/...>,
+        "weight": <int>, "dscp": <int|None>}}``. The result always covers
+        queues 0-7; any queue not present in the per-port ``QUEUE`` config
+        (or whose scheduler is missing from ``SCHEDULER``) falls back to a
+        default entry with equal DWRR weight 15.
+    """
+    if asic_value in (None, "None"):
+        config_facts = host_ans.config_facts(host=host_ans.hostname,
+                                             source="running")["ansible_facts"]
+    else:
+        config_facts = host_ans.config_facts(host=host_ans.hostname,
+                                             source="running",
+                                             namespace=asic_value)["ansible_facts"]
+
+    queue_cfg_all = config_facts.get("QUEUE") or {}
+    scheduler_cfg = config_facts.get("SCHEDULER") or {}
+
+    dscp_to_tc = config_facts.get("DSCP_TO_TC_MAP") or {}
+    tc_to_queue = config_facts.get("TC_TO_QUEUE_MAP") or {}
+    if qos_map_profile is None and dscp_to_tc:
+        qos_map_profile = next(iter(dscp_to_tc))
+    dscp_to_tc_map = dscp_to_tc.get(qos_map_profile, {}) if qos_map_profile else {}
+    tc_to_queue_map = tc_to_queue.get(qos_map_profile, {}) if qos_map_profile else {}
+
+    queue_to_dscp = {}
+    for dscp, tc in dscp_to_tc_map.items():
+        q = tc_to_queue_map.get(str(tc))
+        if q is not None:
+            queue_to_dscp.setdefault(int(q), int(dscp))
+
+    # default entry with equal DWRR weight 15
+    result = {
+        q: {"scheduler": None, "type": "DWRR", "weight": 15,
+            "dscp": queue_to_dscp.get(q)}
+        for q in range(8)
+    }
+
+    if not queue_cfg_all:
+        return result
+
+    if port is None:
+        port = next(iter(queue_cfg_all))
+    if port not in queue_cfg_all:
+        raise KeyError("Port {} not found in QUEUE config (available: {})".format(port, sorted(queue_cfg_all)))
+
+    for q, value in queue_cfg_all[port].items():
+        scheduler = value.get("scheduler")
+        if scheduler is None or scheduler not in scheduler_cfg:
+            continue
+        sched = scheduler_cfg[scheduler]
+        result[int(q)] = {
+            "scheduler": scheduler,
+            "type": sched.get("type"),
+            "weight": int(sched["weight"]),
+            "dscp": queue_to_dscp.get(int(q)),
+        }
+    return result
+
+
 @lru_cache
 def get_testbed_from_args():
     parser = ArgumentParser()

--- a/tests/common/unit_tests/snappi_tests/README.md
+++ b/tests/common/unit_tests/snappi_tests/README.md
@@ -1,0 +1,48 @@
+# Unit Tests for `tests/common/snappi_tests/`
+
+This directory contains unit tests for modules under
+`tests/common/snappi_tests/`.
+
+## Running Unit Tests
+
+### Run all unit tests in this directory
+```bash
+# From repository root
+python3 -m pytest --noconftest tests/common/unit_tests/snappi_tests/ -v
+```
+
+### Run a specific test file
+```bash
+python3 -m pytest --noconftest \
+  tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py -v
+```
+
+### Run a specific test case
+```bash
+python3 -m pytest --noconftest \
+  tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py::test_get_queue_scheduler_weight_dict \
+  -v
+```
+
+## Why `--noconftest`
+
+`tests/conftest.py` pulls in integration-test dependencies (for example,
+`paramiko`) that are not needed for these isolated unit tests. Using
+`--noconftest` keeps the run lightweight and avoids unrelated import
+failures.
+
+The target module `tests/common/snappi_tests/common_helpers.py` itself
+imports heavy dependencies (`tests.conftest`, `ipaddr`, mellanox helpers,
+etc.) at import time. To stay dependency-free, the unit tests load only the
+function under test by parsing the source with `ast` and `exec`-ing the
+single function definition in an isolated namespace. No real DUT, Ansible
+inventory, or Snappi environment is required.
+
+If your environment has the full sonic-mgmt test dependencies installed and
+you intentionally want global fixtures, you can remove `--noconftest`.
+
+## Requirements
+
+- Python 3
+- `pytest`
+- `unittest.mock` (built into Python standard library)

--- a/tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py
+++ b/tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py
@@ -1,0 +1,111 @@
+"""Unit test for ``get_queue_scheduler_weight_dict`` in
+``tests/common/snappi_tests/common_helpers.py``.
+
+The target module imports heavy sonic-mgmt deps at import time, so we
+extract the function under test via ``ast`` and exec it in an isolated
+namespace.
+
+Run with::
+
+    python3 -m pytest --noconftest \\
+        tests/common/unit_tests/snappi_tests/unit_test_common_helpers.py -v
+"""
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+MODULE_PATH = (Path(__file__).resolve().parents[3] /
+               "common/snappi_tests/common_helpers.py")
+
+
+def _load(name):
+    tree = ast.parse(MODULE_PATH.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            ns = {}
+            exec(compile(ast.Module(body=[node], type_ignores=[]),
+                         str(MODULE_PATH), "exec"), ns)
+            return ns[name]
+    raise LookupError(name)
+
+
+# Minimal config_facts modeling the str-msn2700-22 (Mellanox-SN2700) DUT,
+# trimmed to the keys read by ``get_queue_scheduler_weight_dict``:
+#   scheduler.0 -> lossy queues, DWRR weight 14
+#   scheduler.1 -> lossless queues 3 & 4, DWRR weight 15
+CONFIG_FACTS = {
+    "QUEUE": {
+        "Ethernet100": {
+            "0": {"scheduler": "scheduler.0"},
+            "1": {"scheduler": "scheduler.0"},
+            "2": {"scheduler": "scheduler.0"},
+            "3": {"scheduler": "scheduler.1",
+                  "wred_profile": "AZURE_LOSSLESS"},
+            "4": {"scheduler": "scheduler.1",
+                  "wred_profile": "AZURE_LOSSLESS"},
+            "5": {"scheduler": "scheduler.0"},
+            "6": {"scheduler": "scheduler.0"},
+        },
+    },
+    "SCHEDULER": {
+        "scheduler.0": {"type": "DWRR", "weight": "14"},
+        "scheduler.1": {"type": "DWRR", "weight": "15"},
+    },
+    "DSCP_TO_TC_MAP": {
+        "AZURE": {
+            "0": "1", "1": "1", "10": "1", "11": "1", "12": "1", "13": "1",
+            "14": "1", "15": "1", "16": "1", "17": "1", "18": "1", "19": "1",
+            "2": "1", "20": "1", "21": "1", "22": "1", "23": "1", "24": "1",
+            "25": "1", "26": "1", "27": "1", "28": "1", "29": "1", "3": "3",
+            "30": "1", "31": "1", "32": "1", "33": "1", "34": "1", "35": "1",
+            "36": "1", "37": "1", "38": "1", "39": "1", "4": "4", "40": "1",
+            "41": "1", "42": "1", "43": "1", "44": "1", "45": "1", "46": "5",
+            "47": "1", "48": "6", "49": "1", "5": "2", "50": "1", "51": "1",
+            "52": "1", "53": "1", "54": "1", "55": "1", "56": "1", "57": "1",
+            "58": "1", "59": "1", "6": "1", "60": "1", "61": "1", "62": "1",
+            "63": "1", "7": "1", "8": "0", "9": "1",
+        },
+    },
+    "TC_TO_QUEUE_MAP": {
+        "AZURE": {str(i): str(i) for i in range(8)},
+    },
+}
+
+EXPECTED = {
+    0: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 8},
+    1: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 0},
+    2: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 5},
+    3: {"scheduler": "scheduler.1", "type": "DWRR", "weight": 15, "dscp": 3},
+    4: {"scheduler": "scheduler.1", "type": "DWRR", "weight": 15, "dscp": 4},
+    5: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 46},
+    6: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 48},
+    # Queue 7 is not in the per-port QUEUE config; falls back to default.
+    7: {"scheduler": None, "type": "DWRR", "weight": 15, "dscp": None},
+}
+
+
+def test_get_queue_scheduler_weight_dict():
+    host = MagicMock()
+    host.hostname = "test_dut"
+    host.config_facts.return_value = {"ansible_facts": CONFIG_FACTS}
+
+    assert _load("get_queue_scheduler_weight_dict")(host) == EXPECTED
+
+
+def test_get_queue_scheduler_weight_dict_defaults_when_unconfigured():
+    """When QUEUE/SCHEDULER are absent, fall back to 8 queues w/ equal weights."""
+    host = MagicMock()
+    host.hostname = "test_dut"
+    facts = {k: v for k, v in CONFIG_FACTS.items()
+             if k not in ("QUEUE", "SCHEDULER")}
+    host.config_facts.return_value = {"ansible_facts": facts}
+
+    result = _load("get_queue_scheduler_weight_dict")(host)
+    assert set(result) == set(range(8))
+    assert {v["weight"] for v in result.values()} == {15}
+    assert {v["type"] for v in result.values()} == {"DWRR"}
+    # DSCP annotations from DSCP_TO_TC_MAP / TC_TO_QUEUE_MAP still apply.
+    assert result[0]["dscp"] == 8
+    assert result[3]["dscp"] == 3

--- a/tests/common/vxlan_ecmp_utils.py
+++ b/tests/common/vxlan_ecmp_utils.py
@@ -54,7 +54,8 @@ class Ecmp_Utils(object):
                             minigraph_data,
                             af,
                             tunnel_name=None,
-                            src_ip=None):
+                            src_ip=None,
+                            ttl_mode=None):
         '''
             Function to create a vxlan tunnel. The arguments:
                 duthost       : The DUT ansible host object.
@@ -64,6 +65,7 @@ class Ecmp_Utils(object):
                                 local ip address in the DUT. Default: Loopback
                                 ip address.
                 af : Address family : v4 or v6.
+                ttl_mode      : Decap TTL mode. Can be set to "pipe" or "uniform".
         '''
         if tunnel_name is None:
             tunnel_name = "tunnel_{}".format(af)
@@ -71,13 +73,17 @@ class Ecmp_Utils(object):
         if src_ip is None:
             src_ip = self.get_dut_loopback_address(duthost, minigraph_data, af)
 
+        ttl_entry = ""
+        if ttl_mode:
+            ttl_entry = f',\n"ttl_mode": "{ttl_mode}"\n'
+
         config = '''{{
             "VXLAN_TUNNEL": {{
                 "{}": {{
-                    "src_ip": "{}"
+                    "src_ip": "{}"{}
                 }}
             }}
-        }}'''.format(tunnel_name, src_ip)
+        }}'''.format(tunnel_name, src_ip, ttl_entry)
 
         self.apply_config_in_dut(duthost, config, name="vxlan_tunnel_" + af)
         return tunnel_name

--- a/tests/cpu_shaper/test_cpu_shaper.py
+++ b/tests/cpu_shaper/test_cpu_shaper.py
@@ -13,6 +13,7 @@ import re
 from tests.common import config_reload
 from tests.common.reboot import reboot
 from tests.common.platform.processes_utils import wait_critical_processes
+from tests.common.utilities import wait_until
 
 pytestmark = [
     pytest.mark.topology("t0", "t1"),
@@ -60,16 +61,25 @@ def test_cpu_queue_shaper(duthosts, localhost, enum_rand_one_per_hwsku_frontend_
     shaper values before and after reboot.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+
+    def cos_queues_present():
+        before_pps = get_cpu_queue_shaper(duthost)
+        missing = EXPECTED_COS_QUEUES - set(before_pps.keys())
+        return not bool(missing)
+
     try:
         reboot_type = request.config.getoption("--cpu_shaper_reboot_type")
+
+        # Validate all expected queues are present with non-zero shaper values
+        if not wait_until(300, 10, 1, cos_queues_present):
+            before_pps = get_cpu_queue_shaper(duthost)
+            missing = EXPECTED_COS_QUEUES - set(before_pps.keys())
+            assert False, f"CPU queue shaper missing for cos queues {missing} before reboot. Got: {before_pps}"
+
         # Read shaper config before reboot
         before_pps = get_cpu_queue_shaper(duthost)
         logger.info("CPU queue shaper before reboot: {}".format(before_pps))
 
-        # Validate all expected queues are present with non-zero shaper values
-        missing = EXPECTED_COS_QUEUES - set(before_pps.keys())
-        assert not missing, \
-            "CPU queue shaper missing for cos queues {} before reboot. Got: {}".format(missing, before_pps)
         assert all(before_pps[cos] > 0 for cos in EXPECTED_COS_QUEUES), \
             "CPU queue shaper has zero PPS before reboot: {}".format(before_pps)
         # Validate shaper values are close to original 600 PPS (allowing 5% tolerance)
@@ -86,14 +96,13 @@ def test_cpu_queue_shaper(duthosts, localhost, enum_rand_one_per_hwsku_frontend_
         # Wait for critical processes to be up
         wait_critical_processes(duthost)
 
-        # Read shaper config after reboot
-        after_pps = get_cpu_queue_shaper(duthost)
-        logger.info("CPU queue shaper after {} reboot: {}".format(reboot_type, after_pps))
-
         # Verify shaper config survived reboot unchanged
-        assert before_pps == after_pps, \
-            "CPU queue shaper changed after {} reboot: before={}, after={}".format(
-                reboot_type, before_pps, after_pps)
+        assert wait_until(300, 10, 1, lambda: get_cpu_queue_shaper(duthost) == before_pps), (
+                "CPU queue shaper changed after {} reboot: before={}, after={}".format(
+                    reboot_type, before_pps, get_cpu_queue_shaper(duthost)))
+
+        # Read shaper config after reboot
+        logger.info("CPU queue shaper after {} reboot: {}".format(reboot_type, get_cpu_queue_shaper(duthost)))
 
     finally:
         duthost.shell("rm -f {}/{}".format(DEST_DIR, BCM_CINT_FILENAME))

--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -337,6 +337,12 @@ def validate_asic_route(duthost, route, exist=True):
         return exist is False
 
 
+def is_high_scale_platform(duthost) -> bool:
+    interfaces_status = duthost.sonichost.get_interfaces_status()
+    number_of_interfaces = len(interfaces_status.keys())
+    return number_of_interfaces >= 128
+
+
 def test_nhop_group_member_count(duthost, tbinfo, loganalyzer):
     """
     Test next hop group resource count. Steps:
@@ -365,6 +371,10 @@ def test_nhop_group_member_count(duthost, tbinfo, loganalyzer):
         default_max_nhop_paths = 8
         polling_interval = 10
         sleep_time = 120
+    elif is_high_scale_platform(duthost):
+        default_max_nhop_paths = 32
+        polling_interval = 10
+        sleep_time = 380
     else:
         default_max_nhop_paths = 32
         polling_interval = 10
@@ -448,7 +458,7 @@ def test_nhop_group_member_count(duthost, tbinfo, loganalyzer):
 
     # verify the test used up all the NHOP group resources
     # skip this check on Mellanox as ASIC resources are shared
-    if is_cisco_device(duthost) or "7060X6" in duthost.sonichost.get_facts()['platform'].upper():
+    if is_cisco_device(duthost) or is_high_scale_platform(duthost):
         pytest_assert(
             crm_after["available_nhop_grp"] + nhop_group_count == crm_before["available_nhop_grp"],
             "Unused NHOP group resource:{}, used:{}, nhop_group_count:{}, Unused NHOP group resource before:{}".format(

--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -40,11 +40,27 @@ def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loga
         r".*tac_connect_single: .*",
         r".*nss_tacplus: .*",
     ]
+    # On cisco-8000 platforms (e.g. Cisco-8101), the test teardown path that restores
+    # LAG / port-channel members re-binds cached QoS TC->Queue map and PFC settings
+    # on the affected ports. The underlying SAI objects can be recreated during the
+    # test, leaving orchagent with stale OIDs. The re-bind then fails in syncd with
+    # SAI_STATUS_ITEM_NOT_FOUND and orchagent logs ERR for handlePortQosMapTable /
+    # setPortPfc. The test itself passes; only loganalyzer flags these as failures.
+    Cisco8000IgnoreRegex = [
+        r".*sendApiResponse: api SAI_COMMON_API_SET failed in syncd mode: SAI_STATUS_ITEM_NOT_FOUND.*",
+        r".*processQuadEvent: VID: oid:0x[0-9a-f]+ RID: oid:0x[0-9a-f]+.*",
+        r".*processQuadEvent: attr: SAI_PORT_ATTR_QOS_TC_TO_QUEUE_MAP: oid:0x[0-9a-f]+.*",
+        r".*processQuadEvent: attr: SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL: \d+.*",
+        r".*handlePortQosMapTable: Failed to apply \S+ to port Ethernet\d+, rv:-7.*",
+        r".*setPortPfc: Failed to set PFC 0x[0-9a-f]+ to port id 0x[0-9a-f]+ \(rc:-7\).*",
+    ]
     duthost = duthosts[rand_one_dut_hostname]
     if loganalyzer:  # Skip if loganalyzer is disabled
         loganalyzer[duthost.hostname].ignore_regex.extend(TacacsIgnoreRegex)
         if duthost.facts["asic_type"] == "vs":
             loganalyzer[duthost.hostname].ignore_regex.extend(KVMIgnoreRegex)
+        if duthost.facts["asic_type"] == "cisco-8000":
+            loganalyzer[duthost.hostname].ignore_regex.extend(Cisco8000IgnoreRegex)
 
 
 @pytest.fixture(scope='function', autouse=True)

--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -318,7 +318,7 @@ def install_route_from_exabgp(operation, ptfip, route, port):
     """
     route_data = [route]
     url = "http://{}:{}".format(ptfip, port)
-    command = "{} attribute next-hop self nlri {}".format(operation, ' '.join(route_data))
+    command = "{} attributes next-hop self nlri {}".format(operation, ' '.join(route_data))
     data = {"command": command}
     logger.info("url: {}".format(url))
     logger.info("command: {}".format(data))

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2971,29 +2971,45 @@ class QosSaiBase(QosBase):
     @pytest.fixture(scope="function", autouse=False)
     def permit_only_test_traffic_on_fanout(
             self, get_src_dst_asic_and_duts, tbinfo,
-            nbrhosts, dutConfig, fanouthosts,
+            nbrhosts, dutConfig, dutQosConfig, fanouthosts,
             conn_graph_facts, request):
         """
         Block non-test L2 traffic from reaching DUT ingress ports during QoS
         headroom pool tests to prevent false InDiscard counter increments.
 
-        Configures the EOS fanout switch to only forward IP/IPv6/ARP frames
-        toward the DUT, blocking LLDP (0x88CC), LACP (0x8809), and other
-        non-test ethertypes via an egress MAC ACL whitelist.
+        Configures the fanout switch to suppress noise reaching the DUT:
+        - on EOS via an egress MAC ACL whitelist (permit IP/IPv6/ARP, deny
+          all other ethertypes incl. LLDP 0x88CC, LACP 0x8809) plus
+          ``no lldp transmit/receive`` per interface;
+        - on SONiC via stopping the LLDP container only (partial coverage —
+          full L2 ACL filtering is tracked in #24236, see
+          ``_apply_sonic_filter`` for limitations).
 
         Steps:
         1. Stop DUT teamd lacpd (prevents LACP timeout detection)
         2. Set EOS neighbor LACP timer multiplier to 600 (prevents EOS-side timeout)
-        3. Disable LLDP TX/RX + apply egress MAC ACL on fanout DUT-facing ports
+        3. Per-fanout: dispatch by fanout OS to apply the appropriate filter
+
+        Fanout dispatch:
+        - EOS fanout: egress MAC ACL + ``no lldp transmit/receive`` per interface
+        - SONiC fanout: stop LLDP container only (LLDP-stop-only, partial
+          coverage — see ``_apply_sonic_filter`` for limitations and
+          tracked issue #24236)
 
         Note on change_lag_lacp_timer interaction: that fixture only activates
         for broadcom-dnx platforms and operates on dst_port LAGs. This fixture
         operates on src_port LAGs for Broadcom TH (7060CX), so there is no
         overlap on the affected platform.
 
-        Note: Currently supports EOS fanout only. SONiC fanout support is
-        tracked in issue #24236.
+        Note on broadcom-dnx port mismatch: ``testQosSaiHeadroomPoolSize`` /
+        ``testQosSaiHeadroomPoolWatermark`` override ``hdrm_pool_size`` at
+        runtime on broadcom-dnx (non-q3d) platforms with a slice of
+        ``testPortIds``. We pre-emptively include the ``testPortIds`` candidate
+        pool below to cover that case. See issue #24236.
         """
+        # Skip when neighbors are SONiC: this fixture's LACP-multiplier path is
+        # EOS-only, and physical fanout config does not apply to KVM/virtual
+        # topologies which are the typical --neighbor_type=sonic scenario.
         if request.config.getoption("--neighbor_type") == "sonic":
             yield
             return
@@ -3002,15 +3018,47 @@ class QosSaiBase(QosBase):
         src_asic = get_src_dst_asic_and_duts['src_asic']
         src_mgfacts = src_dut.get_extended_minigraph_facts(tbinfo)
 
-        # Protect ALL test ports from noise. The actual src_port_ids used by PTF
-        # come from qos.yml hdrm_pool_size (e.g., [17,18]) which differs from
-        # dutConfig.testPorts.src_port_id (e.g., 2). Apply to all dutInterfaces.
-        # TODO: optimize to only protect actual src/dst ports (tracked in #24236)
-        src_interfaces = [dutConfig['dutInterfaces'][idx]
-                          for idx in sorted(dutConfig.get('dutInterfaces', {}).keys())]
+        # Resolve which DUT ports actually need protection from PTF test config.
+        # PTF sends from `hdrm_pool_size.src_port_ids` and `dst_port_id` from
+        # qos params, not from `dutConfig.testPorts.src_port_id`. Get the real
+        # list from dutQosConfig.
+        protected_port_ids = set()
+        try:
+            qos_param = dutQosConfig['param'].get(dutQosConfig['portSpeedCableLength'], {})
+            hdrm = qos_param.get('hdrm_pool_size', {}) or {}
+            for pid in hdrm.get('src_port_ids', []) or []:
+                protected_port_ids.add(int(pid))
+            if hdrm.get('dst_port_id') is not None:
+                protected_port_ids.add(int(hdrm['dst_port_id']))
+        except (KeyError, TypeError, AttributeError, ValueError) as e:
+            logger.warning("permit_only_test_traffic_on_fanout: "
+                           "failed to read hdrm_pool_size from dutQosConfig: %s", str(e))
 
-        logger.debug("permit_only_test_traffic_on_fanout: testPorts = %s",
-                     dutConfig.get('testPorts', {}))
+        # On broadcom-dnx (non-q3d), the test method overrides hdrm_pool_size
+        # at runtime with a slice of testPortIds. Pre-include the candidate
+        # pool so the optimization covers that path too.
+        try:
+            src_dut_index = get_src_dst_asic_and_duts.get('src_dut_index', 0)
+            src_asic_index = get_src_dst_asic_and_duts.get('src_asic_index', 0)
+            test_port_ids = dutConfig.get('testPortIds', {}) or {}
+            runtime_candidates = (
+                test_port_ids.get(src_dut_index, {}).get(src_asic_index, []) or [])
+            for pid in runtime_candidates:
+                protected_port_ids.add(int(pid))
+        except (KeyError, TypeError, AttributeError, ValueError) as e:
+            logger.debug("permit_only_test_traffic_on_fanout: "
+                         "could not augment with testPortIds: %s", str(e))
+
+        if not protected_port_ids:
+            # Fallback: protect all dutInterfaces
+            logger.info("permit_only_test_traffic_on_fanout: hdrm_pool_size "
+                        "src_port_ids not available; falling back to all dutInterfaces")
+            protected_port_ids = set(dutConfig.get('dutInterfaces', {}).keys())
+
+        src_interfaces = [dutConfig['dutInterfaces'][idx]
+                          for idx in sorted(protected_port_ids)
+                          if idx in dutConfig.get('dutInterfaces', {})]
+
         logger.info(
             "permit_only_test_traffic_on_fanout: protecting %d ports: %s",
             len(src_interfaces), src_interfaces)
@@ -3030,7 +3078,8 @@ class QosSaiBase(QosBase):
         # State tracking for teardown
         eos_restore_list = []
         fanout_restore_list = []
-        acl_created_fanouts = set()
+        acl_created_fanouts = {}  # fanout_name -> fanout_os (for cleanup dispatch)
+        sonic_lldp_stopped = set()  # fanout names where we stopped lldp container
         lacpd_stopped = False
         acl_name = "QOS_TEST_WHITELIST"
         teamd_docker = src_asic.get_docker_name("teamd")
@@ -3084,73 +3133,45 @@ class QosSaiBase(QosBase):
                 logger.info("permit_only_test_traffic_on_fanout: "
                             "no LAGs found, skipping LACP steps")
 
-            # --- Step 3: Disable LLDP + egress MAC ACL on fanout ports ---
-            # Egress MAC ACL permits only IP (0x0800), IPv6 (0x86DD), and ARP
-            # (0x0806). All other ethertypes — including LLDP (0x88CC), LACP
-            # (0x8809), and other broadcast/multicast L2 frames — are denied.
-            # PFC (0x8808) is DUT-originated and travels DUT→fanout, so the
-            # egress (fanout→DUT) ACL does not affect it.
+            # --- Step 3: Per-fanout dispatch (LLDP suppression + ACL where supported) ---
+            # EOS path: egress MAC ACL whitelist (permit IP 0x0800 / IPv6 0x86DD /
+            # ARP 0x0806; deny all others including LLDP 0x88CC, LACP 0x8809) plus
+            # `no lldp transmit/receive` per interface.
+            # SONiC path: stop LLDP container only — see _apply_sonic_filter for
+            # limitations and tracked issue #24236.
+            # PFC (0x8808) is DUT-originated and travels DUT→fanout; the EOS
+            # egress ACL does not affect it. SONiC has no port-side filtering
+            # applied here, so PFC is naturally unaffected.
             dev_conn = conn_graph_facts.get('device_conn', {})
+            # Restrict to only the source DUT's connections to avoid touching
+            # fanout ports of unrelated DUTs in multi-DUT topologies.
+            src_dut_conn = dev_conn.get(src_dut.hostname, {})
 
-            for dut_name, ethernet_ports in dev_conn.items():
-                for dut_port, fanout_rec in ethernet_ports.items():
-                    if dut_port not in src_interfaces:
-                        continue
-                    fanout_name = str(fanout_rec['peerdevice'])
-                    fanout_port = str(fanout_rec['peerport'])
+            for dut_port, fanout_rec in src_dut_conn.items():
+                if dut_port not in src_interfaces:
+                    continue
+                fanout_name = str(fanout_rec['peerdevice'])
+                fanout_port = str(fanout_rec['peerport'])
 
-                    if fanout_name not in fanouthosts:
-                        continue
+                if fanout_name not in fanouthosts:
+                    continue
 
-                    fanout = fanouthosts[fanout_name]
-                    fanout_os = fanout.get_fanout_os()
+                fanout = fanouthosts[fanout_name]
+                fanout_os = fanout.get_fanout_os()
 
-                    if fanout_os == 'eos':
-                        try:
-                            # Disable LLDP first; record immediately for restore
-                            fanout.host.eos_config(
-                                lines=['no lldp transmit', 'no lldp receive'],
-                                parents=['interface %s' % fanout_port])
-                            fanout_restore_list.append(
-                                (fanout, fanout_name, fanout_port))
-                        except Exception as e:
-                            logger.warning(
-                                "permit_only_test_traffic_on_fanout: "
-                                "LLDP disable failed on %s %s: %s",
-                                fanout_name, fanout_port, str(e))
-                            continue
-
-                        try:
-                            # Create MAC ACL once per fanout
-                            if fanout_name not in acl_created_fanouts:
-                                fanout.host.eos_config(
-                                    lines=[
-                                        'permit any any ip',
-                                        'permit any any ipv6',
-                                        'permit any any arp',
-                                        'deny any any',
-                                    ],
-                                    parents=['mac access-list %s' % acl_name])
-                                acl_created_fanouts.add(fanout_name)
-                            # Bind egress MAC ACL (out = fanout→DUT direction)
-                            fanout.host.eos_config(
-                                lines=['mac access-group %s out' % acl_name],
-                                parents=['interface %s' % fanout_port])
-                            logger.info(
-                                "permit_only_test_traffic_on_fanout: "
-                                "protected %s %s", fanout_name, fanout_port)
-                        except Exception as e:
-                            logger.warning(
-                                "permit_only_test_traffic_on_fanout: "
-                                "ACL config failed on %s %s: %s",
-                                fanout_name, fanout_port, str(e))
-
-                    elif fanout_os == 'sonic':
-                        # SONiC fanout support tracked in #24236
-                        logger.warning(
-                            "permit_only_test_traffic_on_fanout: "
-                            "SONiC fanout not supported, skipping %s",
-                            fanout_name)
+                if fanout_os == 'eos':
+                    self._apply_eos_filter(
+                        fanout, fanout_name, fanout_port, acl_name,
+                        fanout_restore_list, acl_created_fanouts)
+                elif fanout_os == 'sonic':
+                    self._apply_sonic_filter(
+                        fanout, fanout_name, fanout_port,
+                        fanout_restore_list, sonic_lldp_stopped)
+                else:
+                    logger.warning(
+                        "permit_only_test_traffic_on_fanout: "
+                        "fanout OS '%s' not supported, skipping %s",
+                        fanout_os, fanout_name)
 
         except Exception as e:
             # Setup failed partway — run teardown for anything already configured
@@ -3160,25 +3181,133 @@ class QosSaiBase(QosBase):
             self._teardown_test_traffic_filter(
                 src_dut, teamd_docker, lacpd_stopped,
                 eos_restore_list, fanout_restore_list,
-                acl_created_fanouts, acl_name, fanouthosts)
+                acl_created_fanouts, sonic_lldp_stopped, acl_name, fanouthosts)
             raise
 
+        eos_count = sum(1 for e in fanout_restore_list if e[0] == 'eos')
+        sonic_count = sum(1 for e in fanout_restore_list if e[0] == 'sonic')
         logger.info(
             "permit_only_test_traffic_on_fanout: setup complete — "
-            "%d ports protected, %d LACP timers set",
-            len(fanout_restore_list), len(eos_restore_list))
+            "EOS=%d ports (egress MAC ACL), SONiC=%d ports "
+            "(LLDP-stop on %d fanouts), %d LACP timers set",
+            eos_count, sonic_count, len(sonic_lldp_stopped),
+            len(eos_restore_list))
 
         yield
 
         self._teardown_test_traffic_filter(
             src_dut, teamd_docker, lacpd_stopped,
             eos_restore_list, fanout_restore_list,
-            acl_created_fanouts, acl_name, fanouthosts)
+            acl_created_fanouts, sonic_lldp_stopped, acl_name, fanouthosts)
+
+    def _apply_eos_filter(self, fanout, fanout_name, fanout_port, acl_name,
+                          fanout_restore_list, acl_created_fanouts):
+        """Apply LLDP disable + egress MAC ACL on an EOS fanout port."""
+        try:
+            # Disable LLDP first; record immediately for restore
+            fanout.host.eos_config(
+                lines=['no lldp transmit', 'no lldp receive'],
+                parents=['interface %s' % fanout_port])
+            fanout_restore_list.append(
+                ('eos', fanout, fanout_name, fanout_port))
+        except Exception as e:
+            logger.warning(
+                "permit_only_test_traffic_on_fanout: "
+                "LLDP disable failed on EOS %s %s: %s",
+                fanout_name, fanout_port, str(e))
+            return
+
+        try:
+            # Create MAC ACL once per fanout
+            if fanout_name not in acl_created_fanouts:
+                fanout.host.eos_config(
+                    lines=[
+                        'permit any any ip',
+                        'permit any any ipv6',
+                        'permit any any arp',
+                        'deny any any',
+                    ],
+                    parents=['mac access-list %s' % acl_name])
+                acl_created_fanouts[fanout_name] = 'eos'
+            # Bind egress MAC ACL (out = fanout→DUT direction)
+            fanout.host.eos_config(
+                lines=['mac access-group %s out' % acl_name],
+                parents=['interface %s' % fanout_port])
+            logger.info(
+                "permit_only_test_traffic_on_fanout: protected EOS %s %s",
+                fanout_name, fanout_port)
+        except Exception as e:
+            logger.warning(
+                "permit_only_test_traffic_on_fanout: "
+                "ACL config failed on EOS %s %s: %s",
+                fanout_name, fanout_port, str(e))
+
+    def _apply_sonic_filter(self, fanout, fanout_name, fanout_port,
+                            fanout_restore_list, sonic_lldp_stopped):
+        """Apply partial filter on SONiC fanout: stop LLDP container only.
+
+        Why partial: Broadcom SONiC does not support egress ACL, so we
+        cannot replicate the EOS "egress on DUT-facing port" approach.
+        Applying ingress ACL on the DUT-facing port would filter the wrong
+        direction (DUT->fanout, blocking PFC). Applying ingress ACL on
+        VM-facing ports requires multi-tier topology discovery that is
+        out of scope for this PR.
+
+        What this DOES cover:
+        - Fanout-self originated LLDP (stopped via container)
+
+        What this does NOT cover (limitation, tracked in #24236):
+        - VM-originated LLDP/LACP that transits through the SONiC fanout
+
+        Mitigations for the uncovered cases come from the existing
+        DUT-side defenses already applied by this fixture and stopServices:
+        - DUT teamd lacpd stopped (no LAG flap from blocked LACP)
+        - EOS neighbor LACP multiplier 600 (no EOS-side LAG flap)
+        - DUT LLDP/BGP/radvd stopped by stopServices fixture
+        """
+        # Stop LLDP container once per fanout (covers fanout-self LLDP).
+        # The 202511 fanout role only stops LLDP for marvell-teralynx;
+        # broadcom SONiC fanouts still run LLDP by default.
+        # Assumption: LLDP is running before the test; "docker stop" rc=0 does
+        # not distinguish "stopped now" from "was already stopped", so the
+        # teardown's symmetric "docker start" will start LLDP even on fanouts
+        # where it was previously off. This is acceptable for the testbeds
+        # in scope (#24236) where LLDP runs by default on Broadcom SONiC.
+        if fanout_name not in sonic_lldp_stopped:
+            try:
+                result = fanout.host.command(
+                    "docker stop lldp", module_ignore_errors=True)
+                if result.get('failed', False) or result.get('rc', 0) != 0:
+                    logger.warning(
+                        "permit_only_test_traffic_on_fanout: "
+                        "docker stop lldp on SONiC %s returned rc=%s, "
+                        "output=%s", fanout_name, result.get('rc', '?'),
+                        result.get('stdout', result.get('stderr', '')))
+                else:
+                    sonic_lldp_stopped.add(fanout_name)
+                    logger.info(
+                        "permit_only_test_traffic_on_fanout: stopped lldp "
+                        "container on SONiC %s", fanout_name)
+            except Exception as e:
+                logger.warning(
+                    "permit_only_test_traffic_on_fanout: "
+                    "failed to stop lldp on SONiC %s: %s",
+                    fanout_name, str(e))
+
+        # Track this port for restore symmetry. The actual SONiC defense is
+        # one-shot per fanout (LLDP container stop above); this per-port
+        # entry is bookkeeping for log-symmetry with the EOS path.
+        fanout_restore_list.append(
+            ('sonic', fanout, fanout_name, fanout_port))
+        logger.debug(
+            "permit_only_test_traffic_on_fanout: SONiC fanout %s associated "
+            "DUT port %s recorded; LLDP-stop already applied at fanout level",
+            fanout_name, fanout_port)
 
     def _teardown_test_traffic_filter(
             self, src_dut, teamd_docker, lacpd_stopped,
             eos_restore_list, fanout_restore_list,
-            acl_created_fanouts, acl_name, fanouthosts):
+            acl_created_fanouts, sonic_lldp_stopped, acl_name, fanouthosts):
         """Reverse all changes made by permit_only_test_traffic_on_fanout."""
         # Step 1 reverse: restart DUT lacpd FIRST (before timer restore)
         if lacpd_stopped:
@@ -3202,28 +3331,50 @@ class QosSaiBase(QosBase):
                     "permit_only_test_traffic_on_fanout: "
                     "failed to restore LACP timer: %s", str(e))
 
-        # Step 3 reverse: restore LLDP + unbind ACL from all ports
-        for fanout, fanout_name, fanout_port in fanout_restore_list:
+        # Step 3 reverse: per-port LLDP/ACL teardown (dispatch by fanout_os)
+        for entry in fanout_restore_list:
+            fanout_os, fanout, fanout_name, fanout_port = entry
             try:
-                fanout.host.eos_config(
-                    lines=['lldp transmit', 'lldp receive',
-                           'no mac access-group %s out' % acl_name],
-                    parents=['interface %s' % fanout_port])
+                if fanout_os == 'eos':
+                    fanout.host.eos_config(
+                        lines=['lldp transmit', 'lldp receive',
+                               'no mac access-group %s out' % acl_name],
+                        parents=['interface %s' % fanout_port])
+                elif fanout_os == 'sonic':
+                    # No per-port action: SONiC path only stops LLDP container
+                    # (see _apply_sonic_filter); LLDP container restart is
+                    # handled below per fanout, not per port.
+                    pass
             except Exception as e:
                 logger.warning(
                     "permit_only_test_traffic_on_fanout: "
-                    "failed to restore %s: %s", fanout_port, str(e))
+                    "failed to restore %s %s: %s",
+                    fanout_name, fanout_port, str(e))
 
-        # Delete ACL definition once per fanout
-        for fanout_name in acl_created_fanouts:
+        # Delete ACL definition once per fanout (dispatch by recorded os)
+        for fanout_name, fanout_os in acl_created_fanouts.items():
             try:
                 fanout = fanouthosts[fanout_name]
-                fanout.host.eos_config(
-                    lines=['no mac access-list %s' % acl_name])
+                if fanout_os == 'eos':
+                    fanout.host.eos_config(
+                        lines=['no mac access-list %s' % acl_name])
+                # SONiC: no ACL was created in this version (see _apply_sonic_filter)
             except Exception as e:
                 logger.warning(
                     "permit_only_test_traffic_on_fanout: "
                     "failed to delete ACL on %s: %s", fanout_name, str(e))
+
+        # Restart LLDP container on SONiC fanouts where we stopped it
+        for fanout_name in sonic_lldp_stopped:
+            try:
+                fanout = fanouthosts[fanout_name]
+                fanout.host.command(
+                    "docker start lldp", module_ignore_errors=True)
+            except Exception as e:
+                logger.warning(
+                    "permit_only_test_traffic_on_fanout: "
+                    "failed to restart lldp on SONiC %s: %s",
+                    fanout_name, str(e))
 
         logger.info("permit_only_test_traffic_on_fanout: teardown complete")
 

--- a/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
@@ -21,6 +21,15 @@ logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
+# Per-ASIC ECN dequeue test parameters.
+# Broadcom devices have a different queue kmin and require more packets to be
+# sent to see the marked packets at the end of the flow.
+ECN_PARAMS_BY_ASIC = {
+    'default':  {'ecn_params': {'kmin': 50000, 'kmax': 51000, 'pmax': 100}, 'pkt_count': 101},
+    'broadcom': {'ecn_params': {'kmin': 40000, 'kmax': 51000, 'pmax': 100}, 'pkt_count': 301},
+}
+
+
 @pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
 def test_dequeue_ecn(request,
                      snappi_api,                    # noqa: F811
@@ -51,6 +60,9 @@ def test_dequeue_ecn(request,
     Returns:
         N/A
     """
+    def _get_ecn_test_params(duthost):
+        asic_type = duthost.facts['asic_type']
+        return ECN_PARAMS_BY_ASIC.get(asic_type, ECN_PARAMS_BY_ASIC['default'])
 
     skip_ecn_tests(duthosts[0])
     for testbed_subtype, rdma_ports in multidut_port_info.items():
@@ -86,9 +98,12 @@ def test_dequeue_ecn(request,
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
     snappi_extra_params.packet_capture_type = packet_capture.IP_CAPTURE
     snappi_extra_params.is_snappi_ingress_port_cap = True
-    snappi_extra_params.ecn_params = {'kmin': 50000, 'kmax': 51000, 'pmax': 100}
+
     data_flow_pkt_size = 1024
-    data_flow_pkt_count = 101
+    ecn_test_params = _get_ecn_test_params(duthosts[0])
+    snappi_extra_params.ecn_params = ecn_test_params['ecn_params']
+    data_flow_pkt_count = ecn_test_params['pkt_count']
+
     num_iterations = 1
     logger.info("Running ECN dequeue test with params: {}".format(snappi_extra_params.ecn_params))
 

--- a/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -3,7 +3,8 @@ from tests.common.helpers.assertions import pytest_assert, pytest_require       
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id                     # noqa: F401
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, stop_pfcwd, \
-    disable_packet_aging, sec_to_nanosec, get_interface_stats                           # noqa: F401
+    disable_packet_aging, sec_to_nanosec, get_interface_stats, \
+    get_queue_scheduler_weight_dict                                                     # noqa: F401
 from tests.common.snappi_tests.port import select_ports                                 # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, \
@@ -18,11 +19,135 @@ TEST_FLOW_NAME = 'Test Flow'
 TEST_FLOW_AGGR_RATE_PERCENT = [20, 10]
 BG_FLOW_NAME = 'Background Flow'
 BG_FLOW_AGGR_RATE_PERCENT = [20, 20]
+BG_LOSS_TOLERANCE_PERCENT = 1
 DATA_PKT_SIZE = 1024
 DATA_FLOW_DURATION_SEC = 10
 DATA_FLOW_DELAY_SEC = 5
 SNAPPI_POLL_DELAY_SEC = 2
 UDP_PORT_START = 5000
+
+
+def get_expected_bg_loss_percent(egress_duthost,
+                                 test_prio_list,
+                                 test_flow_rate_percent,
+                                 bg_prio_list,
+                                 bg_flow_rate_percent,
+                                 asic_value=None,
+                                 port=None,
+                                 qos_map_profile=None):
+    """
+    Compute the expected per-Background-Flow loss percent for the m2o
+    fluctuating-lossless scenario by deriving each flow's egress-queue DWRR
+    weight from ``get_queue_scheduler_weight_dict``.
+
+    Args:
+        egress_duthost: the DUT whose egress port is the congestion point
+        test_prio_list (list[int]): priorities (TCs) of the test flows
+        test_flow_rate_percent (list[int]): per-test-flow line-rate percents,
+            aligned with ``test_prio_list``
+        bg_prio_list (list[int]): priorities (TCs) of the background flows
+            (one flow per priority, on a distinct queue)
+        bg_flow_rate_percent (list[int]): line-rate percents used to generate
+            the background flows; all entries are expected to be equal
+        asic_value: asic namespace of the egress port; ``None`` for single-asic
+            DUTs.
+        port (str, optional): egress port whose ``QUEUE``/``SCHEDULER`` config
+            should drive the weight lookup. Defaults to the first interface in
+            ``QUEUE``, which may not be the congested port on multi-port DUTs.
+        qos_map_profile (str, optional): profile name inside ``DSCP_TO_TC_MAP``
+            / ``TC_TO_QUEUE_MAP``. Defaults to the first profile.
+
+    Returns:
+        float: expected per-Background-Flow loss percent
+    """
+    cfg_args = {"host": egress_duthost.hostname, "source": "running"}
+    if asic_value not in (None, "None"):
+        cfg_args["namespace"] = asic_value
+    config_facts = egress_duthost.config_facts(**cfg_args)["ansible_facts"]
+    q_weight_dict = get_queue_scheduler_weight_dict(
+        egress_duthost,
+        asic_value=asic_value,
+        port=port,
+        qos_map_profile=qos_map_profile)
+    pytest_assert(q_weight_dict,
+                  "FAIL: Unable to read queue scheduler weights from config DB")
+
+    def _prio_to_queue(prio):
+        """Map a SONiC traffic-class (priority) to its egress queue."""
+        tc_to_queue_all = config_facts.get('TC_TO_QUEUE_MAP') or {}
+        pytest_assert(tc_to_queue_all, "FAIL: TC_TO_QUEUE_MAP is missing from config DB")
+        profile = qos_map_profile or next(iter(tc_to_queue_all))
+        tc_to_queue_map = tc_to_queue_all.get(profile) or {}
+        pytest_assert(tc_to_queue_map, "FAIL: TC_TO_QUEUE_MAP profile '{}' is missing".format(profile))
+        pytest_assert(str(prio) in tc_to_queue_map,
+                      "FAIL: TC {} missing from TC_TO_QUEUE_MAP profile '{}'".format(prio, profile))
+        return int(tc_to_queue_map[str(prio)])
+
+    def _compute_dwrr_allocation(queue_demand, queue_weight):
+        """
+        Run the DWRR allocation algorithm: iteratively give each active queue
+        its weight-proportional share of the remaining bandwidth. Queues
+        whose demand is below their share take only what they need; the
+        leftover is redistributed by weight among the remaining queues.
+        """
+        allocated = {q: 0.0 for q in queue_demand}
+        active = {q for q, d in queue_demand.items() if d > 0}
+        remaining_bw = 100.0
+        while active:
+            total_weight = sum(queue_weight[q] for q in active)
+            newly_satisfied = [
+                q for q in active
+                if remaining_bw * queue_weight[q] / total_weight
+                >= queue_demand[q] - allocated[q]
+            ]
+            if newly_satisfied:
+                for q in newly_satisfied:
+                    pending = queue_demand[q] - allocated[q]
+                    allocated[q] = queue_demand[q]
+                    remaining_bw -= pending
+                    active.discard(q)
+            else:
+                for q in active:
+                    allocated[q] += remaining_bw * queue_weight[q] / total_weight
+                return allocated
+        return allocated
+
+    queue_demand = {}
+    queue_weight = {}
+
+    def _add_demand(prio, rate):
+        q = _prio_to_queue(prio)
+        pytest_assert(q in q_weight_dict,
+                      "FAIL: No scheduler weight found for queue {} (TC {})".format(q, prio))
+        queue_demand[q] = queue_demand.get(q, 0.0) + rate
+        queue_weight[q] = q_weight_dict[q]["weight"]
+
+    # zip() silently ignores extra entries when lists differ in length; validate equal length first.
+    pytest_assert(
+        len(test_prio_list) == len(test_flow_rate_percent),
+        "FAIL: test_prio_list and test_flow_rate_percent must have same length (got {} and {})".format(
+            len(test_prio_list), len(test_flow_rate_percent)))
+    for prio, rate in zip(test_prio_list, test_flow_rate_percent):
+        _add_demand(prio, rate)
+
+    pytest_assert(bg_flow_rate_percent, "FAIL: bg_flow_rate_percent must be non-empty")
+
+    # Current assumption: all bg_flow_rate_percent entries must be equal; relax once unequal rates are supported.
+    pytest_assert(
+        len(set(bg_flow_rate_percent)) == 1,
+        "FAIL: bg_flow_rate_percent entries must be equal, got {}".format(bg_flow_rate_percent))
+
+    bg_rate_per_flow = bg_flow_rate_percent[0]
+    for prio in bg_prio_list:
+        _add_demand(prio, bg_rate_per_flow)
+
+    allocated = _compute_dwrr_allocation(queue_demand, queue_weight)
+
+    losses = []
+    for prio in bg_prio_list:
+        q = _prio_to_queue(prio)
+        losses.append((queue_demand[q] - allocated[q]) / queue_demand[q] * 100)
+    return sum(losses) / len(losses)
 
 
 def run_m2o_fluctuating_lossless_test(api,
@@ -154,10 +279,22 @@ def run_m2o_fluctuating_lossless_test(api,
 
     pytest_assert(abs(drop_percentage - 8) < 1, 'FAIL: Drop packets must be around 8 percent')
 
+    expected_bg_loss_percent = get_expected_bg_loss_percent(
+        egress_duthost=egress_duthost,
+        test_prio_list=test_prio_list,
+        test_flow_rate_percent=TEST_FLOW_AGGR_RATE_PERCENT,
+        bg_prio_list=bg_prio_list,
+        bg_flow_rate_percent=BG_FLOW_AGGR_RATE_PERCENT,
+        asic_value=rx_port.get('asic_value'),
+        port=dut_tx_port)
+    logger.info('Expected per-Background-Flow loss: {:.2f}% (tolerance +/- {}%)'.format(
+        expected_bg_loss_percent, BG_LOSS_TOLERANCE_PERCENT))
+
     """ Verify Results """
     verify_m2o_fluctuating_lossless_result(flow_stats,
                                            tx_port,
-                                           rx_port)
+                                           rx_port,
+                                           expected_bg_loss_percent)
 
 
 def __gen_traffic(testbed_config,
@@ -394,7 +531,8 @@ def __gen_data_flow(testbed_config,
 
 def verify_m2o_fluctuating_lossless_result(rows,
                                            tx_port,
-                                           rx_port):
+                                           rx_port,
+                                           expected_bg_loss_percent):
     """
     Verifies the required loss % from the Traffic Items Statistics
 
@@ -402,13 +540,21 @@ def verify_m2o_fluctuating_lossless_result(rows,
         rows (list): Traffic Item Statistics from snappi config
         tx_port (list): Ingress Ports
         rx_port : Egress Port
+        expected_bg_loss_percent (float): expected per-Background-Flow loss
+            percent (derived from the egress DWRR scheduler weights)
     Returns:
         N/A
     """
     background_loss = 0
+    background_flow_count = 0
     for row in rows:
         if 'Test Flow' in row.name:
             pytest_assert(int(row.loss) == 0, "FAIL: {} must have 0% loss".format(row.name))
         elif 'Background Flow' in row.name:
+            background_flow_count += 1
             background_loss += float(row.loss)
-    pytest_assert((abs(background_loss/4) - 10) < 1, "Each Background Flow must have an avg of 10% loss ")
+    pytest_assert(background_flow_count > 0, "FAIL: No Background Flow rows found in traffic stats")
+    avg_loss = background_loss / background_flow_count
+    pytest_assert(abs(avg_loss - expected_bg_loss_percent) < BG_LOSS_TOLERANCE_PERCENT,
+                  "Each Background Flow must have an avg of {:.2f}% loss (got {:.2f}%)".format(
+                      expected_bg_loss_percent, avg_loss))

--- a/tests/snappi_tests/unit_tests/pfc/README.md
+++ b/tests/snappi_tests/unit_tests/pfc/README.md
@@ -1,0 +1,83 @@
+# Unit Tests for `tests/snappi_tests/pfc/`
+
+This directory contains unit tests for modules under
+`tests/snappi_tests/pfc/`.
+
+## Running Unit Tests
+
+### Run all unit tests in this directory
+```bash
+# From repository root
+python3 -m pytest --noconftest tests/snappi_tests/unit_tests/pfc/ -v
+```
+
+### Run a specific test file
+```bash
+python3 -m pytest --noconftest \
+  tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py -v
+```
+
+### Run a specific test case
+```bash
+python3 -m pytest --noconftest \
+  "tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py::test_expected_bg_loss_matches_analytical_dwrr_split[mixed_weights_15_14-0-11.2676]" \
+  -v
+```
+
+## What `unit_test_m2o_fluctuating_lossless_helper.py` covers
+
+The test reproduces the IxNetwork Flow Statistics observed on
+SN4700 / 7260CX3 for the `m2o_fluctuating_lossless` scenario and validates
+that `get_expected_bg_loss_percent` returns a value matching the analytical
+DWRR split.
+
+Fixed scenario inputs:
+
+| Parameter                 | Value           |
+| ------------------------- | --------------- |
+| `test_prio_list`          | `[3, 4]`        |
+| `test_flow_rate_percent`  | `[20, 10]`      |
+| `bg_prio_list`            | `[0, 1, 2, 5]`  |
+| `bg_flow_rate_percent`    | `[20, 20, 20, 20]` |
+
+Parametrized DWRR weight profiles (vary only the scheduler weights):
+
+| Case                  | Q0/Q1/Q2/Q5/Q6 | Q3/Q4 | Expected per-BG loss |
+| --------------------- | -------------- | ----- | -------------------- |
+| `mixed_weights_15_14` | 14             | 15    | ~11.27% (IxNetwork measured 11.259%) |
+| `uniform_weights_15`  | 15             | 15    | 10.0% (fair share)   |
+
+Tolerance: `abs=0.01`.
+
+## Why `--noconftest`
+
+`tests/conftest.py` pulls in integration-test dependencies (for example,
+`paramiko`) that are not needed for these isolated unit tests. Using
+`--noconftest` keeps the run lightweight and avoids unrelated import
+failures.
+
+The target module
+`tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py` itself
+imports heavy sonic-mgmt deps (`tests.conftest`, mellanox helpers, etc.)
+at import time. To stay dependency-free, the test parses the source with
+`ast`, picks just the top-level `get_expected_bg_loss_percent` definition
+(its `_prio_to_queue` / `_compute_dwrr_allocation` / `_add_demand` helpers
+are nested inside it and come along for free) and `exec`s it into a fresh
+namespace. Two names are then injected into that namespace so the function
+can run standalone:
+
+- `get_queue_scheduler_weight_dict` — replaced with a `MagicMock` returning
+  a canned per-queue weight dict, so no DUT / Ansible inventory / Snappi
+  environment is required.
+- `pytest_assert` — replaced with a tiny stub (`assert condition, message`)
+  so the helper's input-validation asserts work without importing
+  `tests.common.helpers.assertions`.
+
+If your environment has the full sonic-mgmt test dependencies installed and
+you intentionally want global fixtures, you can drop `--noconftest`.
+
+## Requirements
+
+- Python 3
+- `pytest`
+- `unittest.mock` (built into the Python standard library)

--- a/tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py
@@ -1,0 +1,176 @@
+"""Unit tests for ``tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py``.
+
+The reference scenario reproduces the IxNetwork Flow Statistics (DWRR weights: lossless=15, lossy=14)::
+
+    Row  Tx Port  Rx Port  Traffic Item                     Loss %
+    1    Port 1   Port 0   Test Flow 1 -> 0 Rate:20         0.000
+    2    Port 2   Port 0   Test Flow 2 -> 0 Rate:10         0.000
+    3    Port 1   Port 0   1 Background Flow 1 -> 0 Rate:20 11.259
+    4    Port 2   Port 0   2 Background Flow 2 -> 0 Rate:20 11.259
+    5    Port 1   Port 0   3 Background Flow 1 -> 0 Rate:20 11.259
+    6    Port 2   Port 0   4 Background Flow 2 -> 0 Rate:20 11.259
+
+Aggregate offered load is 110% (20 + 10 + 4*20), so ~10% over-subscription
+hits the lossy queues. With DWRR weights 15 (Q3, Q4) vs 14 (Q0/Q1/Q2/Q5)
+the analytical per-BG-flow loss is ~11.27% — within the helper's 1%
+tolerance of the IxNetwork-measured 11.259%.
+
+The target module imports heavy sonic-mgmt deps at top level, so we extract
+just ``get_expected_bg_loss_percent`` (and its nested helpers) via ``ast``
+and exec it into a shared namespace, mirroring the lightweight pattern in
+``tests/common/unit_tests/fixtures/unit_test_conn_graph_facts.py``.
+
+Run with::
+
+    python3 -m pytest --noconftest \\
+        tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py \\
+        -v
+"""
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+MODULE_PATH = (Path(__file__).resolve().parents[3] /
+               "snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py")
+
+FUNCTION_NAMES = ("get_expected_bg_loss_percent",)
+
+
+def _load_functions(names):
+    """Load the named top-level functions into a single shared namespace.
+
+    The shared namespace is what each function sees as its globals, so calls
+    between the loaded functions resolve correctly. Names not loaded (e.g.
+    ``get_queue_scheduler_weight_dict``) can be injected by the caller.
+    """
+    source = MODULE_PATH.read_text()
+    tree = ast.parse(source)
+    selected = [node for node in tree.body
+                if isinstance(node, ast.FunctionDef) and node.name in names]
+    missing = set(names) - {n.name for n in selected}
+    if missing:
+        raise LookupError(
+            "Missing functions {} in {}".format(sorted(missing), MODULE_PATH))
+    module = ast.Module(body=selected, type_ignores=[])
+
+    def _pytest_assert(condition, message=""):
+        assert condition, message
+
+    ns = {"pytest_assert": _pytest_assert}
+    exec(compile(module, str(MODULE_PATH), "exec"), ns)
+    return ns
+
+
+@pytest.fixture
+def helper_ns():
+    """Fresh namespace per test so injected stubs don't leak across tests."""
+    return _load_functions(FUNCTION_NAMES)
+
+
+# Two DWRR weight profiles, indexed for parametrization.
+#   [0] mixed weights: lossless queues (Q3, Q4) heavier than lossy queues
+#       — the SN4700 / 7260CX3 default observed in the IxNetwork screenshot.
+#   [1] uniform weights: every queue at weight 15, modeling a platform where
+#       lossless and lossy schedulers are configured identically.
+SCHEDULER_WEIGHT_DICT = [
+    {
+        0: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 8},
+        1: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 0},
+        2: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 5},
+        3: {"scheduler": "scheduler.1", "type": "DWRR", "weight": 15, "dscp": 3},
+        4: {"scheduler": "scheduler.1", "type": "DWRR", "weight": 15, "dscp": 4},
+        5: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 46},
+        6: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 14, "dscp": 48},
+    },
+    {
+        0: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 15, "dscp": 8},
+        1: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 15, "dscp": 0},
+        2: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 15, "dscp": 5},
+        3: {"scheduler": "scheduler.1", "type": "DWRR", "weight": 15, "dscp": 3},
+        4: {"scheduler": "scheduler.1", "type": "DWRR", "weight": 15, "dscp": 4},
+        5: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 15, "dscp": 46},
+        6: {"scheduler": "scheduler.0", "type": "DWRR", "weight": 15, "dscp": 48},
+    },
+]
+
+CONFIG_FACTS = {
+    "TC_TO_QUEUE_MAP": {
+        "AZURE": {str(i): str(i) for i in range(7)},
+    },
+}
+
+# IxNetwork scenario parameters (matches the m2o_fluctuating_lossless test):
+TEST_PRIO_LIST = [3, 4]              # lossless TC3 / TC4
+TEST_FLOW_RATE_PERCENT = [20, 10]    # Test Flow 1 / Test Flow 2
+BG_PRIO_LIST = [0, 1, 2, 5]          # 4 lossy background TCs
+BG_FLOW_RATE_PERCENT = [20, 20, 20, 20]
+
+
+def _make_egress_duthost(config_facts=None):
+    """Create a mock egress DUT whose ``config_facts(...)`` returns the
+    canned config_facts dict."""
+    duthost = MagicMock()
+    duthost.config_facts.return_value = {
+        "ansible_facts": config_facts or CONFIG_FACTS,
+    }
+    return duthost
+
+
+def _inject_weight_stub(helper_ns, weight_dict=None):
+    """Inject a stub for ``get_queue_scheduler_weight_dict`` into the loaded
+    namespace so ``get_expected_bg_loss_percent`` can resolve it."""
+    helper_ns["get_queue_scheduler_weight_dict"] = MagicMock(
+        return_value=weight_dict if weight_dict is not None
+        else SCHEDULER_WEIGHT_DICT[0])
+
+
+# -- Tests for get_expected_bg_loss_percent ----------------------------------
+@pytest.mark.parametrize(
+    "case_id, weight_dict_idx, expected_loss",
+    [
+        # SCHEDULER_WEIGHT_DICT[0] — mixed weights (lossless=15, lossy=14):
+        #   Q4 (demand 10) is satisfied first; Q3 + 4 lossy queues split the
+        #   remaining 90% by weight 15:14:14:14:14 (sum 71). Each lossy queue
+        #   gets 90*14/71 = 17.746%.
+        #   Per-BG loss = (20 - 17.746) / 20 * 100 = 11.267%
+        #   Measured by IxNetwork: 11.259% (within the 1% tolerance).
+        ("mixed_weights_15_14", 0, 11.2676),
+        # SCHEDULER_WEIGHT_DICT[1] — uniform weights (all queues = 15):
+        #   With equal weights the DWRR split is fair-share by active queue.
+        #   Iter 1: 6 active queues, share = 100/6 = 16.667%
+        #     Q4 demand 10 < 16.667 → satisfied with 10.
+        #   Iter 2: 5 active queues, remaining 90%, share = 18% each
+        #     All five remaining queues have demand ≥ 18 → fallback split,
+        #     each gets exactly 18%.
+        #   Per-BG loss = (20 - 18) / 20 * 100 = 10.0%
+        ("uniform_weights_15", 1, 10.0),
+    ],
+)
+def test_expected_bg_loss_matches_analytical_dwrr_split(
+        helper_ns, case_id, weight_dict_idx, expected_loss):
+    """Per-BG-flow loss must match the analytical DWRR split.
+
+    Inputs vary only by the egress scheduler weight profile. The fluctuating
+    m2o test parameters are held constant::
+
+        test_prio_list           = [3, 4]
+        test_flow_rate_percent   = [20, 10]
+        bg_prio_list             = [0, 1, 2, 5]
+        bg_flow_rate_percent     = [20, 20, 20, 20]
+    """
+    _inject_weight_stub(helper_ns, SCHEDULER_WEIGHT_DICT[weight_dict_idx])
+    duthost = _make_egress_duthost()
+
+    result = helper_ns["get_expected_bg_loss_percent"](
+        egress_duthost=duthost,
+        test_prio_list=TEST_PRIO_LIST,
+        test_flow_rate_percent=TEST_FLOW_RATE_PERCENT,
+        bg_prio_list=BG_PRIO_LIST,
+        bg_flow_rate_percent=BG_FLOW_RATE_PERCENT,
+    )
+
+    assert result == pytest.approx(expected_loss, abs=0.01)

--- a/tests/vxlan/test_vxlan_decap_ttl.py
+++ b/tests/vxlan/test_vxlan_decap_ttl.py
@@ -1,0 +1,247 @@
+import pytest
+import logging
+import ptf.testutils as testutils
+import ptf.packet as packet
+
+from tests.common.vxlan_ecmp_utils import Ecmp_Utils
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+from ptf.mask import Mask
+
+
+pytestmark = [
+    pytest.mark.topology("t0"),
+    pytest.mark.disable_loganalyzer
+]
+
+VNI = 8000
+VXLAN_DST_PORT = 4789
+
+logger = logging.getLogger(__name__)
+ecmp_utils = Ecmp_Utils()
+
+
+@pytest.fixture(scope="module", params=["v4", "v6"])
+def inner_ip_version(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=["v4", "v6"])
+def outer_ip_version(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_ecmp_utils():
+    # Need to set these constants before calling any ecmp_utils function.
+    ecmp_utils.Constants["KEEP_TEMP_FILES"] = False
+    ecmp_utils.Constants["DEBUG"] = True
+    ecmp_utils.Constants["DUT_HOSTID"] = 1
+
+
+@pytest.fixture
+def configure_vxlan_global(duthost):
+    """
+        Fixture to configure global VxLAN parameters before a test and restore previous values after the test.
+    """
+    logger.info("Configuring global VxLAN parameters...")
+    prev_vxlan_port = duthost.shell("sonic-db-cli APPL_DB HGET 'SWITCH_TABLE:switch' 'vxlan_port'")["stdout"].strip()
+    prev_vxlan_router_mac = \
+        duthost.shell("sonic-db-cli APPL_DB HGET 'SWITCH_TABLE:switch' 'vxlan_router_mac'")["stdout"].strip()
+    router_mac = duthost.facts["router_mac"]
+    ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=VXLAN_DST_PORT, dutmac=router_mac)
+    yield
+    if prev_vxlan_port:
+        ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=int(prev_vxlan_port), dutmac=prev_vxlan_router_mac)
+    else:
+        ecmp_utils.configure_vxlan_switch(duthost, dutmac=prev_vxlan_router_mac)
+        duthost.shell("sonic-db-cli APPL_DB HDEL 'SWITCH_TABLE:switch' 'vxlan_port'")
+    if not prev_vxlan_router_mac:
+        duthost.shell("sonic-db-cli APPL_DB HDEL 'SWITCH_TABLE:switch' 'vxlan_router_mac'")
+
+
+def is_vxlan_tunnel_in_app_db(duthost, vxlan_tunnel):
+    """
+        Function to check if VXLAN_TUNNEL_TABLE:<vxlan_tunnel> exists in APP DB.
+    """
+    result = duthost.shell(f"sonic-db-cli APPL_DB KEYS 'VXLAN_TUNNEL_TABLE:{vxlan_tunnel}'")["stdout"]
+    return bool(result)
+
+
+def is_a_vxlan_tunnel_in_asic_db(duthost):
+    """
+        Function to check if at least one VxLAN tunnel is present in ASIC DB.
+    """
+    tunnel_keys = duthost.shell("sonic-db-cli ASIC_DB KEYS 'ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:oid*'")["stdout_lines"]
+    for key in tunnel_keys:
+        tunnel_type = duthost.shell(f"sonic-db-cli ASIC_DB HGET '{key}' 'SAI_TUNNEL_ATTR_TYPE'")["stdout"].strip()
+        if tunnel_type == "SAI_TUNNEL_TYPE_VXLAN":
+            return True
+    return False
+
+
+@pytest.fixture
+def create_vxlan_tunnel(duthost, tbinfo, outer_ip_version, configure_vxlan_global):  # noqa F811
+    """
+        Fixture to configure a VxLAN tunnel before a test and remove it after the test.
+    """
+    logger.info("Creating a VxLAN tunnel...")
+    minigraph_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    vxlan_tunnel = ecmp_utils.create_vxlan_tunnel(duthost, minigraph_facts, outer_ip_version, ttl_mode="pipe")
+    pytest_assert(wait_until(10, 2, 0, is_vxlan_tunnel_in_app_db, duthost, vxlan_tunnel),
+                  "The VxLAN tunnel is not created in APP DB.")
+    yield vxlan_tunnel
+    # Clean-up
+    duthost.shell(f"sonic-db-cli CONFIG_DB DEL \"VXLAN_TUNNEL|{vxlan_tunnel}\"")
+    pytest_assert(wait_until(10, 2, 0, lambda: not is_vxlan_tunnel_in_app_db(duthost, vxlan_tunnel)),
+                  "The VxLAN tunnel is not removed from APP DB.")
+
+
+@pytest.fixture
+def create_vnet(duthost, create_vxlan_tunnel):
+    """
+        Fixture to configure a VNet before a test and remove it after the test.
+    """
+    logger.info("Creating a VNet...")
+    vxlan_tunnel = create_vxlan_tunnel
+    vnet_dict = ecmp_utils.create_vnets(duthost, vxlan_tunnel, vnet_count=1, scope="default", vni_base=VNI)
+    vnet = next(iter(vnet_dict))
+    pytest_assert(wait_until(10, 2, 0, is_a_vxlan_tunnel_in_asic_db, duthost),
+                  "The VxLAN tunnel is not created in ASIC DB.")
+    yield vnet
+    # Clean-up
+    duthost.shell(f"sonic-db-cli CONFIG_DB DEL \"VNET|{vnet}\"")
+    pytest_assert(wait_until(10, 2, 0, lambda: not is_a_vxlan_tunnel_in_asic_db(duthost)),
+                  "The VxLAN tunnel is not removed from ASIC DB.")
+
+
+def select_ingress_port(duthost):
+    """
+        Returns the name of an oper UP Ethernet interface to be used as ingress port in tests.
+    """
+    interfaces_status = duthost.show_interface(command="status")["ansible_facts"]["int_status"]
+    for intf, info in interfaces_status.items():
+        if info["oper_state"].lower() == "up" and intf.startswith("Ethernet"):
+            logger.info(f"Selected {intf} as ingress port.")
+            return intf
+    pytest.skip("No oper UP Ethernet interface found on the DUT to be used as ingress port.")
+
+
+def select_egress_ip_and_ports(duthost, minigraph_facts, inner_ip_version, exclude_ports=[]):
+    """
+        Returns a tuple of (egress_ip, egress_port_list) to be used in tests.
+        Ports in exclude_ports are not considered for selection.
+        If the DUT has an Ethernet or PortChannel interface that is
+            1. oper UP, and
+            2. has a neighbor with a 'inner_ip_version' IP address,
+        then we return that interface's members and its neighbor IP as (egress_ip, egress_port_list).
+    """
+    portchannel_info = minigraph_facts["minigraph_portchannels"]
+    if inner_ip_version == "v4":
+        ip_interfaces = duthost.show_ip_interface()["ansible_facts"]["ip_interfaces"]
+    else:
+        ip_interfaces = duthost.show_ipv6_interfaces()
+    for intf, info in ip_interfaces.items():
+        if not (intf.startswith("Ethernet") or intf.startswith("PortChannel")):
+            continue
+        if intf in exclude_ports:
+            continue
+        if inner_ip_version == "v4":
+            if info["oper_state"].lower() != "up":
+                continue
+            neigh_ip = info.get("peer_ipv4", "")
+            if not neigh_ip or neigh_ip.lower() == "n/a":
+                continue
+        else:
+            if info["oper"].lower() != "up":
+                continue
+            neigh_ip = info.get("neighbor ip", "")
+            if not neigh_ip or neigh_ip.lower() == "n/a":
+                continue
+
+        if intf.startswith("PortChannel"):
+            members = portchannel_info[intf]["members"]
+        else:
+            members = [intf]
+        logger.info(f"Selected egress packet's dest IP '{neigh_ip}' and egress interface '{intf}'.")
+        return (neigh_ip, members)
+    pytest.skip("No suitable egress interface found on the DUT.")
+
+
+def get_inner_packet(dst_mac, src_mac, ip_version, dst_ip, ttl):
+    if ip_version == "v4":
+        return testutils.simple_udp_packet(eth_dst=dst_mac, eth_src=src_mac, ip_dst=dst_ip, ip_ttl=ttl)
+    else:
+        return testutils.simple_udpv6_packet(eth_dst=dst_mac, eth_src=src_mac, ipv6_dst=dst_ip, ipv6_hlim=ttl)
+
+
+def get_outer_packet(eth_dst, eth_src, ip_version, ip_dst, inner_pkt):
+    if ip_version == "v4":
+        return testutils.simple_vxlan_packet(eth_dst=eth_dst, eth_src=eth_src, ip_dst=ip_dst,
+                                             udp_dport=VXLAN_DST_PORT, vxlan_vni=VNI, inner_frame=inner_pkt)
+    else:
+        return testutils.simple_vxlanv6_packet(eth_dst=eth_dst, eth_src=eth_src, ipv6_dst=ip_dst,
+                                               udp_dport=VXLAN_DST_PORT, vxlan_vni=VNI, inner_frame=inner_pkt)
+
+
+def get_expected_packet_mask_ipv4(inner_pkt):
+    exp_pkt = inner_pkt.copy()
+    exp_pkt["IP"].ttl -= 1
+    exp_pkt_mask = Mask(exp_pkt)
+    exp_pkt_mask.set_do_not_care_packet(packet.Ether, "dst")
+    exp_pkt_mask.set_do_not_care_packet(packet.Ether, "src")
+    exp_pkt_mask.set_do_not_care_packet(packet.IP, "ihl")
+    exp_pkt_mask.set_do_not_care_packet(packet.IP, "tos")
+    exp_pkt_mask.set_do_not_care_packet(packet.IP, "id")
+    exp_pkt_mask.set_do_not_care_packet(packet.IP, "flags")
+    exp_pkt_mask.set_do_not_care_packet(packet.IP, "chksum")
+    exp_pkt_mask.set_do_not_care_packet(packet.UDP, "chksum")
+    return exp_pkt_mask
+
+
+def get_expected_packet_mask_ipv6(inner_pkt):
+    exp_pkt = inner_pkt.copy()
+    exp_pkt["IPv6"].hlim -= 1
+    exp_pkt_mask = Mask(exp_pkt)
+    exp_pkt_mask.set_do_not_care_packet(packet.Ether, "dst")
+    exp_pkt_mask.set_do_not_care_packet(packet.Ether, "src")
+    exp_pkt_mask.set_do_not_care_packet(packet.IPv6, "tc")
+    exp_pkt_mask.set_do_not_care_packet(packet.IPv6, "fl")
+    exp_pkt_mask.set_do_not_care_packet(packet.UDP, "chksum")
+    return exp_pkt_mask
+
+
+def get_expected_packet_mask(inner_pkt, inner_ip_version):
+    if inner_ip_version == "v4":
+        return get_expected_packet_mask_ipv4(inner_pkt)
+    else:
+        return get_expected_packet_mask_ipv6(inner_pkt)
+
+
+def test_vxlan_decap_ttl(duthost, tbinfo, ptfadapter, create_vnet, outer_ip_version, inner_ip_version):  # noqa F811
+    """
+        In this test, the DUT acts as a VNET endpoint and decapulates VxLAN packets sent to it that match
+        the VNI of the VNET configured on it.
+        The test verifies that TTL/Hop limit of the egress packet is set correctly when using the pipe model
+        (i.e., to the TTL/Hop limit of the inner ingress packet minus 1).
+    """
+    minigraph_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    router_mac = duthost.facts["router_mac"]
+    vnet_endpoint = ecmp_utils.get_dut_loopback_address(duthost, minigraph_facts, outer_ip_version)
+    ptf_indices = minigraph_facts["minigraph_ptf_indices"]
+    ingress_port = select_ingress_port(duthost)
+    inner_dst_ip, egress_ports = select_egress_ip_and_ports(duthost, minigraph_facts,
+                                                            inner_ip_version, exclude_ports=[ingress_port])
+    egress_port_indices = [ptf_indices[port] for port in egress_ports]
+    ptf_src_mac = ptfadapter.dataplane.get_mac(0, ptf_indices[ingress_port])
+
+    inner_pkt = get_inner_packet(dst_mac=router_mac, src_mac=ptf_src_mac, ip_version=inner_ip_version,
+                                 dst_ip=inner_dst_ip, ttl=2)
+    outer_pkt = get_outer_packet(eth_dst=router_mac, eth_src=ptf_src_mac, ip_version=outer_ip_version,
+                                 ip_dst=vnet_endpoint, inner_pkt=inner_pkt)
+
+    exp_pkt_mask = get_expected_packet_mask(inner_pkt, inner_ip_version)
+    ptfadapter.dataplane.flush()
+    testutils.send(ptfadapter, ptf_indices[ingress_port], outer_pkt)
+    _, received_pkt = testutils.verify_packet_any_port(ptfadapter, exp_pkt_mask, egress_port_indices)
+    logger.info(f"Received packet: \n{packet.Ether(received_pkt)}\n")


### PR DESCRIPTION
```
* c7d640b2f - [action] [PR:24993] Fix test_m2o_fluctuating_lossless (#25304) (2026-06-12) [mssonicbld]
* cbb85a8f6 - [action] [PR:25181] Increase timeout for bgp recovery (#25272) (2026-06-11) [mssonicbld]
* f79f90477 - [action] [PR:25120] [snappi_tests/ecn] Parameterize ECN dequeue test by ASIC type (#25207) (2026-06-11) [mssonicbld]
* ba3f8e411 - [action] [PR:23631] Skip ipfwd/test_nhop_group.py on ipv6-only topos (#25270) (2026-06-11) [mssonicbld]
* 028dd230d - [action] [PR:24687] pfcwd: ignore benign cisco-8000 SAI/orchagent errors during teardown of test_pfcwd_cli (#25280) (2026-06-11) [mssonicbld]
* 0529726c1 - [action] [PR:24816] Fix wait_until call of check-table (#25273) (2026-06-11) [mssonicbld]
* 324b803f2 - Update variables (2026-06-10) [P Sai Yasaswini]
* 0c778e35f - [action] [PR:24317] fix(qos): SONiC fanout LLDP-stop and narrow port scope (#24236) (#25246) (2026-06-10) [mssonicbld]
* 4d052d051 - [action] [PR:25166] [qos] Fix ineffective exabgp route withdraw in test_qos_dscp_mapping causing BGP prefix leak (#25247) (2026-06-10) [mssonicbld]
* 0421d79e0 - [action] [PR:25157] [ansible/golden_config_db]: Disable acms in smartswitch DPU extra config (#25163) (2026-06-10) [mssonicbld]
* 7ea79df0e - [action] [PR:21156] Adding a new test to check TTL decap mode for VxLAN tunnels (#22008) (2026-06-10) [mssonicbld]
* f9ebe42e3 - [action] [PR:21891] Skip multi-binding ACL tests on non-dual-tor testbeds (#25184) (2026-06-10) [mssonicbld]
* 44b755965 - [action] [PR:24819] Use wait_until for getting cpu queue shapers (#25186) (2026-06-10) [mssonicbld]
* 01616a877 - [action] [PR:24524] [ipfwd] Increase timeout for high-scale platforms (#25201) (2026-06-10) [mssonicbld]
```
