### PR TITLE
Remove branch '202512' from sync workflow

### DIFF
--- a/.github/workflows/autosync_pub_msft.yml
+++ b/.github/workflows/autosync_pub_msft.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           set -ex
 
-          branches="202412 202506 202512 202511_azd"
+          branches="202412 202506 202511_azd"
           pushd sonic-mgmt.msft
 
           [ -z "$branches" ] && exit 1


### PR DESCRIPTION
This PR is to stop the code sync from 202511 to msft-202512 branch