### PR TITLE
[manual] [PR:23789] [copp] Pin ptf_nn_agent.py wget URLs to nnpy-compatible PTF commit (workaround)

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -17,6 +17,14 @@ _ADD_IP_SCRIPT = "scripts/add_ip.sh"
 _ADD_IP_BACKEND_SCRIPT = "scripts/add_ip_backend.sh"
 _UPDATE_COPP_SCRIPT = "copp/scripts/update_copp_config.py"
 
+_PTF_COMMIT = "9d41838d634c479fc24fac7a527ec5ee2d0ce8eb"
+_PTF_NN_AGENT_URL = (
+    "https://raw.githubusercontent.com/p4lang/ptf"
+    "/{}/ptf_nn/ptf_nn_agent.py".format(_PTF_COMMIT))
+_PTF_AFPACKET_URL = (
+    "https://raw.githubusercontent.com/p4lang/ptf"
+    "/{}/src/ptf/afpacket.py".format(_PTF_COMMIT))
+
 _BASE_COPP_CONFIG = "/tmp/base_copp_config.json"
 _APP_DB_COPP_CONFIG = ":/etc/swss/config.d/00-copp.config.json"
 _CONFIG_DB_COPP_CONFIG = "/etc/sonic/copp_cfg.json"
@@ -210,20 +218,19 @@ def _install_nano_bookworm(dut, creds, syncd_docker_name):
         http_proxy = creds.get('proxy_env', {}).get('http_proxy', '')
         https_proxy = creds.get('proxy_env', {}).get('https_proxy', '')
         # Change the permission of /tmp to 1777 to workaround issue sonic-net/sonic-buildimage#16034
-        cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+        cmd = '''docker exec -e http_proxy={0} -e https_proxy={1} {2} bash -c " \
                 chmod 1777 /tmp \
                 && rm -rf /var/lib/apt/lists/* \
                 && apt-get update \
                 && apt-get install -y python3-pip build-essential libssl-dev libffi-dev \
                 python3-dev python3-setuptools wget libnanomsg-dev python-is-python3 \
                 && pip3 install cffi==1.16.0 && pip3 install nnpy \
-                && mkdir -p /opt && cd /opt && wget \
-                https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                && mkdir ptf && cd ptf && wget \
-                https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
+                && mkdir -p /opt && cd /opt && wget {3} \
+                && mkdir ptf && cd ptf && wget {4} && touch __init__.py \
                 && apt-get -y purge build-essential libssl-dev libffi-dev python3-dev \
                 python3-setuptools wget \
-                " '''.format(http_proxy, https_proxy, syncd_docker_name)
+                " '''.format(http_proxy, https_proxy, syncd_docker_name,
+                             _PTF_NN_AGENT_URL, _PTF_AFPACKET_URL)
         dut.command(cmd)
 
 
@@ -254,7 +261,7 @@ def _install_nano(dut, creds,  syncd_docker_name):
         check_cmd = "docker exec -i {} bash -c 'cat /etc/os-release'".format(syncd_docker_name)
         # Change the permission of /tmp to 1777 to workaround issue sonic-net/sonic-buildimage#16034
         if "bullseye" in dut.shell(check_cmd)['stdout'].lower():
-            cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+            cmd = '''docker exec -e http_proxy={0} -e https_proxy={1} {2} bash -c " \
                     chmod 1777 /tmp \
                     && rm -rf /var/lib/apt/lists/* \
                     && apt-get update \
@@ -264,13 +271,12 @@ def _install_nano(dut, creds,  syncd_docker_name):
                     && tar xzf 1.0.0.tar.gz && cd nanomsg-1.0.0 \
                     && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
                     && rm -f 1.0.0.tar.gz && pip3 install cffi && pip3 install --upgrade cffi && pip3 install nnpy \
-                    && mkdir -p /opt && cd /opt && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                    && mkdir ptf && cd ptf && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
-                    " '''.format(http_proxy, https_proxy, syncd_docker_name)
+                    && mkdir -p /opt && cd /opt && wget {3} \
+                    && mkdir ptf && cd ptf && wget {4} && touch __init__.py \
+                    " '''.format(http_proxy, https_proxy, syncd_docker_name,
+                                 _PTF_NN_AGENT_URL, _PTF_AFPACKET_URL)
         else:
-            cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
+            cmd = '''docker exec -e http_proxy={0} -e https_proxy={1} {2} bash -c " \
                     chmod 1777 /tmp \
                     && rm -rf /var/lib/apt/lists/* \
                     && apt-get update \
@@ -281,11 +287,10 @@ def _install_nano(dut, creds,  syncd_docker_name):
                     && mkdir -p build && cmake . && make install && ldconfig && cd .. && rm -rf nanomsg-1.0.0 \
                     && rm -f 1.0.0.tar.gz && pip2 install cffi==1.7.0 && pip2 install --upgrade \
                     cffi==1.7.0 && pip2 install nnpy \
-                    && mkdir -p /opt && cd /opt && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-                    && mkdir ptf && cd ptf && wget \
-                    https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
-                    " '''.format(http_proxy, https_proxy, syncd_docker_name)
+                    && mkdir -p /opt && cd /opt && wget {3} \
+                    && mkdir ptf && cd ptf && wget {4} && touch __init__.py \
+                    " '''.format(http_proxy, https_proxy, syncd_docker_name,
+                                 _PTF_NN_AGENT_URL, _PTF_AFPACKET_URL)
         dut.command(cmd)
 
 


### PR DESCRIPTION
### Description of PR
Manual cherry-pick of sonic-net/sonic-mgmt #23789 to the 202405 branch.
Original PR: https://github.com/sonic-net/sonic-mgmt/pull/23789
(merge commit f9db8708, by @lipxu, merged 2026-04-10)

`copp/test_copp` downloads `ptf_nn_agent.py` into the DUT `syncd` container at
test time from `p4lang/ptf` master. After p4lang/ptf `ebc00f94` (Apr 2026) that
agent imports `pynng`, but the DUT only has `nnpy` installed -> the agent
crashes (`Cannot find pynng package`), DUT TCP port 10900 never listens, and the
PTF-side test blocks forever (the copp hang on the Cisco 8800 T2 chassis
nightly). Pinning the download to nnpy-compatible commit `9d41838d` restores a
working agent. Already merged on public `master` and internal; only `202405` was
missing it.

Summary: Fixes Microsoft ADO 38556056
(https://msazure.visualstudio.com/One/_workitems/edit/38556056)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
Stop `copp/test_copp` from fetching the pynng-based agent (which hangs the test)
on the 202405 chassis nightly.

#### How did you do it?
Cherry-picked `f9db8708` (#23789): adds `_PTF_COMMIT` / `_PTF_NN_AGENT_URL` /
`_PTF_AFPACKET_URL` and pins all 3 wget sites (`_install_nano_bookworm` +
`_install_nano` bullseye/non-bullseye). The only conflict
(`_install_nano_bookworm`) was resolved by keeping the 202405 body (the
`chmod 1777 /tmp` workaround for sonic-net/sonic-buildimage#16034) and applying
only the URL pin.

#### How did you verify/test it?
`copp/test_copp.py` completes and passes on Cisco 8800 T2 (vmsvc6-t2-8800-1) on
the 202405-chassis image (SONiC.20240532.77) — 20 passed / 8 skipped / 0 failed,
finishing in ~85 min instead of hanging:
https://elastictest.org/scheduler/testplan/6a3a8e1c9d632805e39bd34d
