### PR TITLE
test_continous_pfc: add polling and retry for counter check

### DIFF
--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -168,6 +168,12 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
             ).format(len(failures))
 
     else:
+        """ Poll interval and timeout for waiting on counter updates """
+        POLL_INTERVAL = 0.5
+        POLL_TIMEOUT = 10
+        """ Retry sending frames once if the counter does not update in time """
+        MAX_RETRIES = 2
+
         for intf in active_phy_intfs:
             """only check priority 3 and 4: lossless priorities"""
             for priority in range(3, 5):
@@ -196,13 +202,33 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
                         cmd = 'docker exec %s "python %s -i %s -p %d -t %d -n %d"' % (
                             onyx_pfc_container_name, PFC_GEN_FILE_ABSOLUTE_PATH,
                             peer_port_name, 2 ** priority, pause_time, PKT_COUNT)
-                        peerdev_ans.host.config(cmd)
+                        send_frames = lambda: peerdev_ans.host.config(cmd)  # noqa: E731
                     else:
                         cmd = "sudo python %s -i %s -p %d -t %d -n %d" % (
                             PFC_GEN_FILE_DEST, peer_port_name, 2 ** priority, pause_time, PKT_COUNT)
-                        peerdev_ans.host.command(cmd)
+                        send_frames = lambda: peerdev_ans.host.command(cmd)  # noqa: E731
 
-                time.sleep(5)
+                    send_frames()
+
+                pfc_rx = {}
+                for attempt in range(1, MAX_RETRIES + 1):
+                    """ Poll until counter reaches PKT_COUNT or timeout """
+                    deadline = time.time() + POLL_TIMEOUT
+                    while time.time() < deadline:
+                        pfc_rx = duthost.sonic_pfc_counters(method="get")['ansible_facts']
+                        if asic_type == 'vs' or pfc_rx[intf]['Rx'][priority] == str(PKT_COUNT):
+                            break
+                        time.sleep(POLL_INTERVAL)
+
+                    if asic_type == 'vs' or pfc_rx[intf]['Rx'][priority] == str(PKT_COUNT):
+                        break
+
+                    if attempt < MAX_RETRIES:
+                        logger.warning(
+                            "Counter not updated for intf {} priority {} after {}s, retrying ({}/{})".format(
+                                intf, priority, POLL_TIMEOUT, attempt, MAX_RETRIES))
+                        duthost.sonic_pfc_counters(method="clear")
+                        send_frames()
 
                 pfc_rx = duthost.sonic_pfc_counters(
                     method="get")['ansible_facts']


### PR DESCRIPTION
### Description of PR

Cherry-pick of sonic-net/sonic-mgmt#25316 for `msft/202512` branch.

The `run_test` function was moved from `tests/common/helpers/pfc_counters.py` into `tests/qos/test_pfc_counters.py` in this branch, so the changes were applied there directly.

**Summary:** Replace the fixed 5-second sleep before reading PFC counters with a polling loop (0.5s interval, 10s timeout) that exits early as soon as the counter reaches the expected value. If the counter stays at 0 after the polling timeout, retry by re-clearing and re-sending PFC frames once before declaring failure.

**Motivation:** Transient SSH/infrastructure blips occasionally prevent `pfc_gen.py` from sending frames to the fanout. Observed on Nokia IXR7220-H6-128 (str4 testbed): 1 out of ~300 port/priority pairs fails intermittently due to fanout SSH timeouts during the long-running test (~60 min, 300+ SSH connections).

### Type of change
- [x] Bug fix
- [x] Test case improvement

### Approach
#### What is the motivation for this PR?
See sonic-net/sonic-mgmt#25316 for full context.

#### How did you do it?
Adapted the cherry-pick to apply changes directly in `test_pfc_counters.py` since `pfc_counters.py` helper was removed in this branch.

#### How did you verify/test it?
Original PR verified on Nokia IXR7220-H6-128 testbed (vms13-lt2-nokia-th6-1).

### Documentation
N/A