### PR TITLE
syslog: accept standard rsyslogd rate-limit message in test_syslog_rate_limit

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -21,8 +21,11 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 LOCAL_LOG_GENERATOR_FILE = os.path.join(BASE_DIR, 'log_generator.py')
 REMOTE_LOG_GENERATOR_FILE = os.path.join('/tmp', 'log_generator.py')
 DOCKER_LOG_GENERATOR_FILE = '/log_generator.py'
-# rsyslogd prints this log when rate-limiting reached
-LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = '.*rate-limit-test>: begin to drop messages due to rate-limiting.*'
+# rsyslogd emits one of two messages depending on version when rate-limiting kicks in:
+#   - "begin to drop messages due to rate-limiting"  (logged when drops start)
+#   - "N messages lost due to rate-limiting (M allowed within K seconds)"  (logged as summary)
+# Accept either form so the test works across different rsyslogd versions.
+LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = r'.*(?:begin to drop messages|messages lost) due to rate-limiting.*'
 # Log pattern for tests/syslog/log_generator.py
 LOG_EXPECT_LAST_MESSAGE = '.*{}rate-limit-test: This is a test log:.*'
 


### PR DESCRIPTION
Cherry-pick of sonic-net/sonic-mgmt#25494 to 202512 branch.

### Description of PR
Summary:
Fix `test_syslog_rate_limit` failure on platforms where rsyslogd emits a different rate-limit message.

rsyslogd emits two different messages depending on version when rate-limiting triggers:
- `"begin to drop messages due to rate-limiting"` — logged when drops **start** (transition 0→1)
- `"N messages lost due to rate-limiting (M allowed within K seconds)"` — logged as a **summary** when the rate-limit window ends

Both are standard rsyslogd messages from `ratelimit.c`. The test only matched the first form, causing failures on rsyslogd versions that emit the summary form.

This fix uses regex alternation to accept either form. The 202512 branch additionally had an overly specific pattern with a `rate-limit-test>:` prefix that would not match the summary message form.

### Type of change
- [x] Bug fix