### PR TITLE
Revert "syslog: accept standard rsyslogd rate-limit message in test_syslog_rate_limit"

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -21,11 +21,8 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 LOCAL_LOG_GENERATOR_FILE = os.path.join(BASE_DIR, 'log_generator.py')
 REMOTE_LOG_GENERATOR_FILE = os.path.join('/tmp', 'log_generator.py')
 DOCKER_LOG_GENERATOR_FILE = '/log_generator.py'
-# rsyslogd emits one of two messages depending on version when rate-limiting kicks in:
-#   - "begin to drop messages due to rate-limiting"  (logged when drops start)
-#   - "N messages lost due to rate-limiting (M allowed within K seconds)"  (logged as summary)
-# Accept either form so the test works across different rsyslogd versions.
-LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = r'.*(?:begin to drop messages|messages lost) due to rate-limiting.*'
+# rsyslogd prints this log when rate-limiting reached
+LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = '.*rate-limit-test>: begin to drop messages due to rate-limiting.*'
 # Log pattern for tests/syslog/log_generator.py
 LOG_EXPECT_LAST_MESSAGE = '.*{}rate-limit-test: This is a test log:.*'
 


### PR DESCRIPTION
Reverts Azure/sonic-mgmt.msft#1247


Reverting this PR as it caused test failures
```
E               tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: Log analyzer expected 101 messages but found only 103
E               match: 0
E               expected_match: 103
E               expected_missing_match: 0
E               
E               Expected Messages:
```