### PR TITLE
[code sync] Merge code from sonic-net/sonic-mgmt:202511 to 202603

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -7396,224 +7396,158 @@ sensors_checks:
       - raa228228-i2c-25-45/vout2/in4_crit_alarm
       - raa228228-i2c-25-45/vout2/in4_lcrit_alarm
       temp:
-      - amax31732-i2c-19-1c/temp1/temp1_crit_alarm
-      - amax31732-i2c-19-1c/temp1/temp1_lcrit_alarm
-      - amax31732-i2c-19-1c/temp1/temp1_max_alarm
-      - amax31732-i2c-19-1c/temp1/temp1_min_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_crit_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_fault
-      - amax31732-i2c-19-1c/temp2/temp2_lcrit_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_max_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_min_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_crit_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_fault
-      - amax31732-i2c-19-1c/temp3/temp3_lcrit_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_max_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_min_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_crit_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_fault
-      - amax31732-i2c-19-1c/temp4/temp4_lcrit_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_max_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_min_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_crit_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_fault
-      - amax31732-i2c-19-1c/temp5/temp5_lcrit_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_max_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_min_alarm
-      - dps800-i2c-22-58/temp1/temp1_crit_alarm
-      - dps800-i2c-22-58/temp1/temp1_lcrit_alarm
-      - dps800-i2c-22-58/temp1/temp1_max_alarm
-      - dps800-i2c-22-58/temp1/temp1_min_alarm
-      - dps800-i2c-22-58/temp2/temp2_crit_alarm
-      - dps800-i2c-22-58/temp2/temp2_lcrit_alarm
-      - dps800-i2c-22-58/temp2/temp2_max_alarm
-      - dps800-i2c-22-58/temp2/temp2_min_alarm
-      - dps800-i2c-22-58/temp3/temp3_crit_alarm
-      - dps800-i2c-22-58/temp3/temp3_lcrit_alarm
-      - dps800-i2c-22-58/temp3/temp3_max_alarm
-      - dps800-i2c-22-58/temp3/temp3_min_alarm
-      - dps800-i2c-23-58/temp1/temp1_crit_alarm
-      - dps800-i2c-23-58/temp1/temp1_lcrit_alarm
-      - dps800-i2c-23-58/temp1/temp1_max_alarm
-      - dps800-i2c-23-58/temp1/temp1_min_alarm
-      - dps800-i2c-23-58/temp2/temp2_crit_alarm
-      - dps800-i2c-23-58/temp2/temp2_lcrit_alarm
-      - dps800-i2c-23-58/temp2/temp2_max_alarm
-      - dps800-i2c-23-58/temp2/temp2_min_alarm
-      - dps800-i2c-23-58/temp3/temp3_crit_alarm
-      - dps800-i2c-23-58/temp3/temp3_lcrit_alarm
-      - dps800-i2c-23-58/temp3/temp3_max_alarm
-      - dps800-i2c-23-58/temp3/temp3_min_alarm
-      - isl68223-i2c-25-47/temp1/temp1_crit_alarm
-      - isl68223-i2c-25-47/temp1/temp1_lcrit_alarm
-      - isl68223-i2c-25-47/temp1/temp1_max_alarm
-      - isl68223-i2c-25-47/temp2/temp2_crit_alarm
-      - isl68223-i2c-25-47/temp2/temp2_lcrit_alarm
-      - isl68223-i2c-25-47/temp2/temp2_max_alarm
-      - isl68223-i2c-25-47/temp3/temp3_crit_alarm
-      - isl68223-i2c-25-47/temp3/temp3_lcrit_alarm
-      - isl68223-i2c-25-47/temp3/temp3_max_alarm
-      - isl68223-i2c-25-47/temp4/temp4_crit_alarm
-      - isl68223-i2c-25-47/temp4/temp4_lcrit_alarm
-      - isl68223-i2c-25-47/temp4/temp4_max_alarm
-      - isl68223-i2c-25-47/temp5/temp5_crit_alarm
-      - isl68223-i2c-25-47/temp5/temp5_lcrit_alarm
-      - isl68223-i2c-25-47/temp5/temp5_max_alarm
-      - isl68226-i2c-24-4c/temp1/temp1_crit_alarm
-      - isl68226-i2c-24-4c/temp1/temp1_lcrit_alarm
-      - isl68226-i2c-24-4c/temp1/temp1_max_alarm
-      - isl68226-i2c-24-4c/temp2/temp2_crit_alarm
-      - isl68226-i2c-24-4c/temp2/temp2_lcrit_alarm
-      - isl68226-i2c-24-4c/temp2/temp2_max_alarm
-      - isl68226-i2c-24-4c/temp3/temp3_crit_alarm
-      - isl68226-i2c-24-4c/temp3/temp3_lcrit_alarm
-      - isl68226-i2c-24-4c/temp3/temp3_max_alarm
-      - isl68226-i2c-24-4c/temp4/temp4_crit_alarm
-      - isl68226-i2c-24-4c/temp4/temp4_lcrit_alarm
-      - isl68226-i2c-24-4c/temp4/temp4_max_alarm
-      - isl68226-i2c-24-4c/temp5/temp5_crit_alarm
-      - isl68226-i2c-24-4c/temp5/temp5_lcrit_alarm
-      - isl68226-i2c-24-4c/temp5/temp5_max_alarm
-      - isl68226-i2c-24-4c/temp6/temp6_crit_alarm
-      - isl68226-i2c-24-4c/temp6/temp6_lcrit_alarm
-      - isl68226-i2c-24-4c/temp6/temp6_max_alarm
-      - isl68226-i2c-24-4c/temp7/temp7_crit_alarm
-      - isl68226-i2c-24-4c/temp7/temp7_lcrit_alarm
-      - isl68226-i2c-24-4c/temp7/temp7_max_alarm
-      - isl68226-i2c-24-4f/temp1/temp1_crit_alarm
-      - isl68226-i2c-24-4f/temp1/temp1_lcrit_alarm
-      - isl68226-i2c-24-4f/temp1/temp1_max_alarm
-      - isl68226-i2c-24-4f/temp2/temp2_crit_alarm
-      - isl68226-i2c-24-4f/temp2/temp2_lcrit_alarm
-      - isl68226-i2c-24-4f/temp2/temp2_max_alarm
-      - isl68226-i2c-24-4f/temp3/temp3_crit_alarm
-      - isl68226-i2c-24-4f/temp3/temp3_lcrit_alarm
-      - isl68226-i2c-24-4f/temp3/temp3_max_alarm
-      - isl68226-i2c-24-4f/temp4/temp4_crit_alarm
-      - isl68226-i2c-24-4f/temp4/temp4_lcrit_alarm
-      - isl68226-i2c-24-4f/temp4/temp4_max_alarm
-      - isl68226-i2c-24-4f/temp5/temp5_crit_alarm
-      - isl68226-i2c-24-4f/temp5/temp5_lcrit_alarm
-      - isl68226-i2c-24-4f/temp5/temp5_max_alarm
-      - isl68226-i2c-24-4f/temp6/temp6_crit_alarm
-      - isl68226-i2c-24-4f/temp6/temp6_lcrit_alarm
-      - isl68226-i2c-24-4f/temp6/temp6_max_alarm
-      - isl68226-i2c-24-4f/temp7/temp7_crit_alarm
-      - isl68226-i2c-24-4f/temp7/temp7_lcrit_alarm
-      - isl68226-i2c-24-4f/temp7/temp7_max_alarm
-      - isl68226-i2c-25-4c/temp1/temp1_crit_alarm
-      - isl68226-i2c-25-4c/temp1/temp1_lcrit_alarm
-      - isl68226-i2c-25-4c/temp1/temp1_max_alarm
-      - isl68226-i2c-25-4c/temp2/temp2_crit_alarm
-      - isl68226-i2c-25-4c/temp2/temp2_lcrit_alarm
-      - isl68226-i2c-25-4c/temp2/temp2_max_alarm
-      - isl68226-i2c-25-4c/temp3/temp3_crit_alarm
-      - isl68226-i2c-25-4c/temp3/temp3_lcrit_alarm
-      - isl68226-i2c-25-4c/temp3/temp3_max_alarm
-      - isl68226-i2c-25-4c/temp4/temp4_crit_alarm
-      - isl68226-i2c-25-4c/temp4/temp4_lcrit_alarm
-      - isl68226-i2c-25-4c/temp4/temp4_max_alarm
-      - isl68226-i2c-25-4c/temp5/temp5_crit_alarm
-      - isl68226-i2c-25-4c/temp5/temp5_lcrit_alarm
-      - isl68226-i2c-25-4c/temp5/temp5_max_alarm
-      - isl68226-i2c-25-4c/temp6/temp6_crit_alarm
-      - isl68226-i2c-25-4c/temp6/temp6_lcrit_alarm
-      - isl68226-i2c-25-4c/temp6/temp6_max_alarm
-      - isl68226-i2c-25-4c/temp7/temp7_crit_alarm
-      - isl68226-i2c-25-4c/temp7/temp7_lcrit_alarm
-      - isl68226-i2c-25-4c/temp7/temp7_max_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_crit_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_lcrit_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_max_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_min_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_crit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_fault
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_lcrit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_max_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_min_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_crit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_fault
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_lcrit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_max_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_min_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_crit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_fault
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_lcrit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_max_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_min_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_crit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_fault
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_lcrit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_max_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_min_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_crit_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_max_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_min_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_crit_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_max_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_min_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_crit_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_lcrit_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_max_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_min_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_crit_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_lcrit_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_max_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_min_alarm
+      - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_crit_alarm
+      - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_lcrit_alarm
+      - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_max_alarm
+      - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_crit_alarm
+      - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_lcrit_alarm
+      - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_max_alarm
+      - isl68226-i2c-24-4c/POS0V9_D0/temp2_crit_alarm
+      - isl68226-i2c-24-4c/POS0V9_D0/temp2_lcrit_alarm
+      - isl68226-i2c-24-4c/POS0V9_D0/temp2_max_alarm
+      - isl68226-i2c-24-4c/POS0V75_D0/temp3_crit_alarm
+      - isl68226-i2c-24-4c/POS0V75_D0/temp3_lcrit_alarm
+      - isl68226-i2c-24-4c/POS0V75_D0/temp3_max_alarm
+      - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_crit_alarm
+      - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_lcrit_alarm
+      - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_max_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_crit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_lcrit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_max_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_crit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_lcrit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_max_alarm
+      - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_crit_alarm
+      - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_lcrit_alarm
+      - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_max_alarm
+      - isl68226-i2c-25-4c/POS0V9_D1/temp2_crit_alarm
+      - isl68226-i2c-25-4c/POS0V9_D1/temp2_lcrit_alarm
+      - isl68226-i2c-25-4c/POS0V9_D1/temp2_max_alarm
+      - isl68226-i2c-25-4c/POS0V75_D1/temp3_crit_alarm
+      - isl68226-i2c-25-4c/POS0V75_D1/temp3_lcrit_alarm
+      - isl68226-i2c-25-4c/POS0V75_D1/temp3_max_alarm
       - nvme-pci-0500/Composite/temp1_alarm
-      - raa228228-i2c-24-45/temp1/temp1_crit_alarm
-      - raa228228-i2c-24-45/temp1/temp1_lcrit_alarm
-      - raa228228-i2c-24-45/temp1/temp1_max_alarm
-      - raa228228-i2c-24-45/temp2/temp2_crit_alarm
-      - raa228228-i2c-24-45/temp2/temp2_lcrit_alarm
-      - raa228228-i2c-24-45/temp2/temp2_max_alarm
-      - raa228228-i2c-24-45/temp3/temp3_crit_alarm
-      - raa228228-i2c-24-45/temp3/temp3_lcrit_alarm
-      - raa228228-i2c-24-45/temp3/temp3_max_alarm
-      - raa228228-i2c-25-45/temp1/temp1_crit_alarm
-      - raa228228-i2c-25-45/temp1/temp1_lcrit_alarm
-      - raa228228-i2c-25-45/temp1/temp1_max_alarm
-      - raa228228-i2c-25-45/temp2/temp2_crit_alarm
-      - raa228228-i2c-25-45/temp2/temp2_lcrit_alarm
-      - raa228228-i2c-25-45/temp2/temp2_max_alarm
-      - raa228228-i2c-25-45/temp3/temp3_crit_alarm
-      - raa228228-i2c-25-45/temp3/temp3_lcrit_alarm
-      - raa228228-i2c-25-45/temp3/temp3_max_alarm
+      - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_crit_alarm
+      - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_lcrit_alarm
+      - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_max_alarm
+      - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_crit_alarm
+      - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_lcrit_alarm
+      - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_max_alarm
+      - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_crit_alarm
+      - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_lcrit_alarm
+      - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_max_alarm
+      - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_crit_alarm
+      - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_lcrit_alarm
+      - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_max_alarm
 
     compares:
       fan: [ ]
       power: [ ]
       temp:
-      - - amax31732-i2c-19-1c/temp1/temp1_input
-        - amax31732-i2c-19-1c/temp1/temp1_crit
-      - - amax31732-i2c-19-1c/temp2/temp2_input
-        - amax31732-i2c-19-1c/temp2/temp2_crit
-      - - amax31732-i2c-19-1c/temp3/temp3_input
-        - amax31732-i2c-19-1c/temp3/temp3_crit
-      - - amax31732-i2c-19-1c/temp4/temp4_input
-        - amax31732-i2c-19-1c/temp4/temp4_crit
-      - - amax31732-i2c-19-1c/temp5/temp5_input
-        - amax31732-i2c-19-1c/temp5/temp5_crit
-      - - dps800-i2c-22-58/temp1/temp1_input
-        - dps800-i2c-22-58/temp1/temp1_crit
-      - - dps800-i2c-22-58/temp2/temp2_input
-        - dps800-i2c-22-58/temp2/temp2_crit
-      - - dps800-i2c-22-58/temp3/temp3_input
-        - dps800-i2c-22-58/temp3/temp3_crit
-      - - dps800-i2c-23-58/temp1/temp1_input
-        - dps800-i2c-23-58/temp1/temp1_crit
-      - - dps800-i2c-23-58/temp2/temp2_input
-        - dps800-i2c-23-58/temp2/temp2_crit
-      - - dps800-i2c-23-58/temp3/temp3_input
-        - dps800-i2c-23-58/temp3/temp3_crit
-      - - isl68223-i2c-25-47/temp1/temp1_input
-        - isl68223-i2c-25-47/temp1/temp1_crit
-      - - isl68223-i2c-25-47/temp3/temp3_input
-        - isl68223-i2c-25-47/temp3/temp3_crit
-      - - isl68226-i2c-24-4c/temp1/temp1_input
-        - isl68226-i2c-24-4c/temp1/temp1_crit
-      - - isl68226-i2c-24-4c/temp2/temp2_input
-        - isl68226-i2c-24-4c/temp2/temp2_crit
-      - - isl68226-i2c-24-4c/temp3/temp3_input
-        - isl68226-i2c-24-4c/temp3/temp3_crit
-      - - isl68226-i2c-24-4c/temp4/temp4_input
-        - isl68226-i2c-24-4c/temp4/temp4_crit
-      - - isl68226-i2c-24-4f/temp1/temp1_input
-        - isl68226-i2c-24-4f/temp1/temp1_crit
-      - - isl68226-i2c-24-4f/temp2/temp2_input
-        - isl68226-i2c-24-4f/temp2/temp2_crit
-      - - isl68226-i2c-24-4f/temp3/temp3_input
-        - isl68226-i2c-24-4f/temp3/temp3_crit
-      - - isl68226-i2c-24-4f/temp4/temp4_input
-        - isl68226-i2c-24-4f/temp4/temp4_crit
-      - - isl68226-i2c-25-4c/temp1/temp1_input
-        - isl68226-i2c-25-4c/temp1/temp1_crit
-      - - isl68226-i2c-25-4c/temp2/temp2_input
-        - isl68226-i2c-25-4c/temp2/temp2_crit
-      - - isl68226-i2c-25-4c/temp3/temp3_input
-        - isl68226-i2c-25-4c/temp3/temp3_crit
-      - - isl68226-i2c-25-4c/temp4/temp4_input
-        - isl68226-i2c-25-4c/temp4/temp4_crit
+      - - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_input
+        - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_crit
+      - - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_input
+        - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_crit
+      - - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_input
+        - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_crit
+      - - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_input
+        - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_crit
+      - - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_input
+        - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_crit
+      - - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_input
+        - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_crit
+      - - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_input
+        - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_input
+        - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_crit
+      - - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_input
+        - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_crit
+      - - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_input
+        - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_input
+        - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_crit
+      - - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_input
+        - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_crit
+      - - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_input
+        - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_crit
+      - - isl68226-i2c-24-4c/POS0V9_D0/temp2_input
+        - isl68226-i2c-24-4c/POS0V9_D0/temp2_crit
+      - - isl68226-i2c-24-4c/POS0V75_D0/temp3_input
+        - isl68226-i2c-24-4c/POS0V75_D0/temp3_crit
+      - - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_input
+        - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_crit
+      - - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_input
+        - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_crit
+      - - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_input
+        - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_crit
+      - - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_input
+        - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_crit
+      - - isl68226-i2c-25-4c/POS0V9_D1/temp2_input
+        - isl68226-i2c-25-4c/POS0V9_D1/temp2_crit
+      - - isl68226-i2c-25-4c/POS0V75_D1/temp3_input
+        - isl68226-i2c-25-4c/POS0V75_D1/temp3_crit
       - - nvme-pci-0500/Composite/temp1_input
         - nvme-pci-0500/Composite/temp1_crit
-      - - raa228228-i2c-24-45/temp1/temp1_input
-        - raa228228-i2c-24-45/temp1/temp1_crit
-      - - raa228228-i2c-24-45/temp2/temp2_input
-        - raa228228-i2c-24-45/temp2/temp2_crit
-      - - raa228228-i2c-24-45/temp3/temp3_input
-        - raa228228-i2c-24-45/temp3/temp3_crit
-      - - raa228228-i2c-25-45/temp1/temp1_input
-        - raa228228-i2c-25-45/temp1/temp1_crit
-      - - raa228228-i2c-25-45/temp2/temp2_input
-        - raa228228-i2c-25-45/temp2/temp2_crit
-      - - raa228228-i2c-25-45/temp3/temp3_input
-        - raa228228-i2c-25-45/temp3/temp3_crit
-      - - tmp75-i2c-16-48/temp1/temp1_input
-        - tmp75-i2c-16-48/temp1/temp1_max
-      - - tmp75-i2c-19-48/temp1/temp1_input
-        - tmp75-i2c-19-48/temp1/temp1_max
+      - - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_input
+        - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_crit
+      - - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_input
+        - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_crit
+      - - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_input
+        - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_crit
+      - - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_input
+        - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_crit
+      - - tmp75-i2c-16-48/Outlet/temp1_input
+        - tmp75-i2c-16-48/Outlet/temp1_max
+      - - tmp75-i2c-19-48/Management Card/temp1_input
+        - tmp75-i2c-19-48/Management Card/temp1_max
 
     non_zero:
       fan:
@@ -7822,224 +7756,158 @@ sensors_checks:
       - raa228228-i2c-25-45/vout2/in4_crit_alarm
       - raa228228-i2c-25-45/vout2/in4_lcrit_alarm
       temp:
-      - amax31732-i2c-19-1c/temp1/temp1_crit_alarm
-      - amax31732-i2c-19-1c/temp1/temp1_lcrit_alarm
-      - amax31732-i2c-19-1c/temp1/temp1_max_alarm
-      - amax31732-i2c-19-1c/temp1/temp1_min_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_crit_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_fault
-      - amax31732-i2c-19-1c/temp2/temp2_lcrit_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_max_alarm
-      - amax31732-i2c-19-1c/temp2/temp2_min_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_crit_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_fault
-      - amax31732-i2c-19-1c/temp3/temp3_lcrit_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_max_alarm
-      - amax31732-i2c-19-1c/temp3/temp3_min_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_crit_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_fault
-      - amax31732-i2c-19-1c/temp4/temp4_lcrit_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_max_alarm
-      - amax31732-i2c-19-1c/temp4/temp4_min_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_crit_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_fault
-      - amax31732-i2c-19-1c/temp5/temp5_lcrit_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_max_alarm
-      - amax31732-i2c-19-1c/temp5/temp5_min_alarm
-      - dps800-i2c-22-58/temp1/temp1_crit_alarm
-      - dps800-i2c-22-58/temp1/temp1_lcrit_alarm
-      - dps800-i2c-22-58/temp1/temp1_max_alarm
-      - dps800-i2c-22-58/temp1/temp1_min_alarm
-      - dps800-i2c-22-58/temp2/temp2_crit_alarm
-      - dps800-i2c-22-58/temp2/temp2_lcrit_alarm
-      - dps800-i2c-22-58/temp2/temp2_max_alarm
-      - dps800-i2c-22-58/temp2/temp2_min_alarm
-      - dps800-i2c-22-58/temp3/temp3_crit_alarm
-      - dps800-i2c-22-58/temp3/temp3_lcrit_alarm
-      - dps800-i2c-22-58/temp3/temp3_max_alarm
-      - dps800-i2c-22-58/temp3/temp3_min_alarm
-      - dps800-i2c-23-58/temp1/temp1_crit_alarm
-      - dps800-i2c-23-58/temp1/temp1_lcrit_alarm
-      - dps800-i2c-23-58/temp1/temp1_max_alarm
-      - dps800-i2c-23-58/temp1/temp1_min_alarm
-      - dps800-i2c-23-58/temp2/temp2_crit_alarm
-      - dps800-i2c-23-58/temp2/temp2_lcrit_alarm
-      - dps800-i2c-23-58/temp2/temp2_max_alarm
-      - dps800-i2c-23-58/temp2/temp2_min_alarm
-      - dps800-i2c-23-58/temp3/temp3_crit_alarm
-      - dps800-i2c-23-58/temp3/temp3_lcrit_alarm
-      - dps800-i2c-23-58/temp3/temp3_max_alarm
-      - dps800-i2c-23-58/temp3/temp3_min_alarm
-      - isl68223-i2c-25-47/temp1/temp1_crit_alarm
-      - isl68223-i2c-25-47/temp1/temp1_lcrit_alarm
-      - isl68223-i2c-25-47/temp1/temp1_max_alarm
-      - isl68223-i2c-25-47/temp2/temp2_crit_alarm
-      - isl68223-i2c-25-47/temp2/temp2_lcrit_alarm
-      - isl68223-i2c-25-47/temp2/temp2_max_alarm
-      - isl68223-i2c-25-47/temp3/temp3_crit_alarm
-      - isl68223-i2c-25-47/temp3/temp3_lcrit_alarm
-      - isl68223-i2c-25-47/temp3/temp3_max_alarm
-      - isl68223-i2c-25-47/temp4/temp4_crit_alarm
-      - isl68223-i2c-25-47/temp4/temp4_lcrit_alarm
-      - isl68223-i2c-25-47/temp4/temp4_max_alarm
-      - isl68223-i2c-25-47/temp5/temp5_crit_alarm
-      - isl68223-i2c-25-47/temp5/temp5_lcrit_alarm
-      - isl68223-i2c-25-47/temp5/temp5_max_alarm
-      - isl68226-i2c-24-4c/temp1/temp1_crit_alarm
-      - isl68226-i2c-24-4c/temp1/temp1_lcrit_alarm
-      - isl68226-i2c-24-4c/temp1/temp1_max_alarm
-      - isl68226-i2c-24-4c/temp2/temp2_crit_alarm
-      - isl68226-i2c-24-4c/temp2/temp2_lcrit_alarm
-      - isl68226-i2c-24-4c/temp2/temp2_max_alarm
-      - isl68226-i2c-24-4c/temp3/temp3_crit_alarm
-      - isl68226-i2c-24-4c/temp3/temp3_lcrit_alarm
-      - isl68226-i2c-24-4c/temp3/temp3_max_alarm
-      - isl68226-i2c-24-4c/temp4/temp4_crit_alarm
-      - isl68226-i2c-24-4c/temp4/temp4_lcrit_alarm
-      - isl68226-i2c-24-4c/temp4/temp4_max_alarm
-      - isl68226-i2c-24-4c/temp5/temp5_crit_alarm
-      - isl68226-i2c-24-4c/temp5/temp5_lcrit_alarm
-      - isl68226-i2c-24-4c/temp5/temp5_max_alarm
-      - isl68226-i2c-24-4c/temp6/temp6_crit_alarm
-      - isl68226-i2c-24-4c/temp6/temp6_lcrit_alarm
-      - isl68226-i2c-24-4c/temp6/temp6_max_alarm
-      - isl68226-i2c-24-4c/temp7/temp7_crit_alarm
-      - isl68226-i2c-24-4c/temp7/temp7_lcrit_alarm
-      - isl68226-i2c-24-4c/temp7/temp7_max_alarm
-      - isl68226-i2c-24-4f/temp1/temp1_crit_alarm
-      - isl68226-i2c-24-4f/temp1/temp1_lcrit_alarm
-      - isl68226-i2c-24-4f/temp1/temp1_max_alarm
-      - isl68226-i2c-24-4f/temp2/temp2_crit_alarm
-      - isl68226-i2c-24-4f/temp2/temp2_lcrit_alarm
-      - isl68226-i2c-24-4f/temp2/temp2_max_alarm
-      - isl68226-i2c-24-4f/temp3/temp3_crit_alarm
-      - isl68226-i2c-24-4f/temp3/temp3_lcrit_alarm
-      - isl68226-i2c-24-4f/temp3/temp3_max_alarm
-      - isl68226-i2c-24-4f/temp4/temp4_crit_alarm
-      - isl68226-i2c-24-4f/temp4/temp4_lcrit_alarm
-      - isl68226-i2c-24-4f/temp4/temp4_max_alarm
-      - isl68226-i2c-24-4f/temp5/temp5_crit_alarm
-      - isl68226-i2c-24-4f/temp5/temp5_lcrit_alarm
-      - isl68226-i2c-24-4f/temp5/temp5_max_alarm
-      - isl68226-i2c-24-4f/temp6/temp6_crit_alarm
-      - isl68226-i2c-24-4f/temp6/temp6_lcrit_alarm
-      - isl68226-i2c-24-4f/temp6/temp6_max_alarm
-      - isl68226-i2c-24-4f/temp7/temp7_crit_alarm
-      - isl68226-i2c-24-4f/temp7/temp7_lcrit_alarm
-      - isl68226-i2c-24-4f/temp7/temp7_max_alarm
-      - isl68226-i2c-25-4c/temp1/temp1_crit_alarm
-      - isl68226-i2c-25-4c/temp1/temp1_lcrit_alarm
-      - isl68226-i2c-25-4c/temp1/temp1_max_alarm
-      - isl68226-i2c-25-4c/temp2/temp2_crit_alarm
-      - isl68226-i2c-25-4c/temp2/temp2_lcrit_alarm
-      - isl68226-i2c-25-4c/temp2/temp2_max_alarm
-      - isl68226-i2c-25-4c/temp3/temp3_crit_alarm
-      - isl68226-i2c-25-4c/temp3/temp3_lcrit_alarm
-      - isl68226-i2c-25-4c/temp3/temp3_max_alarm
-      - isl68226-i2c-25-4c/temp4/temp4_crit_alarm
-      - isl68226-i2c-25-4c/temp4/temp4_lcrit_alarm
-      - isl68226-i2c-25-4c/temp4/temp4_max_alarm
-      - isl68226-i2c-25-4c/temp5/temp5_crit_alarm
-      - isl68226-i2c-25-4c/temp5/temp5_lcrit_alarm
-      - isl68226-i2c-25-4c/temp5/temp5_max_alarm
-      - isl68226-i2c-25-4c/temp6/temp6_crit_alarm
-      - isl68226-i2c-25-4c/temp6/temp6_lcrit_alarm
-      - isl68226-i2c-25-4c/temp6/temp6_max_alarm
-      - isl68226-i2c-25-4c/temp7/temp7_crit_alarm
-      - isl68226-i2c-25-4c/temp7/temp7_lcrit_alarm
-      - isl68226-i2c-25-4c/temp7/temp7_max_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_crit_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_lcrit_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_max_alarm
+      - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_min_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_crit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_fault
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_lcrit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_max_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_min_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_crit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_fault
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_lcrit_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_max_alarm
+      - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_min_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_crit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_fault
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_lcrit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_max_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_min_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_crit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_fault
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_lcrit_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_max_alarm
+      - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_min_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_crit_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_max_alarm
+      - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_min_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_crit_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_lcrit_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_max_alarm
+      - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_min_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_crit_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_lcrit_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_max_alarm
+      - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_min_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_crit_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_lcrit_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_max_alarm
+      - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_min_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_crit_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_lcrit_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_max_alarm
+      - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_min_alarm
+      - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_crit_alarm
+      - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_lcrit_alarm
+      - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_max_alarm
+      - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_crit_alarm
+      - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_lcrit_alarm
+      - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_max_alarm
+      - isl68226-i2c-24-4c/POS0V9_D0/temp2_crit_alarm
+      - isl68226-i2c-24-4c/POS0V9_D0/temp2_lcrit_alarm
+      - isl68226-i2c-24-4c/POS0V9_D0/temp2_max_alarm
+      - isl68226-i2c-24-4c/POS0V75_D0/temp3_crit_alarm
+      - isl68226-i2c-24-4c/POS0V75_D0/temp3_lcrit_alarm
+      - isl68226-i2c-24-4c/POS0V75_D0/temp3_max_alarm
+      - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_crit_alarm
+      - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_lcrit_alarm
+      - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_max_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_crit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_lcrit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_max_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_crit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_lcrit_alarm
+      - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_max_alarm
+      - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_crit_alarm
+      - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_lcrit_alarm
+      - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_max_alarm
+      - isl68226-i2c-25-4c/POS0V9_D1/temp2_crit_alarm
+      - isl68226-i2c-25-4c/POS0V9_D1/temp2_lcrit_alarm
+      - isl68226-i2c-25-4c/POS0V9_D1/temp2_max_alarm
+      - isl68226-i2c-25-4c/POS0V75_D1/temp3_crit_alarm
+      - isl68226-i2c-25-4c/POS0V75_D1/temp3_lcrit_alarm
+      - isl68226-i2c-25-4c/POS0V75_D1/temp3_max_alarm
       - nvme-pci-0500/Composite/temp1_alarm
-      - raa228228-i2c-24-45/temp1/temp1_crit_alarm
-      - raa228228-i2c-24-45/temp1/temp1_lcrit_alarm
-      - raa228228-i2c-24-45/temp1/temp1_max_alarm
-      - raa228228-i2c-24-45/temp2/temp2_crit_alarm
-      - raa228228-i2c-24-45/temp2/temp2_lcrit_alarm
-      - raa228228-i2c-24-45/temp2/temp2_max_alarm
-      - raa228228-i2c-24-45/temp3/temp3_crit_alarm
-      - raa228228-i2c-24-45/temp3/temp3_lcrit_alarm
-      - raa228228-i2c-24-45/temp3/temp3_max_alarm
-      - raa228228-i2c-25-45/temp1/temp1_crit_alarm
-      - raa228228-i2c-25-45/temp1/temp1_lcrit_alarm
-      - raa228228-i2c-25-45/temp1/temp1_max_alarm
-      - raa228228-i2c-25-45/temp2/temp2_crit_alarm
-      - raa228228-i2c-25-45/temp2/temp2_lcrit_alarm
-      - raa228228-i2c-25-45/temp2/temp2_max_alarm
-      - raa228228-i2c-25-45/temp3/temp3_crit_alarm
-      - raa228228-i2c-25-45/temp3/temp3_lcrit_alarm
-      - raa228228-i2c-25-45/temp3/temp3_max_alarm
+      - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_crit_alarm
+      - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_lcrit_alarm
+      - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_max_alarm
+      - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_crit_alarm
+      - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_lcrit_alarm
+      - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_max_alarm
+      - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_crit_alarm
+      - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_lcrit_alarm
+      - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_max_alarm
+      - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_crit_alarm
+      - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_lcrit_alarm
+      - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_max_alarm
 
     compares:
       fan: [ ]
       power: [ ]
       temp:
-      - - amax31732-i2c-19-1c/temp1/temp1_input
-        - amax31732-i2c-19-1c/temp1/temp1_crit
-      - - amax31732-i2c-19-1c/temp2/temp2_input
-        - amax31732-i2c-19-1c/temp2/temp2_crit
-      - - amax31732-i2c-19-1c/temp3/temp3_input
-        - amax31732-i2c-19-1c/temp3/temp3_crit
-      - - amax31732-i2c-19-1c/temp4/temp4_input
-        - amax31732-i2c-19-1c/temp4/temp4_crit
-      - - amax31732-i2c-19-1c/temp5/temp5_input
-        - amax31732-i2c-19-1c/temp5/temp5_crit
-      - - dps800-i2c-22-58/temp1/temp1_input
-        - dps800-i2c-22-58/temp1/temp1_crit
-      - - dps800-i2c-22-58/temp2/temp2_input
-        - dps800-i2c-22-58/temp2/temp2_crit
-      - - dps800-i2c-22-58/temp3/temp3_input
-        - dps800-i2c-22-58/temp3/temp3_crit
-      - - dps800-i2c-23-58/temp1/temp1_input
-        - dps800-i2c-23-58/temp1/temp1_crit
-      - - dps800-i2c-23-58/temp2/temp2_input
-        - dps800-i2c-23-58/temp2/temp2_crit
-      - - dps800-i2c-23-58/temp3/temp3_input
-        - dps800-i2c-23-58/temp3/temp3_crit
-      - - isl68223-i2c-25-47/temp1/temp1_input
-        - isl68223-i2c-25-47/temp1/temp1_crit
-      - - isl68223-i2c-25-47/temp3/temp3_input
-        - isl68223-i2c-25-47/temp3/temp3_crit
-      - - isl68226-i2c-24-4c/temp1/temp1_input
-        - isl68226-i2c-24-4c/temp1/temp1_crit
-      - - isl68226-i2c-24-4c/temp2/temp2_input
-        - isl68226-i2c-24-4c/temp2/temp2_crit
-      - - isl68226-i2c-24-4c/temp3/temp3_input
-        - isl68226-i2c-24-4c/temp3/temp3_crit
-      - - isl68226-i2c-24-4c/temp4/temp4_input
-        - isl68226-i2c-24-4c/temp4/temp4_crit
-      - - isl68226-i2c-24-4f/temp1/temp1_input
-        - isl68226-i2c-24-4f/temp1/temp1_crit
-      - - isl68226-i2c-24-4f/temp2/temp2_input
-        - isl68226-i2c-24-4f/temp2/temp2_crit
-      - - isl68226-i2c-24-4f/temp3/temp3_input
-        - isl68226-i2c-24-4f/temp3/temp3_crit
-      - - isl68226-i2c-24-4f/temp4/temp4_input
-        - isl68226-i2c-24-4f/temp4/temp4_crit
-      - - isl68226-i2c-25-4c/temp1/temp1_input
-        - isl68226-i2c-25-4c/temp1/temp1_crit
-      - - isl68226-i2c-25-4c/temp2/temp2_input
-        - isl68226-i2c-25-4c/temp2/temp2_crit
-      - - isl68226-i2c-25-4c/temp3/temp3_input
-        - isl68226-i2c-25-4c/temp3/temp3_crit
-      - - isl68226-i2c-25-4c/temp4/temp4_input
-        - isl68226-i2c-25-4c/temp4/temp4_crit
+      - - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_input
+        - amax31732-i2c-19-1c/PCB Temp Near Q3D/temp1_crit
+      - - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_input
+        - amax31732-i2c-19-1c/D0 Temp diode 0/temp2_crit
+      - - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_input
+        - amax31732-i2c-19-1c/D0 Temp diode 1/temp3_crit
+      - - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_input
+        - amax31732-i2c-19-1c/D1 Temp diode 0/temp4_crit
+      - - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_input
+        - amax31732-i2c-19-1c/D1 Temp diode 1/temp5_crit
+      - - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_input
+        - dps800-i2c-22-58/Power supply 1 inlet sensor/temp1_crit
+      - - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_input
+        - dps800-i2c-22-58/Power supply 1 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_input
+        - dps800-i2c-22-58/Power supply 1 primary hotspot sensor/temp3_crit
+      - - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_input
+        - dps800-i2c-23-58/Power supply 2 inlet sensor/temp1_crit
+      - - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_input
+        - dps800-i2c-23-58/Power supply 2 secondary hotspot sensor/temp2_crit
+      - - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_input
+        - dps800-i2c-23-58/Power supply 2 primary hotspot sensor/temp3_crit
+      - - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_input
+        - isl68223-i2c-25-47/POS0V8_PBVDD/temp1_crit
+      - - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_input
+        - isl68226-i2c-24-4c/POS1V2_HBM_D0/temp1_crit
+      - - isl68226-i2c-24-4c/POS0V9_D0/temp2_input
+        - isl68226-i2c-24-4c/POS0V9_D0/temp2_crit
+      - - isl68226-i2c-24-4c/POS0V75_D0/temp3_input
+        - isl68226-i2c-24-4c/POS0V75_D0/temp3_crit
+      - - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_input
+        - isl68226-i2c-24-4f/POS1V2_VAA_PHY/temp1_crit
+      - - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_input
+        - isl68226-i2c-24-4f/POS0V75_VDD_PHY1/temp2_crit
+      - - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_input
+        - isl68226-i2c-24-4f/POS0V75_VDD_PHY2/temp3_crit
+      - - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_input
+        - isl68226-i2c-25-4c/POS1V2_HBM_D1/temp1_crit
+      - - isl68226-i2c-25-4c/POS0V9_D1/temp2_input
+        - isl68226-i2c-25-4c/POS0V9_D1/temp2_crit
+      - - isl68226-i2c-25-4c/POS0V75_D1/temp3_input
+        - isl68226-i2c-25-4c/POS0V75_D1/temp3_crit
       - - nvme-pci-0500/Composite/temp1_input
         - nvme-pci-0500/Composite/temp1_crit
-      - - raa228228-i2c-24-45/temp1/temp1_input
-        - raa228228-i2c-24-45/temp1/temp1_crit
-      - - raa228228-i2c-24-45/temp2/temp2_input
-        - raa228228-i2c-24-45/temp2/temp2_crit
-      - - raa228228-i2c-24-45/temp3/temp3_input
-        - raa228228-i2c-24-45/temp3/temp3_crit
-      - - raa228228-i2c-25-45/temp1/temp1_input
-        - raa228228-i2c-25-45/temp1/temp1_crit
-      - - raa228228-i2c-25-45/temp2/temp2_input
-        - raa228228-i2c-25-45/temp2/temp2_crit
-      - - raa228228-i2c-25-45/temp3/temp3_input
-        - raa228228-i2c-25-45/temp3/temp3_crit
-      - - tmp75-i2c-16-48/temp1/temp1_input
-        - tmp75-i2c-16-48/temp1/temp1_max
-      - - tmp75-i2c-19-48/temp1/temp1_input
-        - tmp75-i2c-19-48/temp1/temp1_max
+      - - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_input
+        - raa228228-i2c-24-45/POS0V75_VDDC_D0/temp1_crit
+      - - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_input
+        - raa228228-i2c-24-45/POS3V3_OPTICS_A/temp2_crit
+      - - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_input
+        - raa228228-i2c-25-45/POS0V75_VDDC_D1/temp1_crit
+      - - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_input
+        - raa228228-i2c-25-45/POS3V3_OPTICS_B/temp2_crit
+      - - tmp75-i2c-16-48/Outlet/temp1_input
+        - tmp75-i2c-16-48/Outlet/temp1_max
+      - - tmp75-i2c-19-48/Management Card/temp1_input
+        - tmp75-i2c-19-48/Management Card/temp1_max
 
     non_zero:
       fan:

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -651,6 +651,13 @@ class IPinIPHashTest(HashTest):
     for IPinIP packet.
     '''
 
+    def send_and_verify_packets(self, src_port, pkt, masked_exp_pkt, dst_port_lists, is_timeout=False, logs=[]):
+        """
+        @summary: Send an IPinIP encapsulated packet and verify it is received on expected ports.
+        """
+        return super().send_and_verify_packets(src_port, pkt, masked_exp_pkt, dst_port_lists, is_timeout=False,
+                                               logs=logs)
+
     def create_packets_logs(
             self, src_port, sport, dport, version='IP', pkt=None, ipinip_pkt=None,
             vxlan_pkt=None, nvgre_pkt=None, inner_pkt=None, outer_sport=None,
@@ -673,9 +680,9 @@ class IPinIPHashTest(HashTest):
                             next_header_key,
                             outer_proto,
                             version,
-                            pkt[version].src,
-                            pkt[version].dst,
-                            pkt[version].proto if version == 'IP' else pkt['IPv6'].nh,
+                            inner_pkt[version].src,
+                            inner_pkt[version].dst,
+                            inner_pkt[version].proto if version == 'IP' else inner_pkt['IPv6'].nh,
                             sport,
                             dport,
                             src_port))

--- a/ansible/vars/topo_t2_single_node_max_64p.yml
+++ b/ansible/vars/topo_t2_single_node_max_64p.yml
@@ -334,7 +334,9 @@ configuration_properties:
     tor_subnet_number: 8
     max_tor_subnet_number: 32
     tor_subnet_size: 128
-    dut_asn: 65100
+    dut_asn: 66000
+    dut_confed_asn: 65100
+    dut_confed_peers: 65300
     dut_type: UpperSpineRouter
     nhipv4: 10.10.246.254
     nhipv6: fc0a::ff
@@ -349,6 +351,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -372,6 +375,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -395,6 +399,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -418,6 +423,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -441,6 +447,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -464,6 +471,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -487,6 +495,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -510,6 +519,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -533,6 +543,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -556,6 +567,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -579,6 +591,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -602,6 +615,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -625,6 +639,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -648,6 +663,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -671,6 +687,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -694,6 +711,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -717,6 +735,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -740,6 +759,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -763,6 +783,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -786,6 +807,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -809,6 +831,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -832,6 +855,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -855,6 +879,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -878,6 +903,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -901,6 +927,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -924,6 +951,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -947,6 +975,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -970,6 +999,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -993,6 +1023,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1016,6 +1047,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1039,6 +1071,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1062,6 +1095,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1085,9 +1119,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64600
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.128
         - fc00::101
     interfaces:
@@ -1106,9 +1142,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64610
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.130
         - fc00::105
     interfaces:
@@ -1127,9 +1165,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64620
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.132
         - fc00::109
     interfaces:
@@ -1148,9 +1188,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64630
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.134
         - fc00::10d
     interfaces:
@@ -1169,9 +1211,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64640
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.136
         - fc00::111
     interfaces:
@@ -1190,9 +1234,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64650
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.138
         - fc00::115
     interfaces:
@@ -1211,9 +1257,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64660
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.140
         - fc00::119
     interfaces:
@@ -1232,9 +1280,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64670
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.142
         - fc00::11d
     interfaces:
@@ -1253,9 +1303,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64680
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.144
         - fc00::121
     interfaces:
@@ -1274,9 +1326,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64690
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.146
         - fc00::125
     interfaces:
@@ -1295,9 +1349,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64700
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.148
         - fc00::129
     interfaces:
@@ -1316,9 +1372,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64710
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.150
         - fc00::12d
     interfaces:
@@ -1337,9 +1395,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64720
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.152
         - fc00::131
     interfaces:
@@ -1358,9 +1418,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64730
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.154
         - fc00::135
     interfaces:
@@ -1379,9 +1441,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64740
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.156
         - fc00::139
     interfaces:
@@ -1400,9 +1464,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64750
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.158
         - fc00::13d
     interfaces:
@@ -1421,9 +1487,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64760
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.160
         - fc00::141
     interfaces:
@@ -1442,9 +1510,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64770
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.162
         - fc00::145
     interfaces:
@@ -1463,9 +1533,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64780
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.164
         - fc00::149
     interfaces:
@@ -1484,9 +1556,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64790
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.166
         - fc00::14d
     interfaces:
@@ -1505,9 +1579,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64800
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.168
         - fc00::151
     interfaces:
@@ -1526,9 +1602,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64810
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.170
         - fc00::155
     interfaces:
@@ -1547,9 +1625,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64820
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.172
         - fc00::159
     interfaces:
@@ -1568,9 +1648,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64830
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.174
         - fc00::15d
     interfaces:
@@ -1589,9 +1671,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64840
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.176
         - fc00::161
     interfaces:
@@ -1610,9 +1694,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64850
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.178
         - fc00::165
     interfaces:
@@ -1631,9 +1717,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64860
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.180
         - fc00::169
     interfaces:
@@ -1652,9 +1740,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64870
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.182
         - fc00::16d
     interfaces:
@@ -1673,9 +1763,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64880
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.184
         - fc00::171
     interfaces:
@@ -1694,9 +1786,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64890
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.186
         - fc00::175
     interfaces:
@@ -1715,9 +1809,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64900
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.188
         - fc00::179
     interfaces:
@@ -1736,9 +1832,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64910
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.190
         - fc00::17d
     interfaces:

--- a/ansible/vars/topo_t2_single_node_max_64p_v2.yml
+++ b/ansible/vars/topo_t2_single_node_max_64p_v2.yml
@@ -329,13 +329,15 @@ topology:
 
 configuration_properties:
   common:
-    dut_asn: 65100
-    dut_type: UpperSpineRouter
     podset_number: 400
     tor_number: 16
     tor_subnet_number: 8
     max_tor_subnet_number: 32
     tor_subnet_size: 128
+    dut_asn: 66000
+    dut_confed_asn: 65100
+    dut_confed_peers: 65300
+    dut_type: UpperSpineRouter
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
   core:
@@ -349,6 +351,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -372,6 +375,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -395,6 +399,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -418,6 +423,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -441,6 +447,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -464,6 +471,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -487,6 +495,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -510,6 +519,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -533,6 +543,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -556,6 +567,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -579,6 +591,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -602,6 +615,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -625,6 +639,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -648,6 +663,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -671,6 +687,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -694,6 +711,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -717,6 +735,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -740,6 +759,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -763,6 +783,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -786,6 +807,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -809,6 +831,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -832,6 +855,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -855,6 +879,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -878,6 +903,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -901,6 +927,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -924,6 +951,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -947,6 +975,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -970,6 +999,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -993,6 +1023,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1016,6 +1047,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1039,6 +1071,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1062,6 +1095,7 @@ configuration:
     - common
     - core
     bgp:
+      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1085,9 +1119,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64600
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.128
         - fc00::101
     interfaces:
@@ -1106,9 +1142,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64610
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.130
         - fc00::105
     interfaces:
@@ -1127,9 +1165,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64620
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.132
         - fc00::109
     interfaces:
@@ -1148,9 +1188,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64630
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.134
         - fc00::10d
     interfaces:
@@ -1169,9 +1211,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64640
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.136
         - fc00::111
     interfaces:
@@ -1190,9 +1234,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64650
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.138
         - fc00::115
     interfaces:
@@ -1211,9 +1257,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64660
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.140
         - fc00::119
     interfaces:
@@ -1232,9 +1280,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64670
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.142
         - fc00::11d
     interfaces:
@@ -1253,9 +1303,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64680
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.144
         - fc00::121
     interfaces:
@@ -1274,9 +1326,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64690
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.146
         - fc00::125
     interfaces:
@@ -1295,9 +1349,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64700
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.148
         - fc00::129
     interfaces:
@@ -1316,9 +1372,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64710
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.150
         - fc00::12d
     interfaces:
@@ -1337,9 +1395,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64720
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.152
         - fc00::131
     interfaces:
@@ -1358,9 +1418,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64730
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.154
         - fc00::135
     interfaces:
@@ -1379,9 +1441,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64740
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.156
         - fc00::139
     interfaces:
@@ -1400,9 +1464,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64750
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.158
         - fc00::13d
     interfaces:
@@ -1421,9 +1487,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64760
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.160
         - fc00::141
     interfaces:
@@ -1442,9 +1510,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64770
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.162
         - fc00::145
     interfaces:
@@ -1463,9 +1533,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64780
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.164
         - fc00::149
     interfaces:
@@ -1484,9 +1556,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64790
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.166
         - fc00::14d
     interfaces:
@@ -1505,9 +1579,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64800
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.168
         - fc00::151
     interfaces:
@@ -1526,9 +1602,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64810
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.170
         - fc00::155
     interfaces:
@@ -1547,9 +1625,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64820
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.172
         - fc00::159
     interfaces:
@@ -1568,9 +1648,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64830
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.174
         - fc00::15d
     interfaces:
@@ -1589,9 +1671,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64840
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.176
         - fc00::161
     interfaces:
@@ -1610,9 +1694,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64850
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.178
         - fc00::165
     interfaces:
@@ -1631,9 +1717,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64860
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.180
         - fc00::169
     interfaces:
@@ -1652,9 +1740,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64870
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.182
         - fc00::16d
     interfaces:
@@ -1673,9 +1763,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64880
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.184
         - fc00::171
     interfaces:
@@ -1694,9 +1786,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64890
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.186
         - fc00::175
     interfaces:
@@ -1715,9 +1809,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64900
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.188
         - fc00::179
     interfaces:
@@ -1736,9 +1832,11 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 64910
+      asn: 65300
+      confed_asn: 65100
+      confed_peers: 66000
       peers:
-        65100:
+        66000:
         - 10.0.0.190
         - fc00::17d
     interfaces:

--- a/ansible/vars/topo_t2_single_node_min.yml
+++ b/ansible/vars/topo_t2_single_node_min.yml
@@ -1,23 +1,23 @@
 topology:
   VMs:
-    VM01T3:
+    ARISTA01T3:
       vlans:
         - 6
       vm_offset: 0
-    VM02T3:
+    ARISTA02T3:
       vlans:
         - 12
       vm_offset: 1
-    VM03T3:
+    ARISTA03T3:
       vlans:
         - 13
       vm_offset: 2
-    VM05LT2:
+    ARISTA05LT2:
       vlans:
         - 24
         - 25
       vm_offset: 3
-    VM07LT2:
+    ARISTA07LT2:
       vlans:
         - 34
       vm_offset: 4
@@ -36,9 +36,7 @@ configuration_properties:
     tor_subnet_number: 8
     max_tor_subnet_number: 32
     tor_subnet_size: 128
-    dut_asn: 66000
-    dut_confed_asn: 65100
-    dut_confed_peers: 65300
+    dut_asn: 65100
     dut_type: UpperSpineRouter
     nhipv4: 10.10.246.254
     nhipv6: fc0a::ff
@@ -48,12 +46,11 @@ configuration_properties:
     swrole: leaf
 
 configuration:
-  VM01T3:
+  ARISTA01T3:
     properties:
       - common
       - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -72,12 +69,11 @@ configuration:
       ipv4: 10.10.246.1/24
       ipv6: fc0a::2/64
 
-  VM02T3:
+  ARISTA02T3:
     properties:
       - common
       - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -94,12 +90,11 @@ configuration:
       ipv4: 10.10.246.2/24
       ipv6: fc0a::4/64
 
-  VM03T3:
+  ARISTA03T3:
     properties:
       - common
       - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -118,16 +113,14 @@ configuration:
       ipv4: 10.10.246.3/24
       ipv6: fc0a::6/64
 
-  VM05LT2:
+  ARISTA05LT2:
     properties:
       - common
       - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 65012
       peers:
-        66000:
+        65100:
           - 10.0.0.100
           - fc00::d
     interfaces:
@@ -145,16 +138,14 @@ configuration:
       ipv4: 10.10.246.103/24
       ipv6: fc0a::66/64
 
-  VM07LT2:
+  ARISTA07LT2:
     properties:
       - common
       - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 65013
       peers:
-        66000:
+        65100:
           - 10.0.0.102
           - fc00::11
     interfaces:

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -501,6 +501,16 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
             # In multi-asic we need config both in host and namespace.
             if v['namespace']:
                 acl_table_ports[''].append(k)
+        # Add upstream ports not covered by any PortChannel
+        pc_members = set()
+        for pc in port_channels.values():
+            pc_members.update(pc.get('members', []))
+        for namespace, port in list(upstream_ports.items()):
+            non_pc_ports = [p for p in port if p not in pc_members]
+            acl_table_ports[namespace] += non_pc_ports
+            # In multi-asic we need config both in host and namespace.
+            if namespace:
+                acl_table_ports[''] += non_pc_ports
     elif topo == "t2":
         acl_table_ports = t2_info['acl_table_ports']
     elif topo == "lt2":

--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -438,6 +438,16 @@ def check_results(results):
                   'Unexpected routes on neighbors, failed_results={}'.format(json.dumps(failed_results, indent=2)))
 
 
+def check_routes_presence(result, prefix):
+    # Filter the route output
+    matched_lines = [line for line in result["stdout"].splitlines() if prefix in line]
+
+    if matched_lines:
+        logging.info("Found prefix {} in BGP received-routes: {}".format(prefix, matched_lines))
+    else:
+        logging.warning("Prefix {} not found in BGP received-routes".format(prefix))
+
+
 def check_routes_on_neighbors_empty_allow_list(nbrhosts, setup, permit=True):
     """
     Check routes result for neighbors in parallel without applying allow list

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -14,7 +14,8 @@ from scapy.contrib import bgp
 from tests.bgp.bgp_helpers import (
         capture_bgp_packages_to_file,
         fetch_and_delete_pcap_file,
-        is_neighbor_sessions_established
+        is_neighbor_sessions_established,
+        check_routes_presence
 )
 from tests.common.helpers.bgp import BGPNeighbor
 from tests.common.utilities import wait_until, delete_running_config
@@ -330,33 +331,22 @@ def test_bgp_update_timer_single_route(
         for i, route in enumerate(constants.routes):
             bgp_pcap = BGP_LOG_TMPL % i
             with capture_bgp_packages_to_file(duthost, "any", bgp_pcap, n0.namespace):
+                asichost = duthost.asic_instance_from_namespace(n0.namespace)
                 n0.announce_route(route)
                 time.sleep(constants.sleep_interval)
-                duthost.shell(
-                    "vtysh -c 'show {} neighbors {} received-routes' | grep '{}'".format(
-                        "bgp ipv6" if is_v6_topo else "ip bgp", n0.ip, route["prefix"]
-                    ),
-                    module_ignore_errors=True,
-                )
-                duthost.shell(
-                    "vtysh -c 'show {} neighbors {} advertised-routes' | grep '{}'".format(
-                        "bgp ipv6" if is_v6_topo else "ip bgp", n1.ip, route["prefix"]
-                    ),
-                    module_ignore_errors=True,
-                )
+                res = asichost.run_vtysh(
+                    " -c \'show ip bgp neighbors {} received-routes\'".format(n0.ip))
+                check_routes_presence(res, route["prefix"])
+                res = asichost.run_vtysh(
+                    " -c \'show ip bgp neighbors {} received-routes\'".format(n1.ip))
+                check_routes_presence(res, route["prefix"])
                 n0.withdraw_route(route)
-                duthost.shell(
-                    "vtysh -c 'show {} neighbors {} received-routes' | grep '{}'".format(
-                        "bgp ipv6" if is_v6_topo else "ip bgp", n0.ip, route["prefix"]
-                    ),
-                    module_ignore_errors=True,
-                )
-                duthost.shell(
-                    "vtysh -c 'show {} neighbors {} advertised-routes' | grep '{}'".format(
-                        "bgp ipv6" if is_v6_topo else "ip bgp", n1.ip, route["prefix"]
-                    ),
-                    module_ignore_errors=True,
-                )
+                res = asichost.run_vtysh(
+                    " -c \'show ip bgp neighbors {} received-routes\'".format(n0.ip))
+                check_routes_presence(res, route["prefix"])
+                res = asichost.run_vtysh(
+                    " -c \'show ip bgp neighbors {} received-routes\'".format(n1.ip))
+                check_routes_presence(res, route["prefix"])
                 time.sleep(constants.sleep_interval)
 
             local_pcap_filename = fetch_and_delete_pcap_file(bgp_pcap, constants.log_dir, duthost, request)

--- a/tests/common/connections/base_console_conn.py
+++ b/tests/common/connections/base_console_conn.py
@@ -3,8 +3,10 @@ Base class for console connection of SONiC devices
 """
 
 import logging
+import paramiko
 
 from netmiko.cisco_base_connection import CiscoBaseConnection
+
 try:
     from netmiko.ssh_exception import NetMikoAuthenticationException
 except ImportError:
@@ -16,6 +18,8 @@ import socket
 import termios
 import tty
 import select
+
+logger = logging.getLogger(__name__)
 
 # All supported console types
 # Console login via telnet (mad console)
@@ -47,6 +51,46 @@ class BaseConsoleConn(CiscoBaseConnection):
         for key in key_to_rm:
             if key in kwargs:
                 del kwargs[key]
+
+        # Allow legacy KEX and host key algorithms for older console servers
+        # (e.g. Cisco SSH-2.0-Cisco-1.25) that only support legacy crypto.
+        # paramiko 5.x removed these from _preferred_kex, _kex_info,
+        # _preferred_keys, _key_info, and RSAKey.HASHES.
+        try:
+            from paramiko.kex_group14 import KexGroup14SHA256
+            from paramiko.kex_gex import KexGexSHA256
+            from paramiko.rsakey import RSAKey
+            from hashlib import sha1 as _sha1
+            from cryptography.hazmat.primitives.hashes import SHA1
+
+            # Reconstruct legacy KEX classes from existing SHA256 variants
+            class _KexGroup14SHA1(KexGroup14SHA256):
+                name = "diffie-hellman-group14-sha1"
+                hash_algo = _sha1
+
+            class _KexGexSHA1(KexGexSHA256):
+                name = "diffie-hellman-group-exchange-sha1"
+                hash_algo = _sha1
+
+            _legacy_kex = {
+                "diffie-hellman-group14-sha1": _KexGroup14SHA1,
+                "diffie-hellman-group-exchange-sha1": _KexGexSHA1,
+            }
+            for kex_name, kex_cls in _legacy_kex.items():
+                if kex_name not in paramiko.Transport._preferred_kex:
+                    paramiko.Transport._preferred_kex += (kex_name,)
+                if kex_name not in paramiko.Transport._kex_info:
+                    paramiko.Transport._kex_info[kex_name] = kex_cls
+
+            # Re-enable ssh-rsa host key support
+            if "ssh-rsa" not in paramiko.Transport._preferred_keys:
+                paramiko.Transport._preferred_keys += ("ssh-rsa",)
+            if "ssh-rsa" not in paramiko.Transport._key_info:
+                paramiko.Transport._key_info["ssh-rsa"] = RSAKey
+            if "ssh-rsa" not in RSAKey.HASHES:
+                RSAKey.HASHES["ssh-rsa"] = SHA1
+        except Exception as e:
+            logger.debug("Could not re-enable legacy SSH algorithms for console: %s", e)
 
         for i in range(0, len(all_passwords)):
             kwargs['password'] = all_passwords[i]

--- a/tests/common/dash_utils.py
+++ b/tests/common/dash_utils.py
@@ -1,4 +1,6 @@
 import logging
+import re
+from enum import IntEnum
 from os import path
 from time import sleep
 
@@ -11,6 +13,198 @@ from jinja2 import Template
 from constants import TEMPLATE_DIR
 
 logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# DASH config ordering utility
+#
+# DASH objects pushed to the DPU via gNMI (``gnmi_utils.apply_messages``) have
+# inter-table dependencies (e.g. ``DASH_ENI_TABLE`` references a
+# ``DASH_VNET_TABLE`` and ``DASH_METER_POLICY_TABLE``;
+# ``DASH_ENI_ROUTE_TABLE`` binds an ENI to a ``DASH_ROUTE_GROUP_TABLE``).
+# Historically each test fixture has manually re-implemented the same
+# table-bucketing-and-apply order. ``apply_dash_configs`` below centralises
+# that policy: callers pass any number of config dicts keyed by
+# ``DASH_<TABLE_NAME>_TABLE:<key>`` and the helper groups + applies them in
+# the dependency order defined by ``DASH_TABLE_PHASE``.
+#
+# To add a new DASH table type, add an entry to ``DASH_TABLE_PHASE`` choosing
+# the ``DashPhase`` that satisfies its dependencies. To make an entry land in
+# a non-default phase from a specific call site, split it into its own dict
+# and rely on the registry; per-call overrides intentionally aren't supported.
+# --------------------------------------------------------------------------- #
+
+
+class DashPhase(IntEnum):
+    """Phases for applying DASH configurations in dependency order.
+
+    Lower-numbered phases are applied first on setup and deleted last on
+    teardown. Two table names may share a phase if they have no ordering
+    dependency relative to each other (or if their inter-dependency is
+    handled within a single gNMI batch by orchagent/SAI).
+
+    Phase contents (canonical ordering):
+      - ``GROUP_1`` — APPLIANCE
+      - ``GROUP_2`` — ROUTING_TYPE, METER_POLICY, OUTBOUND_PORT_MAP, VNET
+      - ``GROUP_3`` — METER_RULE
+      - ``GROUP_4`` — TUNNEL, OUTBOUND_PORT_MAP_RANGE, ENI, ROUTE_GROUP
+      - ``GROUP_5`` — ROUTE_RULE, ROUTE, VNET_MAPPING
+      - ``GROUP_6`` — ENI_ROUTE
+    """
+    GROUP_1 = 1
+    GROUP_2 = 2
+    GROUP_3 = 3
+    GROUP_4 = 4
+    GROUP_5 = 5
+    GROUP_6 = 6
+
+
+DASH_TABLE_PHASE = {
+    "APPLIANCE":               DashPhase.GROUP_1,
+    "ROUTING_TYPE":            DashPhase.GROUP_2,
+    "METER_POLICY":            DashPhase.GROUP_2,
+    "OUTBOUND_PORT_MAP":       DashPhase.GROUP_2,
+    "VNET":                    DashPhase.GROUP_2,
+    "METER_RULE":              DashPhase.GROUP_3,
+    "TUNNEL":                  DashPhase.GROUP_4,
+    "OUTBOUND_PORT_MAP_RANGE": DashPhase.GROUP_4,
+    "ENI":                     DashPhase.GROUP_4,
+    "ROUTE_GROUP":             DashPhase.GROUP_4,
+    "ROUTE_RULE":              DashPhase.GROUP_5,
+    "ROUTE":                   DashPhase.GROUP_5,
+    "VNET_MAPPING":            DashPhase.GROUP_5,
+    "ENI_ROUTE":               DashPhase.GROUP_6,
+}
+
+# Phase used for any ``DASH_<UNKNOWN>_TABLE`` key not present in
+# ``DASH_TABLE_PHASE``. Defaulting to the latest phase makes new tables
+# effectively "apply last / delete first", which is the safer fallback when
+# their real dependencies aren't yet known.
+DEFAULT_DASH_PHASE = DashPhase.GROUP_6
+
+# Captures DASH_<TABLE_NAME>_TABLE at the start of a redis-style key.
+# Greedy ``\w+`` correctly handles multi-word table names such as
+# ``DASH_OUTBOUND_PORT_MAP_RANGE_TABLE``.
+_DASH_KEY_RE = re.compile(r"^DASH_(\w+)_TABLE(?::|$)")
+
+
+def dash_table_name(key):
+    """Extract the DASH table name from a redis-style DASH key.
+
+    Args:
+        key: A string like ``"DASH_VNET_MAPPING_TABLE:Vnet1:10.0.0.1"`` or
+            just ``"DASH_APPLIANCE_TABLE"``.
+
+    Returns:
+        The table name without the ``DASH_`` prefix or ``_TABLE`` suffix
+        (e.g. ``"VNET_MAPPING"``, ``"APPLIANCE"``).
+
+    Raises:
+        ValueError: if ``key`` does not match the DASH table key shape.
+    """
+    m = _DASH_KEY_RE.match(key)
+    if not m:
+        raise ValueError("Not a DASH table key: {!r}".format(key))
+    return m.group(1)
+
+
+def bucket_dash_configs(*config_dicts):
+    """Merge config dicts and group entries by their :class:`DashPhase`.
+
+    Entries from later dicts that share a key with earlier dicts overwrite
+    the earlier value (the same semantics as ``{**a, **b}``), but a warning
+    is logged when the two values differ so silent config drift is visible.
+
+    Args:
+        *config_dicts: Any number of dicts keyed by
+            ``"DASH_<TABLE>_TABLE:<key>"``.
+
+    Returns:
+        A list of ``(phase, merged_dict)`` tuples sorted by ascending phase.
+        Empty if no input entries were supplied.
+
+    Raises:
+        ValueError: if any key is not a DASH table key.
+    """
+    by_phase = {}
+    seen = {}
+    for d in config_dicts:
+        for k, v in d.items():
+            if k in seen and seen[k] != v:
+                logger.warning(
+                    "Duplicate DASH key %s with conflicting values across input dicts; "
+                    "later value wins", k,
+                )
+            seen[k] = v
+            tbl = dash_table_name(k)
+            phase = DASH_TABLE_PHASE.get(tbl)
+            if phase is None:
+                logger.warning(
+                    "Unknown DASH table %r in key %r; defaulting to phase %s. "
+                    "Add an entry to DASH_TABLE_PHASE to silence this warning.",
+                    tbl, k, DEFAULT_DASH_PHASE.name,
+                )
+                phase = DEFAULT_DASH_PHASE
+            by_phase.setdefault(phase, {})[k] = v
+    return sorted(by_phase.items(), key=lambda item: item[0])
+
+
+def apply_dash_configs(
+    localhost, duthost, ptfhost, dpu_index, *config_dicts,
+    set_db=True, wait_after_apply=5, max_updates_in_single_cmd=1024,
+    apply_fn=None,
+):
+    """Apply DASH configs to the DPU in dependency order based on table name.
+
+    Buckets entries from all ``config_dicts`` by :class:`DashPhase` (see
+    ``DASH_TABLE_PHASE``) and calls the underlying gNMI apply function once
+    per non-empty phase, in ascending phase order on setup or descending
+    order when ``set_db=False`` (delete) so dependents are removed first.
+
+    Args:
+        localhost, duthost, ptfhost, dpu_index: passed through to ``apply_fn``.
+        *config_dicts: Any number of dicts keyed by
+            ``"DASH_<TABLE>_TABLE:<key>"``. Empty / ``None`` dicts are
+            tolerated and skipped (so callers can use conditional inclusion
+            patterns like ``*(extra if condition else [])``).
+        set_db: ``True`` (default) to write configs; ``False`` to delete.
+        wait_after_apply: seconds to wait after each phase's apply; forwarded
+            to ``apply_fn`` per phase.
+        max_updates_in_single_cmd: forwarded to ``apply_fn``.
+        apply_fn: optional callable matching the signature of
+            ``gnmi_utils.apply_messages``. Defaults to a lazy import so this
+            module does not require ``gnmi_utils`` to be on ``sys.path`` at
+            import time. Pass an injectable fake for unit tests.
+    """
+    if apply_fn is None:
+        # Lazy import: ``tests/common/dash_utils.py`` is imported by both
+        # DASH and HA tests, each of which provides its own ``gnmi_utils``
+        # module on ``sys.path`` with a compatible ``apply_messages``.
+        from gnmi_utils import apply_messages as _default_apply_fn
+        apply_fn = _default_apply_fn
+
+    non_empty = [d for d in config_dicts if d]
+    if not non_empty:
+        logger.info("apply_dash_configs called with no entries; nothing to do")
+        return
+
+    buckets = bucket_dash_configs(*non_empty)
+    if not set_db:
+        buckets = list(reversed(buckets))
+
+    op_label = "SET" if set_db else "DEL"
+    for phase, messages in buckets:
+        tables = sorted({dash_table_name(k) for k in messages})
+        logger.info(
+            "[%s] DASH phase %s (priority %d): %d entries across tables %s",
+            op_label, phase.name, int(phase), len(messages), tables,
+        )
+        apply_fn(
+            localhost, duthost, ptfhost, messages, dpu_index,
+            set_db=set_db,
+            wait_after_apply=wait_after_apply,
+            max_updates_in_single_cmd=max_updates_in_single_cmd,
+        )
 
 
 def safe_open_template(template_path):
@@ -116,16 +310,16 @@ def verify_tunnel_packets(ptfadapter, ports, exp_dpu_to_vm_pkt, tunnel_endpoint_
             if pkt_repr["IP"].dst in tunnel_endpoint_counts:
                 tunnel_endpoint_counts[pkt_repr["IP"].dst] += 1
                 logging.debug(
-                    f"Packet sent to tunnel endpoint {pkt_repr['IP'].dst} matches:\
-                        \n{result.format()} \nExpected:\n{exp_dpu_to_vm_pkt}"
+                    f"Packet sent to tunnel endpoint {pkt_repr['IP'].dst} matches: \
+                        \n{result.format()} \nExpected: \n{exp_dpu_to_vm_pkt}"
                 )
                 return
             else:
                 pytest.fail(
                     f"Received packet has unexpected dst IP {pkt_repr['IP'].dst}, \
                         expected one of {tunnel_endpoint_counts.keys()} \
-                        \n{result.format()} \nExpected:\n{exp_dpu_to_vm_pkt}"
+                        \n{result.format()} \nExpected: \n{exp_dpu_to_vm_pkt}"
                 )
         else:
             pytest.fail(f"Got expected packet on unexpected port {result.port}: {pkt_repr}")
-    pytest.fail(f"DP poll failed:\n{result.format()}")
+    pytest.fail(f"DP poll failed: \n{result.format()}")

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -598,6 +598,65 @@ def is_support_psu(duthosts, rand_one_dut_hostname):
         return True
 
 
+@pytest.fixture(scope='module')
+def frontend_asic_index_with_portchannel(request, duthosts, tbinfo):
+    """
+    Select a frontend ASIC that has portchannels configured.
+    Returns the ASIC index or None for single-ASIC devices.
+
+    This fixture is useful for tests that require portchannels on multi-ASIC devices,
+    ensuring the test runs on an ASIC that actually has portchannels configured.
+
+    Args:
+        request: Pytest request object to detect which DUT fixture is being used
+        duthosts: Fixture for DUT hosts
+        tbinfo: Testbed info fixture
+
+    Returns:
+        int: ASIC index for multi-ASIC devices with portchannels
+        None: For single-ASIC devices
+
+    Raises:
+        pytest_require: If no frontend ASIC with external portchannels is found
+    """
+    # Determine which DUT hostname fixture is being used
+    if "enum_rand_one_per_hwsku_frontend_hostname" in request.fixturenames:
+        dut_hostname = request.getfixturevalue("enum_rand_one_per_hwsku_frontend_hostname")
+    elif "rand_one_dut_front_end_hostname" in request.fixturenames:
+        dut_hostname = request.getfixturevalue("rand_one_dut_front_end_hostname")
+    elif "enum_frontend_dut_hostname" in request.fixturenames:
+        dut_hostname = request.getfixturevalue("enum_frontend_dut_hostname")
+    else:
+        # Fallback to rand_one_dut_hostname if no frontend-specific fixture is found
+        dut_hostname = request.getfixturevalue("rand_one_dut_hostname")
+
+    duthost = duthosts[dut_hostname]
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+    if duthost.is_multi_asic:
+        # For multi-ASIC, find an ASIC with portchannels
+        for asic_index in duthost.get_frontend_asic_ids():
+            asic_namespace = duthost.get_namespace_from_asic_id(asic_index)
+            asic_cfg_facts = duthost.config_facts(
+                host=duthost.hostname,
+                source="persistent",
+                namespace=asic_namespace
+            )['ansible_facts']
+
+            portchannel_dict = asic_cfg_facts.get('PORTCHANNEL', {})
+            if portchannel_dict:
+                # Check if there are external (non-backend) portchannels
+                for portchannel_key in portchannel_dict:
+                    if not duthost.is_backend_portchannel(portchannel_key, mg_facts):
+                        logger.info(f"Selected ASIC {asic_index} with external portchannel: {portchannel_key}")
+                        return asic_index
+
+        pt_assert(False, "No frontend ASIC with external portchannels found")
+    else:
+        # For single-ASIC, return None
+        return None
+
+
 def separated_dscp_to_tc_map_on_uplink(dut_qos_maps_module):
     """
     A helper function to check if separated DSCP_TO_TC_MAP is applied to

--- a/tests/common/unit_tests/fixtures/unit_test_dash_utils.py
+++ b/tests/common/unit_tests/fixtures/unit_test_dash_utils.py
@@ -1,0 +1,557 @@
+"""Unit tests for the DASH config ordering helpers in
+``tests/common/dash_utils.py``.
+
+These tests load the target module in isolation using ``importlib`` so we
+don't drag in the wider sonic-mgmt fixture stack. The module also does
+``from constants import TEMPLATE_DIR`` at import time; we stub that out with
+a fake ``constants`` module before loading so no DASH-test path needs to be
+on ``sys.path``.
+
+Run with::
+
+    python3 -m pytest --noconftest tests/common/unit_tests/fixtures/unit_test_dash_utils.py -v
+"""
+
+import importlib.util
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+MODULE_PATH = (Path(__file__).resolve().parents[3]
+               / "common" / "dash_utils.py")
+
+
+def _install_stub_modules():
+    """Install minimal stubs for modules ``dash_utils`` imports at module load
+    time so the unit tests don't depend on the sonic-mgmt test path layout."""
+    if "constants" not in sys.modules:
+        constants_stub = types.ModuleType("constants")
+        constants_stub.TEMPLATE_DIR = "/tmp/_unit_test_template_dir"
+        sys.modules["constants"] = constants_stub
+
+    # ``dash_utils`` also imports ``ptf.packet``, ``ptf.testutils``, ``pytest``,
+    # and ``jinja2``. ptf isn't installed in lightweight unit-test environments,
+    # so stub it; the other three should be present.
+    if "ptf" not in sys.modules:
+        ptf_stub = types.ModuleType("ptf")
+        ptf_packet_stub = types.ModuleType("ptf.packet")
+        ptf_testutils_stub = types.ModuleType("ptf.testutils")
+        sys.modules["ptf"] = ptf_stub
+        sys.modules["ptf.packet"] = ptf_packet_stub
+        sys.modules["ptf.testutils"] = ptf_testutils_stub
+
+
+def _load_target_module():
+    _install_stub_modules()
+    spec = importlib.util.spec_from_file_location(
+        "unit_target_dash_utils", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    # Register in sys.modules so test helpers can also resolve it by name
+    # (and so any internal `importlib.import_module` lookups work).
+    sys.modules["unit_target_dash_utils"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def dash_utils():
+    return _load_target_module()
+
+
+@pytest.fixture(autouse=True)
+def _bypass_repo_log_format(monkeypatch):
+    """The repo's ``tests/pytest.ini`` configures ``log_format`` with a
+    custom ``%(funcNamewithModule)s`` field that is injected by the
+    ``log_section_start`` pytest plugin. Under ``--noconftest`` that plugin
+    isn't loaded, so any log record emitted during a test crashes pytest's
+    auto-attached ``LogCaptureHandler`` with ``KeyError: 'funcNamewithModule'``.
+
+    Replace pytest's percent-style formatter with a plain ``%(message)s``
+    formatter for the duration of every test so emitted warnings don't blow
+    up unrelated tests."""
+    try:
+        import _pytest.logging as _pylog
+    except ImportError:  # pragma: no cover - pytest internals always present
+        return
+    plain = logging.Formatter("%(message)s")
+    monkeypatch.setattr(
+        _pylog.PercentStyleMultiline, "format",
+        lambda self, record: plain.format(record),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# dash_table_name
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("key,expected", [
+    ("DASH_APPLIANCE_TABLE", "APPLIANCE"),
+    ("DASH_APPLIANCE_TABLE:100", "APPLIANCE"),
+    ("DASH_VNET_TABLE:Vnet1", "VNET"),
+    ("DASH_VNET_MAPPING_TABLE:Vnet1:10.2.0.100", "VNET_MAPPING"),
+    ("DASH_ENI_TABLE:497f23d7-f0ac-4c99-a98f-59b470e8c7bd", "ENI"),
+    ("DASH_ENI_ROUTE_TABLE:eni-id", "ENI_ROUTE"),
+    ("DASH_ROUTING_TYPE_TABLE:privatelink", "ROUTING_TYPE"),
+    ("DASH_OUTBOUND_PORT_MAP_TABLE:portmap_1", "OUTBOUND_PORT_MAP"),
+    ("DASH_OUTBOUND_PORT_MAP_RANGE_TABLE:portmap_1:8001-9000",
+     "OUTBOUND_PORT_MAP_RANGE"),
+    ("DASH_ROUTE_RULE_TABLE:eni:100:1.2.3.4/32", "ROUTE_RULE"),
+])
+def test_dash_table_name_parses_real_keys(dash_utils, key, expected):
+    assert dash_utils.dash_table_name(key) == expected
+
+
+@pytest.mark.parametrize("bad_key", [
+    "",
+    "FOO",
+    "VNET_TABLE:x",                  # missing DASH_ prefix
+    "DASH_VNET:foo",                 # missing _TABLE suffix
+    "dash_vnet_table:foo",           # wrong case
+    "PREFIX_DASH_VNET_TABLE:foo",    # DASH_ not at start
+])
+def test_dash_table_name_rejects_non_dash_keys(dash_utils, bad_key):
+    with pytest.raises(ValueError):
+        dash_utils.dash_table_name(bad_key)
+
+
+# --------------------------------------------------------------------------- #
+# bucket_dash_configs
+# --------------------------------------------------------------------------- #
+
+# --------------------------------------------------------------------------- #
+# Canonical phase assignment for every known DASH table. Pinning these in a
+# data-driven test makes accidental registry edits visible.
+# --------------------------------------------------------------------------- #
+
+_EXPECTED_TABLE_PHASES = {
+    "APPLIANCE":               "GROUP_1",
+    "ROUTING_TYPE":            "GROUP_2",
+    "METER_POLICY":            "GROUP_2",
+    "OUTBOUND_PORT_MAP":       "GROUP_2",
+    "VNET":                    "GROUP_2",
+    "METER_RULE":              "GROUP_3",
+    "TUNNEL":                  "GROUP_4",
+    "OUTBOUND_PORT_MAP_RANGE": "GROUP_4",
+    "ENI":                     "GROUP_4",
+    "ROUTE_GROUP":             "GROUP_4",
+    "ROUTE_RULE":              "GROUP_5",
+    "ROUTE":                   "GROUP_5",
+    "VNET_MAPPING":            "GROUP_5",
+    "ENI_ROUTE":               "GROUP_6",
+}
+
+
+def test_registry_contains_all_known_tables_with_expected_phases(dash_utils):
+    actual = {tbl: phase.name
+              for tbl, phase in dash_utils.DASH_TABLE_PHASE.items()}
+    assert actual == _EXPECTED_TABLE_PHASES
+
+
+@pytest.mark.parametrize("table,phase_name", sorted(_EXPECTED_TABLE_PHASES.items()))
+def test_each_table_buckets_into_its_canonical_phase(dash_utils, table, phase_name):
+    cfg = {"DASH_{}_TABLE:k".format(table): {"v": 1}}
+    buckets = dash_utils.bucket_dash_configs(cfg)
+    assert len(buckets) == 1
+    phase, _ = buckets[0]
+    assert phase.name == phase_name, (
+        "{} expected in phase {} but landed in {}".format(
+            table, phase_name, phase.name))
+
+
+def test_bucket_groups_by_phase_and_sorts_ascending(dash_utils):
+    appliance = {"DASH_APPLIANCE_TABLE:100": {"sip": "10.1.0.5"}}
+    vnet = {"DASH_VNET_TABLE:Vnet1": {"vni": 1000}}
+    eni = {"DASH_ENI_TABLE:eni-id": {"vnet": "Vnet1"}}
+    eni_route = {"DASH_ENI_ROUTE_TABLE:eni-id": {"group_id": "rg1"}}
+
+    # Pass them out of order to confirm the helper sorts.
+    buckets = dash_utils.bucket_dash_configs(eni_route, vnet, appliance, eni)
+
+    phases = [p for p, _ in buckets]
+    assert phases == sorted(phases)
+    phase_names = [p.name for p in phases]
+    # APPLIANCE first (GROUP_1); VNET in GROUP_2; ENI in GROUP_4; ENI_ROUTE in GROUP_6.
+    assert phase_names == ["GROUP_1", "GROUP_2", "GROUP_4", "GROUP_6"]
+
+
+def test_bucket_merges_same_phase_dicts_into_one_batch(dash_utils):
+    # TUNNEL, OUTBOUND_PORT_MAP_RANGE, ENI, ROUTE_GROUP all live in GROUP_4.
+    tunnel = {"DASH_TUNNEL_TABLE:T1": {"vni": 100}}
+    port_map_range = {"DASH_OUTBOUND_PORT_MAP_RANGE_TABLE:pm1:8001-9000": {}}
+    eni = {"DASH_ENI_TABLE:eni-id": {"vnet": "Vnet1"}}
+    route_group = {"DASH_ROUTE_GROUP_TABLE:rg1": {"guid": "g"}}
+
+    buckets = dash_utils.bucket_dash_configs(
+        tunnel, port_map_range, eni, route_group)
+    assert len(buckets) == 1
+    phase, merged = buckets[0]
+    assert phase == dash_utils.DashPhase.GROUP_4
+    assert set(merged) == {
+        "DASH_TUNNEL_TABLE:T1",
+        "DASH_OUTBOUND_PORT_MAP_RANGE_TABLE:pm1:8001-9000",
+        "DASH_ENI_TABLE:eni-id",
+        "DASH_ROUTE_GROUP_TABLE:rg1",
+    }
+
+
+def test_bucket_empty_input_returns_empty_list(dash_utils):
+    assert dash_utils.bucket_dash_configs() == []
+    assert dash_utils.bucket_dash_configs({}, {}) == []
+
+
+def test_bucket_warns_on_conflicting_duplicate_key(dash_utils, caplog):
+    a = {"DASH_VNET_TABLE:Vnet1": {"vni": 1000}}
+    b = {"DASH_VNET_TABLE:Vnet1": {"vni": 9999}}  # same key, different value
+    with caplog.at_level(logging.WARNING, logger=dash_utils.logger.name):
+        buckets = dash_utils.bucket_dash_configs(a, b)
+    # Later value wins (matches {**a, **b} semantics).
+    _, merged = buckets[0]
+    assert merged["DASH_VNET_TABLE:Vnet1"] == {"vni": 9999}
+    assert any("Duplicate DASH key" in r.message for r in caplog.records)
+
+
+def test_bucket_does_not_warn_on_identical_duplicate(dash_utils, caplog):
+    a = {"DASH_VNET_TABLE:Vnet1": {"vni": 1000}}
+    b = {"DASH_VNET_TABLE:Vnet1": {"vni": 1000}}
+    with caplog.at_level(logging.WARNING, logger=dash_utils.logger.name):
+        dash_utils.bucket_dash_configs(a, b)
+    assert not any("Duplicate DASH key" in r.message for r in caplog.records)
+
+
+def test_bucket_unknown_table_falls_back_to_default_phase_with_warning(
+        dash_utils, caplog):
+    cfg = {"DASH_FUTURE_NEW_TABLE:x": {"foo": "bar"}}
+    with caplog.at_level(logging.WARNING, logger=dash_utils.logger.name):
+        buckets = dash_utils.bucket_dash_configs(cfg)
+    assert len(buckets) == 1
+    phase, _ = buckets[0]
+    assert phase == dash_utils.DEFAULT_DASH_PHASE
+    assert any("Unknown DASH table" in r.message for r in caplog.records)
+
+
+def test_bucket_rejects_non_dash_key(dash_utils):
+    with pytest.raises(ValueError):
+        dash_utils.bucket_dash_configs({"not_a_dash_key": {}})
+
+
+# --------------------------------------------------------------------------- #
+# apply_dash_configs
+# --------------------------------------------------------------------------- #
+
+def _fake_apply_fn():
+    """Return a MagicMock that records each apply call's keys + set_db flag."""
+    return MagicMock()
+
+
+def _apply_call_table_summary(dash_utils, call):
+    """Pull out (set_db, sorted list of DASH table names) from a fake call."""
+    args = call.args
+    # apply_fn(localhost, duthost, ptfhost, messages, dpu_index, set_db=..., ...)
+    messages = args[3]
+    set_db = call.kwargs.get("set_db", True)
+    tables = sorted({dash_utils.dash_table_name(k) for k in messages})
+    return set_db, tables
+
+
+def test_apply_calls_apply_fn_in_phase_order_for_set(dash_utils):
+    fake = _fake_apply_fn()
+    appliance = {"DASH_APPLIANCE_TABLE:100": {"sip": "10.1.0.5"}}
+    vnet = {"DASH_VNET_TABLE:Vnet1": {"vni": 1000}}
+    eni = {"DASH_ENI_TABLE:eni-id": {"vnet": "Vnet1"}}
+    eni_route = {"DASH_ENI_ROUTE_TABLE:eni-id": {"group_id": "rg1"}}
+
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0,
+        eni_route, vnet, appliance, eni,   # out of order
+        apply_fn=fake,
+    )
+
+    summaries = [_apply_call_table_summary(dash_utils, c)
+                 for c in fake.call_args_list]
+    # APPLIANCE (GROUP_1), VNET (GROUP_2), ENI (GROUP_4), ENI_ROUTE (GROUP_6).
+    assert summaries == [
+        (True, ["APPLIANCE"]),
+        (True, ["VNET"]),
+        (True, ["ENI"]),
+        (True, ["ENI_ROUTE"]),
+    ]
+
+
+def test_apply_reverses_order_for_set_db_false(dash_utils):
+    fake = _fake_apply_fn()
+    appliance = {"DASH_APPLIANCE_TABLE:100": {"sip": "10.1.0.5"}}
+    eni = {"DASH_ENI_TABLE:eni-id": {"vnet": "Vnet1"}}
+    eni_route = {"DASH_ENI_ROUTE_TABLE:eni-id": {"group_id": "rg1"}}
+
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0,
+        appliance, eni, eni_route,
+        set_db=False,
+        apply_fn=fake,
+    )
+
+    summaries = [_apply_call_table_summary(dash_utils, c)
+                 for c in fake.call_args_list]
+    # On delete we tear down dependents first.
+    assert summaries == [
+        (False, ["ENI_ROUTE"]),
+        (False, ["ENI"]),
+        (False, ["APPLIANCE"]),
+    ]
+
+
+def test_apply_merges_same_phase_into_single_call(dash_utils):
+    fake = _fake_apply_fn()
+    vnet = {"DASH_VNET_TABLE:Vnet1": {"vni": 1000}}
+    meter_policy = {"DASH_METER_POLICY_TABLE:MP": {"ip_version": "v4"}}
+    port_map = {"DASH_OUTBOUND_PORT_MAP_TABLE:pm1": {}}
+
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0, vnet, meter_policy, port_map, apply_fn=fake,
+    )
+    # All three are in GROUP_2, so a single apply call.
+    assert fake.call_count == 1
+    _, tables = _apply_call_table_summary(dash_utils, fake.call_args_list[0])
+    assert tables == ["METER_POLICY", "OUTBOUND_PORT_MAP", "VNET"]
+
+
+def test_apply_meter_policy_before_meter_rule(dash_utils):
+    """METER_RULE references METER_POLICY by name; METER_POLICY lands in
+    GROUP_2 and METER_RULE in GROUP_3 (between GROUP_2 and GROUP_4) so
+    meter rules are programmed after their parent policy but before any
+    ENI binds to that policy."""
+    fake = _fake_apply_fn()
+    policy = {"DASH_METER_POLICY_TABLE:MP": {"ip_version": "v4"}}
+    rule = {"DASH_METER_RULE_TABLE:MP:1": {"priority": 0}}
+
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0, rule, policy, apply_fn=fake)
+    summaries = [_apply_call_table_summary(dash_utils, c)
+                 for c in fake.call_args_list]
+    assert summaries == [(True, ["METER_POLICY"]), (True, ["METER_RULE"])]
+
+
+def test_apply_meter_rule_before_eni(dash_utils):
+    """METER_RULE must land before ENI so meter rules are present before
+    any ENI binds to their parent METER_POLICY."""
+    fake = _fake_apply_fn()
+    rule = {"DASH_METER_RULE_TABLE:MP:1": {"priority": 0}}
+    eni = {"DASH_ENI_TABLE:eni-id": {"vnet": "Vnet1"}}
+
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0, eni, rule, apply_fn=fake)
+    summaries = [_apply_call_table_summary(dash_utils, c)
+                 for c in fake.call_args_list]
+    assert summaries == [(True, ["METER_RULE"]), (True, ["ENI"])]
+
+
+def test_apply_port_map_before_port_map_range(dash_utils):
+    """OUTBOUND_PORT_MAP_RANGE references OUTBOUND_PORT_MAP by name;
+    OUTBOUND_PORT_MAP lands in GROUP_2 and the RANGE in GROUP_4."""
+    fake = _fake_apply_fn()
+    port_map = {"DASH_OUTBOUND_PORT_MAP_TABLE:pm1": {}}
+    port_map_range = {"DASH_OUTBOUND_PORT_MAP_RANGE_TABLE:pm1:8001-9000": {}}
+
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0, port_map_range, port_map, apply_fn=fake)
+    summaries = [_apply_call_table_summary(dash_utils, c)
+                 for c in fake.call_args_list]
+    assert summaries == [
+        (True, ["OUTBOUND_PORT_MAP"]),
+        (True, ["OUTBOUND_PORT_MAP_RANGE"]),
+    ]
+
+
+def test_apply_eni_before_route_rule(dash_utils):
+    """Under the canonical phase ordering ENI lands in GROUP_4 and
+    ROUTE_RULE in GROUP_5, so ROUTE_RULE is applied after ENI exists."""
+    fake = _fake_apply_fn()
+    eni = {"DASH_ENI_TABLE:eni-id": {"vnet": "Vnet1"}}
+    rule = {"DASH_ROUTE_RULE_TABLE:eni-id:100:1.2.3.4/32": {"priority": 0}}
+
+    dash_utils.apply_dash_configs("lh", "dh", "ph", 0, eni, rule, apply_fn=fake)
+    summaries = [_apply_call_table_summary(dash_utils, c)
+                 for c in fake.call_args_list]
+    assert summaries == [(True, ["ENI"]), (True, ["ROUTE_RULE"])]
+
+
+def test_apply_with_no_configs_is_noop(dash_utils):
+    fake = _fake_apply_fn()
+    dash_utils.apply_dash_configs("lh", "dh", "ph", 0, apply_fn=fake)
+    dash_utils.apply_dash_configs("lh", "dh", "ph", 0, {}, {}, apply_fn=fake)
+    fake.assert_not_called()
+
+
+def test_apply_skips_falsy_input_dicts(dash_utils):
+    """Callers use patterns like ``*(extra if cond else [])`` which may yield
+    nothing; we should silently ignore empty dicts."""
+    fake = _fake_apply_fn()
+    appliance = {"DASH_APPLIANCE_TABLE:100": {"sip": "10.1.0.5"}}
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0, appliance, {}, apply_fn=fake,
+    )
+    assert fake.call_count == 1
+
+
+def test_apply_forwards_dpu_index_and_wait_kwargs(dash_utils):
+    fake = _fake_apply_fn()
+    appliance = {"DASH_APPLIANCE_TABLE:100": {"sip": "10.1.0.5"}}
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 7, appliance,
+        wait_after_apply=12, max_updates_in_single_cmd=64,
+        apply_fn=fake,
+    )
+    call = fake.call_args_list[0]
+    # Positional args: localhost, duthost, ptfhost, messages, dpu_index
+    assert call.args[:3] == ("lh", "dh", "ph")
+    assert call.args[4] == 7
+    assert call.kwargs["wait_after_apply"] == 12
+    assert call.kwargs["max_updates_in_single_cmd"] == 64
+    assert call.kwargs["set_db"] is True
+
+
+def test_apply_default_apply_fn_lazy_import(dash_utils, monkeypatch):
+    """When ``apply_fn`` is not provided, the helper should lazy-import
+    ``gnmi_utils.apply_messages``. We stub that module to confirm it gets
+    called with the expected positional + keyword arguments."""
+    recorded = {}
+
+    def fake_apply_messages(localhost, duthost, ptfhost, messages, dpu_index,
+                            set_db=True, wait_after_apply=5,
+                            max_updates_in_single_cmd=1024):
+        recorded["args"] = (localhost, duthost, ptfhost, messages, dpu_index)
+        recorded["kwargs"] = {
+            "set_db": set_db,
+            "wait_after_apply": wait_after_apply,
+            "max_updates_in_single_cmd": max_updates_in_single_cmd,
+        }
+
+    gnmi_stub = types.ModuleType("gnmi_utils")
+    gnmi_stub.apply_messages = fake_apply_messages
+    monkeypatch.setitem(sys.modules, "gnmi_utils", gnmi_stub)
+
+    appliance = {"DASH_APPLIANCE_TABLE:100": {"sip": "10.1.0.5"}}
+    dash_utils.apply_dash_configs("lh", "dh", "ph", 0, appliance)
+
+    assert recorded["args"][:3] == ("lh", "dh", "ph")
+    assert recorded["args"][4] == 0
+    assert recorded["kwargs"]["set_db"] is True
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end check: the canonical phase ordering must split a representative
+# fixture's configs into exactly these gNMI batches (using the
+# ``test_fnic_basic.py``-style config bundle, which omits METER_RULE):
+#   1. GROUP_1 — APPLIANCE
+#   2. GROUP_2 — VNET, ROUTING_TYPE, METER_POLICY
+#   4. GROUP_4 — TUNNEL, ENI, ROUTE_GROUP, OUTBOUND_PORT_MAP*
+#   5. GROUP_5 — ROUTE_RULE, ROUTE, VNET_MAPPING
+#   6. GROUP_6 — ENI_ROUTE
+# (GROUP_3 / METER_RULE is empty here; fixtures that push METER_RULE
+# produce 6 batches.)
+# Sentinel configs below share only the DASH table-name part of each
+# privatelink_config.py dict; values are placeholders.
+# --------------------------------------------------------------------------- #
+
+_SENTINEL = {
+    "APPLIANCE_FNIC_CONFIG":      {"DASH_APPLIANCE_TABLE:100": {"k": "appl"}},
+    "ROUTING_TYPE_PL_CONFIG":     {"DASH_ROUTING_TYPE_TABLE:privatelink": {"k": "rtpl"}},
+    "ROUTING_TYPE_VNET_CONFIG":   {"DASH_ROUTING_TYPE_TABLE:vnet": {"k": "rtvnet"}},
+    "VNET_CONFIG":                {"DASH_VNET_TABLE:Vnet1": {"k": "vnet"}},
+    "ROUTE_GROUP1_CONFIG":        {"DASH_ROUTE_GROUP_TABLE:RG1": {"k": "rg"}},
+    "METER_POLICY_V4_CONFIG":     {"DASH_METER_POLICY_TABLE:MP": {"k": "mp"}},
+    "PE_VNET_MAPPING_CONFIG":     {"DASH_VNET_MAPPING_TABLE:Vnet1:10.2.0.100": {"k": "pe"}},
+    "PE_SUBNET_ROUTE_CONFIG":     {"DASH_ROUTE_TABLE:RG1:10.2.0.0/16": {"k": "rpe"}},
+    "VM_VNET_MAPPING_CONFIG":     {"DASH_VNET_MAPPING_TABLE:Vnet1:10.0.0.11": {"k": "vm"}},
+    "VM_SUBNET_ROUTE_CONFIG":     {"DASH_ROUTE_TABLE:RG1:10.0.0.0/16": {"k": "rvm"}},
+    "VM_VNI_ROUTE_RULE_CONFIG":   {"DASH_ROUTE_RULE_TABLE:eni:2001:vm/32": {"k": "rrvm"}},
+    "INBOUND_VNI_ROUTE_RULE_CONFIG": {"DASH_ROUTE_RULE_TABLE:eni:100:pe/32": {"k": "rrin"}},
+    "TRUSTED_VNI_ROUTE_RULE_CONFIG": {"DASH_ROUTE_RULE_TABLE:eni:800:vm/32": {"k": "rrtr"}},
+    "ENI_FNIC_PL_CONFIG":         {"DASH_ENI_TABLE:eni-id": {"k": "enipl"}},
+    "ENI_FNIC_CONFIG":            {"DASH_ENI_TABLE:eni-id": {"k": "enifn"}},
+    "ENI_ROUTE_GROUP1_CONFIG":    {"DASH_ENI_ROUTE_TABLE:eni-id": {"k": "enirg"}},
+}
+
+
+def _migrated_test_fnic_basic_batches(dash_utils, is_pensando):
+    """Run the migrated fixture's apply_dash_configs invocation through a
+    fake apply_fn and return the captured merged messages per call."""
+    s = _SENTINEL
+    route_rule_configs = []
+    if not is_pensando:
+        route_rule_configs = [
+            s["VM_VNI_ROUTE_RULE_CONFIG"],
+            s["INBOUND_VNI_ROUTE_RULE_CONFIG"],
+            s["TRUSTED_VNI_ROUTE_RULE_CONFIG"],
+        ]
+    fake = _fake_apply_fn()
+    dash_utils.apply_dash_configs(
+        "lh", "dh", "ph", 0,
+        s["APPLIANCE_FNIC_CONFIG"],
+        s["ROUTING_TYPE_PL_CONFIG"],
+        s["ROUTING_TYPE_VNET_CONFIG"],
+        s["VNET_CONFIG"],
+        s["ROUTE_GROUP1_CONFIG"],
+        s["METER_POLICY_V4_CONFIG"],
+        s["PE_VNET_MAPPING_CONFIG"],
+        s["PE_SUBNET_ROUTE_CONFIG"],
+        s["VM_VNET_MAPPING_CONFIG"],
+        s["VM_SUBNET_ROUTE_CONFIG"],
+        *route_rule_configs,
+        s["ENI_FNIC_PL_CONFIG"],
+        s["ENI_ROUTE_GROUP1_CONFIG"],
+        apply_fn=fake,
+    )
+    return [c.args[3] for c in fake.call_args_list]
+
+
+def _expected_test_fnic_basic_batches(is_pensando):
+    """The canonical phase ordering should yield exactly these batches for
+    the migrated ``test_fnic_basic.py`` setup."""
+    s = _SENTINEL
+    routes_batch = {
+        **s["PE_VNET_MAPPING_CONFIG"],
+        **s["PE_SUBNET_ROUTE_CONFIG"],
+        **s["VM_VNET_MAPPING_CONFIG"],
+        **s["VM_SUBNET_ROUTE_CONFIG"],
+    }
+    if not is_pensando:
+        routes_batch.update(s["VM_VNI_ROUTE_RULE_CONFIG"])
+        routes_batch.update(s["INBOUND_VNI_ROUTE_RULE_CONFIG"])
+        routes_batch.update(s["TRUSTED_VNI_ROUTE_RULE_CONFIG"])
+    return [
+        # GROUP_1: APPLIANCE
+        dict(s["APPLIANCE_FNIC_CONFIG"]),
+        # GROUP_2: VNET + ROUTING_TYPE + METER_POLICY
+        {**s["ROUTING_TYPE_PL_CONFIG"], **s["ROUTING_TYPE_VNET_CONFIG"],
+         **s["VNET_CONFIG"], **s["METER_POLICY_V4_CONFIG"]},
+        # GROUP_4: ROUTE_GROUP + ENI (GROUP_3 is empty — no METER_RULE here)
+        {**s["ROUTE_GROUP1_CONFIG"], **s["ENI_FNIC_PL_CONFIG"]},
+        # GROUP_5: ROUTES (+ ROUTE_RULE on non-Pensando)
+        routes_batch,
+        # GROUP_6: ENI_ROUTE
+        dict(s["ENI_ROUTE_GROUP1_CONFIG"]),
+    ]
+
+
+@pytest.mark.parametrize("is_pensando", [False, True],
+                         ids=["non-pensando", "pensando"])
+def test_pilot_migration_matches_expected_phase_batches(
+        dash_utils, is_pensando):
+    """The migrated ``test_fnic_basic.py`` setup should produce exactly the
+    5 phase-bucketed batches defined above."""
+    expected = _expected_test_fnic_basic_batches(is_pensando)
+    actual = _migrated_test_fnic_basic_batches(dash_utils, is_pensando)
+
+    assert len(actual) == len(expected), (
+        "batch count differs: actual={}, expected={}".format(
+            len(actual), len(expected)))
+    for i, (act, exp) in enumerate(zip(actual, expected)):
+        assert set(act) == set(exp), (
+            "batch {} key sets differ:\n  actual only: {}\n  expected only: {}"
+            .format(i, set(act) - set(exp), set(exp) - set(act)))

--- a/tests/dash/test_config_churn.py
+++ b/tests/dash/test_config_churn.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E231
 import logging
 import time
 
@@ -8,6 +9,7 @@ from dash_api.route_type_pb2 import RoutingType
 from gnmi_utils import apply_messages
 
 from tests.common import config_reload
+from tests.common.dash_utils import apply_dash_configs
 from tests.common.helpers.assertions import pytest_assert
 from tests.dash.sairedis_utils import (get_sairedis_line_count,
                                        parse_sairedis_changes)
@@ -33,44 +35,37 @@ def common_setup_teardown(
         yield
         return
     dpuhost = dpuhosts[dpu_index]
-    logger.info(pl.ROUTING_TYPE_PL_CONFIG)
-
-    base_config_messages = {
-        **pl.APPLIANCE_FNIC_CONFIG,
-        **pl.ROUTING_TYPE_PL_CONFIG,
-        **pl.ROUTING_TYPE_VNET_CONFIG,
-        **pl.VNET_CONFIG,
-        **pl.ROUTE_GROUP1_CONFIG,
-        **pl.METER_POLICY_V4_CONFIG,
-    }
-    logger.info(base_config_messages)
-
-    apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
-
-    route_and_mapping_messages = {
-        **pl.PE_VNET_MAPPING_CONFIG,
-        **pl.PE_SUBNET_ROUTE_CONFIG,
-        **pl.VM_VNET_MAPPING_CONFIG,
-        **pl.VM_SUBNET_ROUTE_CONFIG,
-    }
-    logger.info(route_and_mapping_messages)
-    apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
 
     # inbound routing not implemented in Pensando SAI yet, so skip route rule programming
+    route_rule_configs = []
     if "pensando" not in dpuhost.facts["asic_type"]:
-        route_rule_messages = {
-            **pl.VM_VNI_ROUTE_RULE_CONFIG,
-            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
-            **pl.TRUSTED_VNI_ROUTE_RULE_CONFIG,
-        }
-        logger.info(route_rule_messages)
-        apply_messages(localhost, duthost, ptfhost, route_rule_messages, dpuhost.dpu_index)
+        route_rule_configs = [
+            pl.VM_VNI_ROUTE_RULE_CONFIG,
+            pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
+            pl.TRUSTED_VNI_ROUTE_RULE_CONFIG,
+        ]
 
-    logger.info(pl.ENI_FNIC_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_CONFIG, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+    # ``apply_dash_configs`` buckets entries by DASH table name and applies
+    # them in dependency order (see ``DashPhase`` in ``tests/common/dash_utils.py``):
+    # GROUP_1 (APPLIANCE) -> GROUP_2 (ROUTING_TYPE/METER_POLICY/OUTBOUND_PORT_MAP/VNET) ->
+    # GROUP_3 (METER_RULE) -> GROUP_4 (TUNNEL/OUTBOUND_PORT_MAP_RANGE/ENI/ROUTE_GROUP) ->
+    # GROUP_5 (ROUTE_RULE/ROUTE/VNET_MAPPING) -> GROUP_6 (ENI_ROUTE).
+    apply_dash_configs(
+        localhost, duthost, ptfhost, dpuhost.dpu_index,
+        pl.APPLIANCE_FNIC_CONFIG,
+        pl.ROUTING_TYPE_PL_CONFIG,
+        pl.ROUTING_TYPE_VNET_CONFIG,
+        pl.VNET_CONFIG,
+        pl.ROUTE_GROUP1_CONFIG,
+        pl.METER_POLICY_V4_CONFIG,
+        pl.PE_VNET_MAPPING_CONFIG,
+        pl.PE_SUBNET_ROUTE_CONFIG,
+        pl.VM_VNET_MAPPING_CONFIG,
+        pl.VM_SUBNET_ROUTE_CONFIG,
+        *route_rule_configs,
+        pl.ENI_FNIC_CONFIG,
+        pl.ENI_ROUTE_GROUP1_CONFIG,
+    )
 
     yield
 
@@ -99,7 +94,7 @@ def test_route_bind_churn(localhost, duthost, ptfhost, dpuhosts, dpu_index):
     pe_subnet_route_group2_config = {
         f"DASH_ROUTE_TABLE:{pl.ROUTE_GROUP2}:{pl.PE_CA_SUBNET}": {
             "routing_type": RoutingType.ROUTING_TYPE_VNET,
-            "vnet": pl.VNET2,
+            "vnet": pl.VNET1,
             "metering_class_or": "2048",
             "metering_class_and": "4095",
         }
@@ -273,15 +268,24 @@ def test_vnet_churn(localhost, duthost, ptfhost, dpuhosts, dpu_index):
         **pl.VM_SUBNET_ROUTE_CONFIG,
     }
     apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index, False)
+    apply_messages(localhost, duthost, ptfhost, pl.ROUTE_GROUP1_CONFIG, dpuhost.dpu_index, False)
+    apply_messages(localhost, duthost, ptfhost, pl.METER_POLICY_V4_CONFIG, dpuhost.dpu_index, False)
     apply_messages(localhost, duthost, ptfhost, pl.VNET_CONFIG, dpuhost.dpu_index, False)
 
     time.sleep(2)
 
     new_vni = "3001"
     vnet_config_v2 = {f"DASH_VNET_TABLE:{pl.VNET1}": {"vni": new_vni, "guid": pl.VNET1_GUID}}
+    eni_fnic_config_v2 = dict(pl.ENI_FNIC_CONFIG)  # deep copy to avoid modifying the original
+    eni_key = list(eni_fnic_config_v2.keys())[0]
+    # Update pl_sip_encoding to reflect the new VNI of 3001
+    eni_fnic_config_v2[eni_key]["pl_sip_encoding"] = f"::b90b:64:ff71:0:0/{pl.PL_ENCODING_MASK}"
+
     apply_messages(localhost, duthost, ptfhost, vnet_config_v2, dpuhost.dpu_index)
+    apply_messages(localhost, duthost, ptfhost, pl.ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+    apply_messages(localhost, duthost, ptfhost, pl.METER_POLICY_V4_CONFIG, dpuhost.dpu_index)
     apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_CONFIG, dpuhost.dpu_index)
+    apply_messages(localhost, duthost, ptfhost, eni_fnic_config_v2, dpuhost.dpu_index)
     apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
 
     time.sleep(2)

--- a/tests/dash/test_dash_metering.py
+++ b/tests/dash/test_dash_metering.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E231
 import logging
 import time
 
@@ -11,7 +12,7 @@ from packets import rand_udp_port_packets
 from tests.common.helpers.assertions import pytest_assert
 from configs.privatelink_config import TUNNEL1_ENDPOINT_IPS, TUNNEL2_ENDPOINT_IPS
 from tests.common import config_reload
-from tests.common.dash_utils import verify_tunnel_packets
+from tests.common.dash_utils import apply_dash_configs, verify_tunnel_packets
 from dash_eni_counter_utils import get_eni_counter_oid, get_eni_meter_counters
 
 logger = logging.getLogger(__name__)
@@ -51,93 +52,60 @@ def common_setup_teardown(
         yield
         return
     dpuhost = dpuhosts[dpu_index]
-    logger.info(pl.ROUTING_TYPE_PL_CONFIG)
 
     if single_endpoint:
         tunnel_config = pl.TUNNEL1_CONFIG
-    else:
-        tunnel_config = pl.TUNNEL2_CONFIG
-
-    base_config_messages = {
-        **pl.APPLIANCE_FNIC_CONFIG,
-        **pl.ROUTING_TYPE_PL_CONFIG,
-        **pl.ROUTING_TYPE_VNET_CONFIG,
-        **pl.VNET_CONFIG,
-        **pl.METER_POLICY_V4_CONFIG,
-        **pl.ROUTE_GROUP1_CONFIG,
-        **pl.ROUTE_GROUP2_CONFIG,
-        **pl.ROUTE_GROUP3_CONFIG,
-        **tunnel_config,
-    }
-    logger.info(base_config_messages)
-
-    apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
-
-    if single_endpoint:
         rg1_vm_subnet_route_config = pl.VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT
         rg2_vm_subnet_route_config = pl.RG2_VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT
         rg3_vm_subnet_route_config = pl.RG3_VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT
     else:
+        tunnel_config = pl.TUNNEL2_CONFIG
         rg1_vm_subnet_route_config = pl.VM_SUBNET_ROUTE_WITH_TUNNEL_MULTI_ENDPOINT
         rg2_vm_subnet_route_config = pl.RG2_VM_SUBNET_ROUTE_WITH_TUNNEL_MULTI_ENDPOINT
         rg3_vm_subnet_route_config = pl.RG3_VM_SUBNET_ROUTE_WITH_TUNNEL_MULTI_ENDPOINT
 
-    # Route-Group1 rule creation
-    route_messages = {
-        **pl.PE_SUBNET_ROUTE_CONFIG,
-        **rg1_vm_subnet_route_config
-    }
-    logger.info(route_messages)
-    apply_messages(localhost, duthost, ptfhost, route_messages, dpuhost.dpu_index)
-
-    # Route-Group2 rule creation
-    route_messages = {
-        **pl.METERCLASSOR_PE_SUBNET_ROUTE_CONFIG,
-        **rg2_vm_subnet_route_config,
-    }
-    logger.info(route_messages)
-    apply_messages(localhost, duthost, ptfhost, route_messages, dpuhost.dpu_index)
-
-    # Route-Group3 rule creation
-    route_messages = {
-        **pl.METERCLASSAND_PE_SUBNET_ROUTE_CONFIG,
-        **rg3_vm_subnet_route_config,
-    }
-    logger.info(route_messages)
-    apply_messages(localhost, duthost, ptfhost, route_messages, dpuhost.dpu_index)
-
     # inbound routing not implemented in Pensando SAI yet, so skip route rule programming
+    route_rule_configs = []
     if 'pensando' not in dpuhost.facts['asic_type']:
-        route_rule_messages = {
-            **pl.VM_VNI_ROUTE_RULE_CONFIG,
-            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
-            **pl.TRUSTED_VNI_ROUTE_RULE_CONFIG
-        }
-        logger.info(route_rule_messages)
-        apply_messages(localhost, duthost, ptfhost, route_rule_messages, dpuhost.dpu_index)
+        route_rule_configs = [
+            pl.VM_VNI_ROUTE_RULE_CONFIG,
+            pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
+            pl.TRUSTED_VNI_ROUTE_RULE_CONFIG,
+        ]
 
-    meter_rule_messages = {
-        **pl.METER_RULE2_V4_CONFIG,
-    }
-    logger.info(meter_rule_messages)
-    apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_FNIC_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_CONFIG, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+    # ``apply_dash_configs`` buckets entries by DASH table name and applies
+    # them in dependency order (see ``DashPhase`` in ``tests/common/dash_utils.py``):
+    # GROUP_1 (APPLIANCE) -> GROUP_2 (ROUTING_TYPE/METER_POLICY/OUTBOUND_PORT_MAP/VNET) ->
+    # GROUP_3 (METER_RULE) -> GROUP_4 (TUNNEL/OUTBOUND_PORT_MAP_RANGE/ENI/ROUTE_GROUP) ->
+    # GROUP_5 (ROUTE_RULE/ROUTE/VNET_MAPPING) -> GROUP_6 (ENI_ROUTE).
+    apply_dash_configs(
+        localhost, duthost, ptfhost, dpuhost.dpu_index,
+        pl.APPLIANCE_FNIC_CONFIG,
+        pl.ROUTING_TYPE_PL_CONFIG,
+        pl.ROUTING_TYPE_VNET_CONFIG,
+        pl.VNET_CONFIG,
+        pl.METER_POLICY_V4_CONFIG,
+        pl.ROUTE_GROUP1_CONFIG,
+        pl.ROUTE_GROUP2_CONFIG,
+        pl.ROUTE_GROUP3_CONFIG,
+        tunnel_config,
+        pl.PE_SUBNET_ROUTE_CONFIG,
+        rg1_vm_subnet_route_config,
+        pl.METERCLASSOR_PE_SUBNET_ROUTE_CONFIG,
+        rg2_vm_subnet_route_config,
+        pl.METERCLASSAND_PE_SUBNET_ROUTE_CONFIG,
+        rg3_vm_subnet_route_config,
+        *route_rule_configs,
+        pl.METER_RULE2_V4_CONFIG,
+        pl.ENI_FNIC_CONFIG,
+        pl.ENI_ROUTE_GROUP1_CONFIG,
+    )
 
     yield
 
     # Route rule removal is broken so config reload to cleanup for now
     # https://github.com/sonic-net/sonic-buildimage/issues/23590
     config_reload(dpuhost, safe_reload=True, yang_validate=False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_TRUSTED_VNI_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index, False)
 
 
 @pytest.mark.parametrize("metering_tc", ['ENI_METERPOLICY_HIT', 'MAPPING_METERCLASS_HIT',

--- a/tests/dash/test_dash_privatelink.py
+++ b/tests/dash/test_dash_privatelink.py
@@ -7,9 +7,9 @@ import random
 import ptf.packet as scapy
 from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
 from constants import VXLAN_UDP_BASE_SRC_PORT, VXLAN_UDP_SRC_PORT_MASK
-from gnmi_utils import apply_messages
 from packets import outbound_pl_packets, inbound_pl_packets
 from tests.common.config_reload import config_reload
+from tests.common.dash_utils import apply_dash_configs
 
 logger = logging.getLogger(__name__)
 
@@ -39,53 +39,38 @@ def common_setup_teardown(
     if skip_config:
         return
     dpuhost = dpuhosts[dpu_index]
-    logger.info(pl.ROUTING_TYPE_PL_CONFIG)
-    base_config_messages = {
-        **pl.APPLIANCE_CONFIG,
-        **pl.ROUTING_TYPE_PL_CONFIG,
-        **pl.VNET_CONFIG,
-        **pl.ROUTE_GROUP1_CONFIG,
-        **pl.METER_POLICY_V4_CONFIG
-    }
-    logger.info(base_config_messages)
 
-    apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
-
-    route_and_mapping_messages = {
-        **pl.PE_VNET_MAPPING_CONFIG,
-        **pl.PE_SUBNET_ROUTE_CONFIG,
-        **pl.VM_SUBNET_ROUTE_CONFIG
-    }
-
+    # ``INBOUND_VNI_ROUTE_RULE_CONFIG`` is only programmed on Bluefield DPUs;
+    # on other platforms ROUTE_RULE entries are skipped at the source.
+    bluefield_route_rule_configs = []
     if 'bluefield' in dpuhost.facts['asic_type']:
-        route_and_mapping_messages.update({
-            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG
-        })
+        bluefield_route_rule_configs = [pl.INBOUND_VNI_ROUTE_RULE_CONFIG]
 
-    logger.info(route_and_mapping_messages)
-    apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
-
-    meter_rule_messages = {
-        **pl.METER_RULE1_V4_CONFIG,
-        **pl.METER_RULE2_V4_CONFIG,
-    }
-    logger.info(meter_rule_messages)
-    apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_CONFIG, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+    # ``apply_dash_configs`` buckets entries by DASH table name and applies
+    # them in dependency order (see ``DashPhase`` in ``tests/common/dash_utils.py``):
+    # GROUP_1 (APPLIANCE) -> GROUP_2 (ROUTING_TYPE/METER_POLICY/OUTBOUND_PORT_MAP/VNET) ->
+    # GROUP_3 (METER_RULE) -> GROUP_4 (TUNNEL/OUTBOUND_PORT_MAP_RANGE/ENI/ROUTE_GROUP) ->
+    # GROUP_5 (ROUTE_RULE/ROUTE/VNET_MAPPING) -> GROUP_6 (ENI_ROUTE).
+    apply_dash_configs(
+        localhost, duthost, ptfhost, dpuhost.dpu_index,
+        pl.APPLIANCE_CONFIG,
+        pl.ROUTING_TYPE_PL_CONFIG,
+        pl.VNET_CONFIG,
+        pl.ROUTE_GROUP1_CONFIG,
+        pl.METER_POLICY_V4_CONFIG,
+        pl.PE_VNET_MAPPING_CONFIG,
+        pl.PE_SUBNET_ROUTE_CONFIG,
+        pl.VM_SUBNET_ROUTE_CONFIG,
+        *bluefield_route_rule_configs,
+        pl.METER_RULE1_V4_CONFIG,
+        pl.METER_RULE2_V4_CONFIG,
+        pl.ENI_CONFIG,
+        pl.ENI_ROUTE_GROUP1_CONFIG,
+    )
 
     yield
 
     config_reload(dpuhost, safe_reload=True, yang_validate=False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index, False)
 
 
 @pytest.mark.parametrize("encap_proto", ["vxlan", "gre"])

--- a/tests/dash/test_fnic.py
+++ b/tests/dash/test_fnic.py
@@ -1,16 +1,14 @@
-import logging
-
 import configs.privatelink_config as pl
 import ptf.testutils as testutils
 import ptf.packet as scapy
 import pytest
+import logging
 from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
-from gnmi_utils import apply_messages
 from packets import rand_udp_port_packets
 from tests.common.helpers.assertions import pytest_assert
 from configs.privatelink_config import TUNNEL1_ENDPOINT_IPS, TUNNEL2_ENDPOINT_IPS
 from tests.common import config_reload
-from tests.common.dash_utils import verify_tunnel_packets
+from tests.common.dash_utils import apply_dash_configs, verify_tunnel_packets
 
 logger = logging.getLogger(__name__)
 
@@ -49,72 +47,53 @@ def common_setup_teardown(
         yield
         return
     dpuhost = dpuhosts[dpu_index]
-    logger.info(pl.ROUTING_TYPE_PL_CONFIG)
 
     if single_endpoint:
         tunnel_config = pl.TUNNEL1_CONFIG
-    else:
-        tunnel_config = pl.TUNNEL2_CONFIG
-
-    base_config_messages = {
-        **pl.APPLIANCE_FNIC_CONFIG,
-        **pl.ROUTING_TYPE_PL_CONFIG,
-        **pl.ROUTING_TYPE_VNET_CONFIG,
-        **pl.VNET_CONFIG,
-        **pl.ROUTE_GROUP1_CONFIG,
-        **pl.METER_POLICY_V4_CONFIG,
-        **tunnel_config,
-    }
-    logger.info(base_config_messages)
-
-    apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
-
-    if single_endpoint:
         vm_subnet_route_config = pl.VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT
     else:
+        tunnel_config = pl.TUNNEL2_CONFIG
         vm_subnet_route_config = pl.VM_SUBNET_ROUTE_WITH_TUNNEL_MULTI_ENDPOINT
-    route_and_mapping_messages = {
-        **pl.PE_VNET_MAPPING_CONFIG,
-        **pl.PE_SUBNET_ROUTE_CONFIG,
-        **pl.VM_VNET_MAPPING_CONFIG,
-        **vm_subnet_route_config
-    }
-    logger.info(route_and_mapping_messages)
-    apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
 
     # inbound routing not implemented in Pensando SAI yet, so skip route rule programming
+    route_rule_configs = []
     if 'pensando' not in dpuhost.facts['asic_type']:
-        route_rule_messages = {
-            **pl.VM_VNI_ROUTE_RULE_CONFIG,
-            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
-            **pl.TRUSTED_VNI_ROUTE_RULE_CONFIG
-        }
-        logger.info(route_rule_messages)
-        apply_messages(localhost, duthost, ptfhost, route_rule_messages, dpuhost.dpu_index)
+        route_rule_configs = [
+            pl.VM_VNI_ROUTE_RULE_CONFIG,
+            pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
+            pl.TRUSTED_VNI_ROUTE_RULE_CONFIG,
+        ]
 
-    meter_rule_messages = {
-        **pl.METER_RULE1_V4_CONFIG,
-        **pl.METER_RULE2_V4_CONFIG,
-    }
-    logger.info(meter_rule_messages)
-    apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_FNIC_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_CONFIG, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+    # ``apply_dash_configs`` buckets entries by DASH table name and applies
+    # them in dependency order (see ``DashPhase`` in ``tests/common/dash_utils.py``):
+    # GROUP_1 (APPLIANCE) -> GROUP_2 (ROUTING_TYPE/METER_POLICY/OUTBOUND_PORT_MAP/VNET) ->
+    # GROUP_3 (METER_RULE) -> GROUP_4 (TUNNEL/OUTBOUND_PORT_MAP_RANGE/ENI/ROUTE_GROUP) ->
+    # GROUP_5 (ROUTE_RULE/ROUTE/VNET_MAPPING) -> GROUP_6 (ENI_ROUTE).
+    apply_dash_configs(
+        localhost, duthost, ptfhost, dpuhost.dpu_index,
+        pl.APPLIANCE_FNIC_CONFIG,
+        pl.ROUTING_TYPE_PL_CONFIG,
+        pl.ROUTING_TYPE_VNET_CONFIG,
+        pl.VNET_CONFIG,
+        pl.ROUTE_GROUP1_CONFIG,
+        pl.METER_POLICY_V4_CONFIG,
+        tunnel_config,
+        pl.PE_VNET_MAPPING_CONFIG,
+        pl.PE_SUBNET_ROUTE_CONFIG,
+        pl.VM_VNET_MAPPING_CONFIG,
+        vm_subnet_route_config,
+        *route_rule_configs,
+        pl.METER_RULE1_V4_CONFIG,
+        pl.METER_RULE2_V4_CONFIG,
+        pl.ENI_FNIC_CONFIG,
+        pl.ENI_ROUTE_GROUP1_CONFIG,
+    )
 
     yield
 
     # Route rule removal is broken so config reload to cleanup for now
     # https://github.com/sonic-net/sonic-buildimage/issues/23590
     config_reload(dpuhost, safe_reload=True, yang_validate=False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_TRUSTED_VNI_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index, False)
 
 
 @pytest.mark.parametrize("encap_proto", ["vxlan", "gre"])

--- a/tests/dash/test_plnsg.py
+++ b/tests/dash/test_plnsg.py
@@ -10,9 +10,8 @@ from constants import (
     VXLAN_UDP_BASE_SRC_PORT,
     VXLAN_UDP_SRC_PORT_MASK,
 )
-from gnmi_utils import apply_messages
 from packets import inbound_pl_packets, plnsg_packets
-from tests.common.dash_utils import verify_tunnel_packets
+from tests.common.dash_utils import apply_dash_configs, verify_tunnel_packets
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 import ptf.packet as scapy
 
@@ -42,59 +41,44 @@ def config_setup_teardown(
         yield
         return
     dpuhost = dpuhosts[dpu_index]
-    logger.info(pl.ROUTING_TYPE_PL_CONFIG)
 
     if single_endpoint:
         tunnel_config = pl.TUNNEL3_CONFIG
-    else:
-        tunnel_config = pl.TUNNEL4_CONFIG
-
-    base_config_messages = {
-        **pl.APPLIANCE_CONFIG,
-        **pl.ROUTING_TYPE_PL_CONFIG,
-        **pl.ROUTING_TYPE_VNET_CONFIG,
-        **pl.VNET_CONFIG,
-        **pl.VNET2_CONFIG,
-        **pl.ROUTE_GROUP1_CONFIG,
-        **pl.METER_POLICY_V4_CONFIG,
-        **tunnel_config,
-    }
-    logger.info(base_config_messages)
-
-    apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
-
-    if single_endpoint:
         vnet_mapping_config = pl.PE_PLNSG_SINGLE_ENDPOINT_VNET_MAPPING_CONFIG
     else:
+        tunnel_config = pl.TUNNEL4_CONFIG
         vnet_mapping_config = pl.PE_PLNSG_MULTI_ENDPOINT_VNET_MAPPING_CONFIG
-    route_and_mapping_messages = {
-        **vnet_mapping_config,
-        **pl.PE_SUBNET_ROUTE_CONFIG,
-        **pl.VM_SUBNET_ROUTE_CONFIG,
-    }
-    logger.info(route_and_mapping_messages)
-    apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
 
+    route_rule_configs = []
     if 'pensando' not in dpuhost.facts['asic_type']:
-        route_rule_messages = {
-            **pl.VM_VNI_ROUTE_RULE_CONFIG,
-            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
-        }
-        logger.info(route_rule_messages)
-        apply_messages(localhost, duthost, ptfhost, route_rule_messages, dpuhost.dpu_index)
+        route_rule_configs = [
+            pl.VM_VNI_ROUTE_RULE_CONFIG,
+            pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
+        ]
 
-    meter_rule_messages = {
-        **pl.METER_RULE1_V4_CONFIG,
-        **pl.METER_RULE2_V4_CONFIG,
-    }
-    logger.info(meter_rule_messages)
-    apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_CONFIG, dpuhost.dpu_index)
-
-    logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+    # ``apply_dash_configs`` buckets entries by DASH table name and applies
+    # them in dependency order (see ``DashPhase`` in ``tests/common/dash_utils.py``):
+    # GROUP_1 (APPLIANCE) -> GROUP_2 (ROUTING_TYPE/METER_POLICY/OUTBOUND_PORT_MAP/VNET) ->
+    # GROUP_3 (METER_RULE) -> GROUP_4 (TUNNEL/OUTBOUND_PORT_MAP_RANGE/ENI/ROUTE_GROUP) ->
+    # GROUP_5 (ROUTE_RULE/ROUTE/VNET_MAPPING) -> GROUP_6 (ENI_ROUTE).
+    apply_dash_configs(
+        localhost, duthost, ptfhost, dpuhost.dpu_index,
+        pl.APPLIANCE_CONFIG,
+        pl.ROUTING_TYPE_PL_CONFIG,
+        pl.ROUTING_TYPE_VNET_CONFIG,
+        pl.VNET_CONFIG,
+        pl.ROUTE_GROUP1_CONFIG,
+        pl.METER_POLICY_V4_CONFIG,
+        tunnel_config,
+        vnet_mapping_config,
+        pl.PE_SUBNET_ROUTE_CONFIG,
+        pl.VM_SUBNET_ROUTE_CONFIG,
+        *route_rule_configs,
+        pl.METER_RULE1_V4_CONFIG,
+        pl.METER_RULE2_V4_CONFIG,
+        pl.ENI_CONFIG,
+        pl.ENI_ROUTE_GROUP1_CONFIG,
+    )
 
     yield
 

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -414,6 +414,11 @@ def hash_keys(duthost, tbinfo):
         #  to ensure packets are evenly distributed to all 64 egress ports
         if 'ip-proto' in hash_keys:
             hash_keys.remove('ip-proto')
+    if tbinfo['topo']['name'] in ['t2_single_node_max_64p', 't2_single_node_max_64p_v2']:
+        # Remove ip-proto on topos that have 64 ports as there isn't enough entropy in
+        # the ip-proto field (8-bits) to get a good distribution across that many ports
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
     # remove the ingress port from multi asic platform
     # In multi asic platform each asic has different hash seed,
     # the same packet coming in different asic

--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -62,19 +62,32 @@ def skip_when_buffer_is_dynamic_model(duthost):
 
 # Function Fixture
 @pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exceptions(duthosts, selected_dut_hostname, loganalyzer):
+def ignore_expected_loganalyzer_exceptions(request, duthosts, loganalyzer):
     """
        Ignore expected yang validation failure during test execution
 
        GCU will try several sortings of JsonPatch until the sorting passes yang validation
 
        Args:
+            request: Pytest request object to detect which DUT fixture is being used
             duthosts: list of DUTs.
-            selected_dut_hostname: Hostname of a random chosen dut
            loganalyzer: Loganalyzer utility fixture
     """
+    # Determine which DUT hostname fixture is being used
+    if "enum_rand_one_per_hwsku_frontend_hostname" in request.fixturenames:
+        dut_hostname = request.getfixturevalue("enum_rand_one_per_hwsku_frontend_hostname")
+    elif "selected_dut_hostname" in request.fixturenames:
+        dut_hostname = request.getfixturevalue("selected_dut_hostname")
+    elif "rand_one_dut_front_end_hostname" in request.fixturenames:
+        dut_hostname = request.getfixturevalue("rand_one_dut_front_end_hostname")
+    elif "rand_one_dut_hostname" in request.fixturenames:
+        dut_hostname = request.getfixturevalue("rand_one_dut_hostname")
+    else:
+        # Fallback - try to get any available DUT
+        return
+
+    duthost = duthosts[dut_hostname]
     # When loganalyzer is disabled, the object could be None
-    duthost = duthosts[selected_dut_hostname]
     if loganalyzer:
         ignoreRegex = [
             ".*ERR sonic_yang.*",

--- a/tests/generic_config_updater/test_portchannel_interface.py
+++ b/tests/generic_config_updater/test_portchannel_interface.py
@@ -34,21 +34,48 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def rand_portchannel_name(cfg_facts):
-    portchannel_dict = cfg_facts.get('PORTCHANNEL', {})
-    pytest_require(portchannel_dict, "Portchannel table is empty")
-    for portchannel_key in portchannel_dict:
-        return portchannel_key
+def cfg_facts(duthosts, enum_rand_one_per_hwsku_frontend_hostname, frontend_asic_index_with_portchannel):
+    """
+    Override cfg_facts to use the ASIC with portchannels.
+    This ensures portchannel tests get config from an ASIC that has portchannels.
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    asic_id = frontend_asic_index_with_portchannel
+    asic_namespace = duthost.get_namespace_from_asic_id(asic_id)
+    return duthost.config_facts(host=duthost.hostname, source="persistent", namespace=asic_namespace)['ansible_facts']
 
 
 @pytest.fixture(scope="module")
-def portchannel_table(cfg_facts):
+def rand_portchannel_name(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, cfg_facts):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    portchannel_dict = cfg_facts.get('PORTCHANNEL', {})
+    pytest_require(portchannel_dict, "Portchannel table is empty")
+
+    # Filter out backend/internal portchannels
+    for portchannel_key in portchannel_dict:
+        if not duthost.is_backend_portchannel(portchannel_key, mg_facts):
+            logger.info(f"Selected external portchannel: {portchannel_key}")
+            return portchannel_key
+
+    pytest_require(False, "No external portchannels found")
+
+
+@pytest.fixture(scope="module")
+def portchannel_table(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, cfg_facts):
     def _is_ipv4_address(ip_addr):
         return ipaddress.ip_address(ip_addr).version == 4
 
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     pytest_require("PORTCHANNEL_INTERFACE" in cfg_facts, "Unsupported without port_channel")
     portchannel_table = {}
     for portchannel, ip_addresses in list(cfg_facts["PORTCHANNEL_INTERFACE"].items()):
+        # Skip backend/internal portchannels
+        if duthost.is_backend_portchannel(portchannel, mg_facts):
+            logger.info(f"Skipping backend portchannel: {portchannel}")
+            continue
+
         ips = {}
         for ip_address in ip_addresses:
             if _is_ipv4_address(ip_address.split("/")[0]):
@@ -69,14 +96,14 @@ def check_portchannel_table(duthost, portchannel_table):
 
 
 @pytest.fixture(autouse=True)
-def setup_env(duthosts, rand_one_dut_hostname, portchannel_table):
+def setup_env(duthosts, enum_rand_one_per_hwsku_frontend_hostname, portchannel_table):
     """
     Setup/teardown fixture for portchannel interface config
     Args:
         duthosts: list of DUTs.
-        rand_one_dut_hostname: The fixture returns a randomly selected DuT
+        enum_rand_one_per_hwsku_frontend_hostname: The fixture returns one DUT per hardware SKU
     """
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     create_checkpoint(duthost)
 
     yield
@@ -89,12 +116,12 @@ def setup_env(duthosts, rand_one_dut_hostname, portchannel_table):
         delete_checkpoint(duthost)
 
 
-def portchannel_interface_tc1_add_duplicate(duthost, portchannel_table, enum_rand_one_frontend_asic_index,
+def portchannel_interface_tc1_add_duplicate(duthost, portchannel_table, frontend_asic_index_with_portchannel,
                                             rand_portchannel_name):
     """ Test adding duplicate portchannel interface
     """
-    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
-        'asic{}'.format(enum_rand_one_frontend_asic_index)
+    asic_namespace = None if frontend_asic_index_with_portchannel is None else \
+        'asic{}'.format(frontend_asic_index_with_portchannel)
     dup_ip = portchannel_table[rand_portchannel_name]["ip"]
     dup_ipv6 = portchannel_table[rand_portchannel_name]["ipv6"]
     json_patch = [
@@ -128,7 +155,7 @@ def portchannel_interface_tc1_add_duplicate(duthost, portchannel_table, enum_ran
         delete_tmpfile(duthost, tmpfile)
 
 
-def portchannel_interface_tc1_xfail(duthost, enum_rand_one_frontend_asic_index, rand_portchannel_name):
+def portchannel_interface_tc1_xfail(duthost, frontend_asic_index_with_portchannel, rand_portchannel_name):
     """ Test invalid ip address and remove unexited interface
 
     ("add", "PortChannel101", "10.0.0.256/31", "FC00::71/126"), ADD Invalid IPv4 address
@@ -136,8 +163,8 @@ def portchannel_interface_tc1_xfail(duthost, enum_rand_one_frontend_asic_index, 
     ("remove", "PortChannel101", "10.0.0.57/31", "FC00::71/126"), REMOVE Unexist IPv4 address
     ("remove", "PortChannel101", "10.0.0.56/31", "FC00::72/126"), REMOVE Unexist IPv6 address
     """
-    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
-        'asic{}'.format(enum_rand_one_frontend_asic_index)
+    asic_namespace = None if frontend_asic_index_with_portchannel is None else \
+        'asic{}'.format(frontend_asic_index_with_portchannel)
     xfail_input = [
         ("add", rand_portchannel_name, "10.0.0.256/31", "FC00::71/126"),
         ("add", rand_portchannel_name, "10.0.0.56/31", "FC00::xyz/126"),
@@ -174,12 +201,12 @@ def portchannel_interface_tc1_xfail(duthost, enum_rand_one_frontend_asic_index, 
 
 
 def portchannel_interface_tc1_add_and_rm(duthost, portchannel_table,
-                                         enum_rand_one_frontend_asic_index,
+                                         frontend_asic_index_with_portchannel,
                                          rand_portchannel_name):
     """ Test portchannel interface replace ip address
     """
-    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
-        'asic{}'.format(enum_rand_one_frontend_asic_index)
+    asic_namespace = None if frontend_asic_index_with_portchannel is None else \
+        'asic{}'.format(frontend_asic_index_with_portchannel)
     org_ip = portchannel_table[rand_portchannel_name]["ip"]
     org_ipv6 = portchannel_table[rand_portchannel_name]["ipv6"]
     rep_ip = "10.0.0.156/31"
@@ -224,15 +251,15 @@ def portchannel_interface_tc1_add_and_rm(duthost, portchannel_table,
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_portchannel_interface_tc1_suite(duthosts, rand_one_dut_hostname, portchannel_table,
-                                         enum_rand_one_frontend_asic_index, rand_portchannel_name):
-    duthost = duthosts[rand_one_dut_hostname]
+def test_portchannel_interface_tc1_suite(duthosts, enum_rand_one_per_hwsku_frontend_hostname, portchannel_table,
+                                         frontend_asic_index_with_portchannel, rand_portchannel_name):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     portchannel_interface_tc1_add_duplicate(duthost, portchannel_table,
-                                            enum_rand_one_frontend_asic_index, rand_portchannel_name)
+                                            frontend_asic_index_with_portchannel, rand_portchannel_name)
     portchannel_interface_tc1_xfail(duthost,
-                                    enum_rand_one_frontend_asic_index, rand_portchannel_name)
+                                    frontend_asic_index_with_portchannel, rand_portchannel_name)
     portchannel_interface_tc1_add_and_rm(duthost, portchannel_table,
-                                         enum_rand_one_frontend_asic_index, rand_portchannel_name)
+                                         frontend_asic_index_with_portchannel, rand_portchannel_name)
 
 
 def verify_po_running(duthost, portchannel_table):
@@ -281,12 +308,12 @@ def verify_attr_change(duthost, po_name, attr, value):
 
 
 def portchannel_interface_tc2_replace(duthost,
-                                      enum_rand_one_frontend_asic_index,
+                                      frontend_asic_index_with_portchannel,
                                       rand_portchannel_name):
     """Test PortChannelXXXX attribute change
     """
-    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
-        'asic{}'.format(enum_rand_one_frontend_asic_index)
+    asic_namespace = None if frontend_asic_index_with_portchannel is None else \
+        'asic{}'.format(frontend_asic_index_with_portchannel)
     attributes = [
         ("mtu", "3324"),
         ("min_links", "2"),
@@ -319,12 +346,12 @@ def portchannel_interface_tc2_replace(duthost,
 
 
 def portchannel_interface_tc2_incremental(duthost,
-                                          enum_rand_one_frontend_asic_index,
+                                          frontend_asic_index_with_portchannel,
                                           rand_portchannel_name):
     """Test PortChannelXXXX incremental change
     """
-    asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
-        'asic{}'.format(enum_rand_one_frontend_asic_index)
+    asic_namespace = None if frontend_asic_index_with_portchannel is None else \
+        'asic{}'.format(frontend_asic_index_with_portchannel)
     json_patch = [
         {
          "op": "add",
@@ -345,13 +372,13 @@ def portchannel_interface_tc2_incremental(duthost,
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_portchannel_interface_tc2_attributes(duthosts, rand_one_dut_hostname,
-                                              enum_rand_one_frontend_asic_index,
+def test_portchannel_interface_tc2_attributes(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                              frontend_asic_index_with_portchannel,
                                               rand_portchannel_name):
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     portchannel_interface_tc2_replace(duthost,
-                                      enum_rand_one_frontend_asic_index,
+                                      frontend_asic_index_with_portchannel,
                                       rand_portchannel_name)
     portchannel_interface_tc2_incremental(duthost,
-                                          enum_rand_one_frontend_asic_index,
+                                          frontend_asic_index_with_portchannel,
                                           rand_portchannel_name)

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -125,6 +125,13 @@ def test_lldp(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
                 )
 
 
+def _neighbor_has_lldp_entry(localhost, hostip, snmp_community, neighbor_interface):
+    """Return True if the neighbor's LLDP table contains the expected interface."""
+    nei_lldp_facts = localhost.lldp_facts(
+        host=hostip, version='v2c', community=snmp_community)['ansible_facts']
+    return neighbor_interface in nei_lldp_facts.get('ansible_lldp_facts', {})
+
+
 def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_duts,
                         enum_rand_one_frontend_asic_index, tbinfo, request):
     """ verify LLDP information on neighbors """
@@ -162,13 +169,22 @@ def check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_
             hostip = nei_meta[v['chassis']['name']]['mgmt_addr']
 
         if request.config.getoption("--neighbor_type") == 'eos':
-            nei_lldp_facts = localhost.lldp_facts(host=hostip, version='v2c', community=eos['snmp_rocommunity'])[
-                'ansible_facts']
             neighbor_interface = v['port']['ifname']
+            snmp_community = eos['snmp_rocommunity']
         else:
-            nei_lldp_facts = localhost.lldp_facts(host=hostip, version='v2c', community=sonic['snmp_rocommunity'])[
-                'ansible_facts']
             neighbor_interface = v['port']['local']
+            snmp_community = sonic['snmp_rocommunity']
+
+        # After swss restart, the DUT's LLDP entry on the neighbor may have aged out
+        # during the restart window. Wait until the neighbor re-learns DUT's LLDP info.
+        assert wait_until(30, 5, 0, _neighbor_has_lldp_entry,
+                          localhost, hostip, snmp_community, neighbor_interface), \
+            "Neighbor {} did not learn LLDP on interface '{}' within 30s".format(
+                hostip, neighbor_interface)
+
+        nei_lldp_facts = localhost.lldp_facts(
+            host=hostip, version='v2c', community=snmp_community)['ansible_facts']
+
         # Verify the published DUT system name field is correct
         assert nei_lldp_facts['ansible_lldp_facts'][neighbor_interface]['neighbor_sys_name'] == duthost.hostname, (
             "LLDP neighbor system name mismatch for interface '{}'. "

--- a/tests/pc/test_po_update.py
+++ b/tests/pc/test_po_update.py
@@ -190,6 +190,22 @@ def test_po_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
             or wait_until(10, 10, 0, pc_active, asichost, tmp_portchannel))
     finally:
         # Recover all states
+        # The T1 topology golden config (smartswitch_t1.json) installs a static route
+        # "10.2.0.1/32 via 18.0.202.1" whose nexthop is resolved recursively. While
+        # PortChannel999 is operationally up and holds the 10.0.0.0/31 subnet, FRR
+        # resolves that static route through PortChannel999. sonic-utilities
+        # config/main.py checks "show ip route vrf all static" before removing the
+        # last IP on an interface and raises:
+        #   "Cannot remove the last IP entry of interface PortChannel999.
+        #    A static ip route is still bound to the RIF."
+        # Issuing admin-down on PortChannel999 first drops the LAG link, tears down
+        # BGP, and causes FRR to withdraw PortChannel999 from the recursive nexthop
+        # resolution. A brief sleep allows FRR to update its routing table before
+        # the IP removal is attempted, preserving the original cleanup order
+        # (IP removed before members).
+        if create_tmp_portchannel:
+            asichost.shutdown_interface(tmp_portchannel)
+            time.sleep(5)
         if add_tmp_portchannel_ip:
             asichost.config_ip_intf(tmp_portchannel, portchannel_ip + "/" + prefix_len, "remove")
 
@@ -384,6 +400,22 @@ def test_po_update_io_no_loss(
                       "Packets lost rate > {} during pc members add/removal, send_count: {}, match_count: {}".format(
                           max_loss_rate, send_count, match_count))
     finally:
+        # The T1 topology golden config (smartswitch_t1.json) installs a static route
+        # "10.2.0.1/32 via 18.0.202.1" whose nexthop is resolved recursively. While
+        # PortChannel999 is operationally up and holds the 10.0.0.0/31 subnet, FRR
+        # resolves that static route through PortChannel999. sonic-utilities
+        # config/main.py checks "show ip route vrf all static" before removing the
+        # last IP on an interface and raises:
+        #   "Cannot remove the last IP entry of interface PortChannel999.
+        #    A static ip route is still bound to the RIF."
+        # Issuing admin-down on PortChannel999 first drops the LAG link, tears down
+        # BGP, and causes FRR to withdraw PortChannel999 from the recursive nexthop
+        # resolution. A brief sleep allows FRR to update its routing table before
+        # the IP removal is attempted, preserving the original cleanup order
+        # (IP removed before members).
+        if create_tmp_pc:
+            asichost.shutdown_interface(tmp_pc)
+            time.sleep(5)
         if add_tmp_pc_ip:
             asichost.config_ip_intf(tmp_pc, pc_ip + "/31", "remove")
             time.sleep(2)

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -167,16 +167,6 @@ def execute_config_reload_cmd(duthost, timeout=120, check_interval=5):
         return False, None
 
 
-def check_docker_status(duthost):
-    containers = duthost.get_all_containers()
-    for container in containers:
-        if 'disabled' in duthost.get_feature_status()[0].get(container, ''):
-            continue
-        if not duthost.is_service_fully_started(container):
-            return False
-    return True
-
-
 def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname, delayed_services,
                                      localhost, conn_graph_facts, xcvr_skip_list):      # noqa: F811
     """
@@ -223,8 +213,8 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
 
     if not duthost.get_facts().get("modular_chassis"):
         # Check if all containers have started
-        assert wait_until(300, 10, 0, check_docker_status, duthost), (
-            "Not all Docker containers reached the 'fully started' state within 300 seconds "
+        assert wait_until(300, 10, 0, duthost.critical_services_fully_started), (
+            "Not all Docker containers reached the 'fully started' state within 300 seconds"
         )
 
         # To ensure the system is stable enough, wait for another 30s

--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -202,25 +202,24 @@ qos_params:
         topo-ft2-64:
             800000_5m:
                 hdrm_pool_size:
-                    dscps:
-                    - 3
-                    - 4
+                    dscps: [3, 4]
                     dst_port_id: 0
                     ecn: 1
                     margin: 4
-                    pgs:
-                    - 3
-                    - 4
+                    pgs: [3, 4]
                     pgs_num: 13
                     pkts_num_hdrm_full: 2853
                     pkts_num_hdrm_partial: 1124
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_pfc: 142285
+                    pkts_num_trig_pfc_multi: [142285, 71159, 35597, 17815, 8925, 4479,
+                        2257, 1145, 590, 312, 173, 103, 69]
+                    src_port_ids: [1, 2, 3, 4, 5, 6, 7]
                 lossy_queue_1:
                     dscp: 8
                     ecn: 1
                     pg: 0
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 141835
+                    pkts_num_trig_egr_drp: 142259
                 pkts_num_egr_mem: 714
                 pkts_num_leak_out: 0
                 wm_pg_headroom:
@@ -229,8 +228,8 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 144715
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_ingr_drp: 145139
+                    pkts_num_trig_pfc: 142285
                 wm_pg_shared_lossless:
                     cell_size: 254
                     dscp: 3
@@ -239,7 +238,7 @@ qos_params:
                     pg: 3
                     pkts_num_fill_min: 34
                     pkts_num_margin: 4
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_pfc: 142285
                 wm_pg_shared_lossy:
                     cell_size: 254
                     dscp: 8
@@ -248,14 +247,14 @@ qos_params:
                     pg: 0
                     pkts_num_fill_min: 7
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 141835
+                    pkts_num_trig_egr_drp: 142259
                 wm_q_shared_lossless:
                     cell_size: 254
                     dscp: 3
                     ecn: 1
                     pkts_num_fill_min: 0
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 144715
+                    pkts_num_trig_ingr_drp: 145139
                     queue: 3
                 wm_q_shared_lossy:
                     cell_size: 254
@@ -263,38 +262,38 @@ qos_params:
                     ecn: 1
                     pkts_num_fill_min: 7
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 141835
+                    pkts_num_trig_egr_drp: 142259
                     queue: 0
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 144715
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_ingr_drp: 145139
+                    pkts_num_trig_pfc: 142285
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 144715
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_ingr_drp: 145139
+                    pkts_num_trig_pfc: 142285
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_dismiss_pfc: 14
                     pkts_num_margin: 4
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_pfc: 142285
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_dismiss_pfc: 14
                     pkts_num_margin: 4
-                    pkts_num_trig_pfc: 141861
+                    pkts_num_trig_pfc: 142285
             cell_size: 254
-            hdrm_pool_wm_multiplier: 1
+            hdrm_pool_wm_multiplier: 2
             wrr:
                 ecn: 1
                 limit: 80

--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -321,25 +321,25 @@ qos_params:
         topo-lt2-p32o64:
             800000_5m:
                 hdrm_pool_size:
-                    dscps:
-                    - 3
-                    - 4
+                    dscps: [3, 4]
                     dst_port_id: 0
                     ecn: 1
                     margin: 4
-                    pgs:
-                    - 3
-                    - 4
+                    pgs: [3, 4]
                     pgs_num: 24
                     pkts_num_hdrm_full: 2853
                     pkts_num_hdrm_partial: 701
-                    pkts_num_trig_pfc: 108469
+                    pkts_num_trig_pfc: 125589
+                    pkts_num_trig_pfc_multi: [125589, 62811, 31423, 15728, 7881, 3958,
+                        1996, 1015, 524, 279, 157, 95, 65, 49, 42, 38, 36, 35, 34,
+                        34, 34, 34, 34, 34]
+                    src_port_ids: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
                 lossy_queue_1:
                     dscp: 8
                     ecn: 1
                     pg: 0
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 108443
+                    pkts_num_trig_egr_drp: 125563
                 pkts_num_egr_mem: 714
                 pkts_num_leak_out: 0
                 wm_pg_headroom:
@@ -348,8 +348,8 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 111323
-                    pkts_num_trig_pfc: 108469
+                    pkts_num_trig_ingr_drp: 128443
+                    pkts_num_trig_pfc: 125589
                 wm_pg_shared_lossless:
                     cell_size: 254
                     dscp: 3
@@ -358,7 +358,7 @@ qos_params:
                     pg: 3
                     pkts_num_fill_min: 34
                     pkts_num_margin: 4
-                    pkts_num_trig_pfc: 108469
+                    pkts_num_trig_pfc: 125589
                 wm_pg_shared_lossy:
                     cell_size: 254
                     dscp: 8
@@ -367,14 +367,14 @@ qos_params:
                     pg: 0
                     pkts_num_fill_min: 7
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 108443
+                    pkts_num_trig_egr_drp: 125563
                 wm_q_shared_lossless:
                     cell_size: 254
                     dscp: 3
                     ecn: 1
                     pkts_num_fill_min: 0
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 111323
+                    pkts_num_trig_ingr_drp: 128443
                     queue: 3
                 wm_q_shared_lossy:
                     cell_size: 254
@@ -382,38 +382,38 @@ qos_params:
                     ecn: 1
                     pkts_num_fill_min: 7
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 108443
+                    pkts_num_trig_egr_drp: 125563
                     queue: 0
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 111323
-                    pkts_num_trig_pfc: 108469
+                    pkts_num_trig_ingr_drp: 128443
+                    pkts_num_trig_pfc: 125589
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 111323
-                    pkts_num_trig_pfc: 108469
+                    pkts_num_trig_ingr_drp: 128443
+                    pkts_num_trig_pfc: 125589
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_dismiss_pfc: 14
                     pkts_num_margin: 4
-                    pkts_num_trig_pfc: 108469
+                    pkts_num_trig_pfc: 125589
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_dismiss_pfc: 14
                     pkts_num_margin: 4
-                    pkts_num_trig_pfc: 108469
+                    pkts_num_trig_pfc: 125589
             cell_size: 254
-            hdrm_pool_wm_multiplier: 1
+            hdrm_pool_wm_multiplier: 2
             wrr:
                 ecn: 1
                 limit: 80

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2472,35 +2472,21 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
-        duthost = duthosts.frontend_nodes[0]
-        if duthost.sonichost.is_multi_asic:
-            for duthost in get_src_dst_asic_and_duts['all_duts']:
-                for asic in duthost.asics:
-                    namespace_arg = '-n asic{}'.format(asic.asic_index)
-                    duthost.command("sudo counterpoll watermark {} enable".format(namespace_arg))
-                    duthost.command("sudo counterpoll queue {} enable".format(namespace_arg))
-        else:
-            for dut_asic in get_src_dst_asic_and_duts["all_asics"]:
-                dut_asic.command("counterpoll watermark enable")
-                dut_asic.command("counterpoll queue enable")
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            for asic in duthost.asics:
+                ConterpollHelper.enable_counterpoll(asic, ['watermark', 'queue'])
 
         time.sleep(70)
-        if duthost.sonichost.is_multi_asic:
-            for duthost in get_src_dst_asic_and_duts['all_duts']:
-                for asic in duthost.asics:
-                    namespace_arg = '-n asic{}'.format(asic.asic_index)
-                    duthost.command("sudo counterpoll watermark {} disable".format(namespace_arg))
-                    duthost.command("sudo counterpoll queue {} disable".format(namespace_arg))
-        else:
-            for dut_asic in get_src_dst_asic_and_duts['all_asics']:
-                dut_asic.command("counterpoll watermark disable")
-                dut_asic.command("counterpoll queue disable")
+
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            for asic in duthost.asics:
+                ConterpollHelper.disable_counterpoll(asic, ['watermark', 'queue'])
 
         yield
 
-        for dut_asic in get_src_dst_asic_and_duts['all_asics']:
-            dut_asic.command("counterpoll watermark enable")
-            dut_asic.command("counterpoll queue enable")
+        for duthost in get_src_dst_asic_and_duts['all_duts']:
+            for asic in duthost.asics:
+                ConterpollHelper.enable_counterpoll(asic, ['watermark', 'queue'])
 
     @pytest.fixture
     def blockGrpcTraffic(self, tbinfo, lower_tor_host, nic_simulator_info):   # noqa F811

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1600,7 +1600,7 @@ class QosSaiBase(QosBase):
 
         src_dut.shell("sudo config bgp start all")
         if src_asic != dst_asic:
-            updateFeatureState(dst_asic, "lldp", "enabled")
+            updateFeatureState(dst_dut, "lldp", "enabled")
             with SafeThreadPoolExecutor(max_workers=8) as executor:
                 for service in dst_services:
                     executor.submit(updateDockerService, dst_dut, action="start", **service)

--- a/tests/route/test_duplicate_route.py
+++ b/tests/route/test_duplicate_route.py
@@ -139,19 +139,17 @@ def setup_routes(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     if interface_types == 'Loopback':
         # Get loopback ips
         intf_ips = get_intf_ips('Loopback', cfg_facts)
-        pytest_require((len(intf_ips['ipv4']) + len(intf_ips['ipv6'])) > 0, "No IP configured on Loopback0")
     else:
         # Get vlan ips
         intf_ips = get_intf_ips('Vlan', cfg_facts)
-        pytest_require((len(intf_ips['ipv4']) + len(intf_ips['ipv6'])) > 0, "No IP configured on any Vlan")
+
+    ip_key = 'ipv4' if ip_versions == 4 else 'ipv6'
+    pytest_require(len(intf_ips[ip_key]) > 0, "No {} configured on {}".format(ip_key, interface_types))
 
     # Generate interfaces and neighbors
     intf_neighs, str_intf_nexthop = generate_intf_neigh(
         asichost, 1, ip_versions)
-    if ip_versions == 4:
-        prefixes.append(str(random.choice(intf_ips['ipv4'])).split("/")[0])
-    else:
-        prefixes.append(str(random.choice(intf_ips['ipv6'])).split("/")[0])
+    prefixes.append(str(random.choice(intf_ips[ip_key])).split("/")[0])
 
     # Setup interface IPs and neighbors
     prepare_dut(asichost, intf_neighs)

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -148,6 +148,14 @@ def get_ifindex(duthost, port):
     ifindex = duthost.shell('cat /sys/class/net/%s/ifindex' % port)['stdout']
     return ifindex
 
+
+def sflow_intfs_exist(duthost, interfaces):
+    for intf in interfaces:
+        res = duthost.shell(f"test -e /sys/class/net/{intf}", module_ignore_errors=True)
+        if res['rc'] != 0:
+            return False
+    return True
+
 # ----------------------------------------------------------------------------------
 
 
@@ -737,6 +745,8 @@ class TestReboot():
             300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
         verify_show_sflow(duthost, status='up', collector=[
                           'collector0', 'collector1'])
+        all_intfs_present = wait_until(120, 10, 0, sflow_intfs_exist, duthost, list(var['sflow_ports'].keys()))
+        assert all_intfs_present, "Not all sflow interfaces present in sysfs after fast reboot"
         for intf in var['sflow_ports']:
             var['sflow_ports'][intf]['ifindex'] = get_ifindex(duthost, intf)
             var['sflow_ports'][intf]['port_index'] = get_port_index(
@@ -761,6 +771,8 @@ class TestReboot():
             300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
         verify_show_sflow(duthost, status='up', collector=[
                           'collector0', 'collector1'])
+        all_intfs_present = wait_until(120, 10, 0, sflow_intfs_exist, duthost, list(var['sflow_ports'].keys()))
+        assert all_intfs_present, "Not all sflow interfaces present in sysfs after warm reboot"
         for intf in var['sflow_ports']:
             var['sflow_ports'][intf]['ifindex'] = get_ifindex(duthost, intf)
             var['sflow_ports'][intf]['port_index'] = get_port_index(

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -57,10 +57,28 @@ def withdraw_and_announce_existing_routes(duthosts, localhost, tbinfo, enum_rand
     logger.info("withdraw existing ipv4 and ipv6 routes")
     localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
 
-    wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
-    sleep_to_wait(CRM_POLLING_INTERVAL * 100)
+    result = wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
+    if not result:
+        logger.warning("Failed to process all withdraw requests in {} seconds".format(MAX_WAIT_TIME))
+
     ipv4_route_used_before = get_crm_resource_status(duthost, "ipv4_route", "used", namespace)
     ipv6_route_used_before = get_crm_resource_status(duthost, "ipv6_route", "used", namespace)
+
+    def routes_stable():
+        nonlocal ipv4_route_used_before, ipv6_route_used_before
+        ipv4_route_used_now = get_crm_resource_status(duthost, "ipv4_route", "used", namespace)
+        ipv6_route_used_now = get_crm_resource_status(duthost, "ipv6_route", "used", namespace)
+        ipv4_stable = ipv4_route_used_now == ipv4_route_used_before
+        ipv6_stable = ipv6_route_used_now == ipv6_route_used_before
+        ipv4_route_used_before = ipv4_route_used_now
+        ipv6_route_used_before = ipv6_route_used_now
+        return ipv4_stable and ipv6_stable
+
+    full_wait_time = MAX_WAIT_TIME + CRM_POLLING_INTERVAL * 100
+    result = wait_until(full_wait_time, CRM_POLLING_INTERVAL, CRM_POLLING_INTERVAL, routes_stable)
+    if not result:
+        pytest.fail("Routes failed to withdraw in {} seconds".format(full_wait_time))
+
     logger.info("ipv4 route used {}".format(ipv4_route_used_before))
     logger.info("ipv6 route used {}".format(ipv6_route_used_before))
 

--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -345,3 +345,16 @@ def restore_config_by_config_reload(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
     logger.info("Restore config after running tests")
     config_reload(duthost, safe_reload=True)
+
+
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exception(duthost, loganalyzer):
+    if loganalyzer:
+        # The following error sometimes happens after removing the VNET during fixture_setUp teardown.
+        # It is a harmless error and does not affect the test results.
+        # The root cause is a race condition that is fixed by https://github.com/sonic-net/sonic-swss/pull/4499.
+        # Since the PR is not merged yet, we need to ignore this error for now.
+        ignore_regex_list = [
+            ".*ERR bgp#fpmsyncd:.*onRouteMsg: Invalid VRF name.*"
+        ]
+        loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_list)


### PR DESCRIPTION
```
* 88e5b5234e - [action] [PR:24091] Adding confed configuration to topo_t2_single_node_max_64p.yml (#25410) (2026-06-17) [mssonicbld]
* 812b35f941 - [action] [PR:23751] Update sku-sensors-data.yml for 7280R4-32QF-32DF-F (#25412) (2026-06-17) [mssonicbld]
* 6ad5320cd0 - [action] [PR:23955] Fix LLDP neighbor check flakiness after swss restart by waiting for neighbor re-learn (#25413) (2026-06-17) [mssonicbld]
* b96239414c - [action] [PR:24105] Skip `ip_proto` variant in `test_fib.py` test on UT2 64p topos (#25414) (2026-06-17) [mssonicbld]
* cf671be511 - [action] [PR:24257] fix resetWatermark QoS fixture on chassis (#25406) (2026-06-17) [mssonicbld]
* 101d7fdb50 - [action] [PR:23542] [ACL] Fix missing upstream ports in ACL table for topologies with a mix of LAG and non-LAG upstream ports (#25409) (2026-06-17) [mssonicbld]
* 04501ee946 - [action] [PR:24756] Fix withdraw_and_announce_existing_routes fixture to wait until routess withdrawn (#25415) (2026-06-17) [mssonicbld]
* 79dd61135c - [action] [PR:24281] Fix check_docker_status on multi-asic to skip checking base name containers (#25416) (2026-06-17) [mssonicbld]
* 3fdb1bb49c - [action] [PR:25314] [route/test_duplicate_route]: Skip unsupported IP family instead of erroring (#25398) (2026-06-17) [mssonicbld]
* 97734f29ac - [action] [PR:24316] test_po_update.py - cannot remove the last IP entry of interface Port… (#25397) (2026-06-17) [mssonicbld]
* 5b8c1208a2 - [action] [PR:25252] [dash]: Add apply_dash_configs helper to enforce DASH table write order (#25376) (2026-06-16) [mssonicbld]
* 6011efda2a - [action] [PR:25203] Update qos params for topo-lt2-p32o64 (#25380) (2026-06-16) [mssonicbld]
* 5753f97e1f - [action] [PR:25250] Update qos params for topo-ft2-64 (#25381) (2026-06-16) [mssonicbld]
* 98b407b518 - [action] [PR:25055] [console] Fix SSH connection for paramiko 5.x by re-enabling legacy KEX and host key algorithms (#25374) (2026-06-16) [mssonicbld]
* 9c4300751a - [action] [PR:23793] [Qos]UpdateFeatureState func call in teardown fixed to run from host (#25321) (2026-06-15) [mssonicbld]
* 1aae2973b8 - [action] [PR:21666] Fix GCU portchannel tests for multi-ASIC devices (#25325) (2026-06-15) [mssonicbld]
* 644c4ef88d - [action] [PR:25313] Ignoring `Invalid VRF name` errors in VxLAN tests (#25340) (2026-06-13) [mssonicbld]
* 0be83ffe43 - [action] [PR:25187] Fix race condition in sflow reboot testing (#25342) (2026-06-13) [mssonicbld]
* e5202315f1 - Revert "[action] [PR:23604] Adding confed config to t2 topology: topo_t2_single_node_min.yml" (#25188) (2026-06-12) [Yatish]
* 325e3b1abe - [action] [PR:20881] Fixing HashTest Bugs #20840 and #21071 (#25323) (2026-06-12) [mssonicbld]
* e95e539ed3 - [action] [PR:21015] Fix vtysh 'received-routes' command for multi-asic duts - bgp_update_timer (#25324) (2026-06-12) [mssonicbld]
```
