### PR TITLE
[code sync] Merge code from sonic-net/sonic-mgmt:202511 to 202603

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -28,6 +28,10 @@ parameters:
   type: string
   default: ""
 
+- name: PTF_IMAGE_TAG
+  type: string
+  default: ""
+
 - name: PTF_MODIFIED
   type: string
   default: "False"
@@ -113,6 +117,7 @@ jobs:
           TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
           MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
           MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+          PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
           PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
           EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
           TOPOLOGY: t0
@@ -154,6 +159,7 @@ jobs:
   #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
   #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
   #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
   #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
   #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
   #         TOPOLOGY: t0
@@ -196,6 +202,7 @@ jobs:
           TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
           MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
           MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+          PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
           PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
           EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
           TOPOLOGY: t1-lag
@@ -237,6 +244,7 @@ jobs:
   #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
   #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
   #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
   #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
   #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
   #         TOPOLOGY: dualtor
@@ -278,6 +286,7 @@ jobs:
   #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
   #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
   #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
   #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
   #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
   #         TOPOLOGY: t0-64-32
@@ -324,6 +333,7 @@ jobs:
   #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
   #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
   #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
   #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
   #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
   #         TOPOLOGY: dpu
@@ -369,6 +379,7 @@ jobs:
   #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
   #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
   #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
   #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
   #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
   #         TOPOLOGY: t1-8-lag
@@ -412,6 +423,7 @@ jobs:
           TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
           MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
           MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+          PTF_IMAGE_TAG: ${{ parameters.PTF_IMAGE_TAG }}
           PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
           EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
           TOPOLOGY: t2

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -183,12 +183,17 @@ class GenerateGoldenConfigDBModule(object):
     def overwrite_feature_golden_config_db_multiasic(self, config, feature_key, auto_restart="enabled",
                                                      state="enabled", feature_data=None):
         full_config = json.loads(config)
-        if full_config == {} or "FEATURE" not in full_config.get("localhost", {}):
-            # need dump running config FEATURE + selected feature
-            gold_config_db = self.get_multiasic_feature_config()
-        else:
-            # need existing config + selected feature
-            gold_config_db = full_config
+        if "FEATURE" not in full_config.get("localhost", {}):
+            # Merge running config FEATURE into existing config instead of replacing,
+            # to preserve other tables (e.g. BGP_DEVICE_GLOBAL) already in full_config.
+            feature_config = self.get_multiasic_feature_config()
+            for ns, ns_data in feature_config.items():
+                if ns in full_config:
+                    full_config[ns].update(ns_data)
+                else:
+                    full_config[ns] = ns_data
+
+        gold_config_db = full_config
 
         if feature_data is None:
             feature_data = {

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -485,7 +485,6 @@ class GenerateGoldenConfigDBModule(object):
         dhcp_server_ipv4_config = {
             "DHCP_SERVER_IPV4": {
                 "bridge-midplane": {
-                    "gateway": "169.254.200.254",
                     "lease_time": "600000000",
                     "mode": "PORT",
                     "netmask": "255.255.255.0",

--- a/ansible/library/ocs_cross_connect.py
+++ b/ansible/library/ocs_cross_connect.py
@@ -1,0 +1,335 @@
+#!/usr/bin/python
+# Configure OCS cross-connects on an L1 (FanoutL1Sonic) switch using the OCS CLI,
+# instead of building a JSON patch and reloading the config.
+#
+# All of the parsing and set math is implemented in Python here so the playbook task is
+# a single, declarative module invocation.
+#
+# Algorithm (mirrors templates/config_patch/l1/ocs_xconnect.json.j2 for the desired set):
+#   1. Read the current configured cross-connects ("show ocs cross-connect config")
+#      and the live hardware status ("show ocs cross-connect status").
+#   2. Compute the desired cross-connects from the cross_connects mapping. Each
+#      (a, b) entry maps to two directed cross-connects: {a}A-{b}B and {b}A-{a}B.
+#   3. Clear "stale" cross-connects that exist in hardware status but not in config
+#      and that block a desired port. A status-only entry cannot be deleted directly,
+#      so it is cleared by an add-then-delete sequence.
+#   4. Remove current cross-connects that conflict (occupy an A or B side a still
+#      missing desired cross-connect needs) so the new ones can be added.
+#   5. Add the desired cross-connects that are not already present.
+#   6. Optionally verify the operational status ("show ocs cross-connect status")
+#      reports "tuned" on both sides for every desired cross-connect.
+#
+# The operation is idempotent: when every desired A-B connection already exists the
+# add/remove/clear lists are all empty and nothing is changed.
+
+import re
+import time
+
+from ansible.module_utils.basic import AnsibleModule
+
+DOCUMENTATION = r'''
+---
+module: ocs_cross_connect
+version_added: "1.0"
+short_description: Configure OCS cross-connects on an L1 (FanoutL1Sonic) switch via live CLI.
+description:
+    - Configure the OCS cross-connects on an L1 switch to match a desired mapping using
+      the "config ocs cross-connect" CLI, instead of building a JSON patch and reloading.
+    - The OCS CLI persists changes automatically, so no "config save" is required.
+    - The operation is idempotent. When every desired cross-connect already exists nothing
+      is changed.
+options:
+    cross_connects:
+        description:
+            - Mapping of bare A-side port number to bare B-side port number for this device,
+              e.g. device_l1_cross_connects[inventory_hostname].
+                        - Each (a, b) entry expands to two directed cross-connects {a}A-{b}B and {b}A-{a}B.
+        required: True
+        type: dict
+    clear_stale:
+        description: Clear status-only entries that block a desired port via add-then-delete.
+        required: False
+        type: bool
+        default: True
+    verify:
+        description: Verify status is "tuned" on both sides for every desired cross-connect.
+        required: False
+        type: bool
+        default: True
+    verify_retries:
+        description: Number of times to poll the status table while verifying.
+        required: False
+        type: int
+        default: 12
+    verify_delay:
+        description: Seconds to wait between status polls while verifying.
+        required: False
+        type: int
+        default: 5
+notes:
+    - Run with become so the "config ocs cross-connect" commands have the required privileges.
+    - Supports check mode, in which the planned changes are computed and returned but not applied.
+'''
+
+EXAMPLES = r'''
+- name: deploy L1 OCS cross-connects via live CLI
+  become: true
+  ocs_cross_connect:
+    cross_connects: "{{ device_l1_cross_connects[inventory_hostname] | default({}) }}"
+    clear_stale: true
+    verify: true
+  register: ocs_reconcile
+'''
+
+RETURN = r'''
+added:
+    description: Ids of cross-connects that were (or would be, in check mode) added.
+    returned: always
+    type: list
+removed:
+    description: Ids of conflicting cross-connects that were (or would be) removed.
+    returned: always
+    type: list
+cleared_stale:
+    description: Ids of stale status-only cross-connects that were (or would be) cleared.
+    returned: always
+    type: list
+desired:
+    description: Ids of all desired cross-connects.
+    returned: always
+    type: list
+'''
+
+# A cross-connect id looks like "<num>A-<num>B", e.g. "29A-1B".
+XCONN_ID_RE = re.compile(r'^[0-9]+[AB]-[0-9]+[AB]$')
+NUMERIC_PORT_RE = re.compile(r'^[0-9]+$')
+SHOW_CONFIG_CMD = 'show ocs cross-connect config'
+SHOW_STATUS_CMD = 'show ocs cross-connect status'
+ADD_CMD_TMPL = 'config ocs cross-connect add {id} update'
+DEL_CMD_TMPL = 'config ocs cross-connect delete {id}'
+
+
+def build_desired(cross_connects):
+    """Expand the bare a->b mapping into the list of directed cross-connects.
+
+    Each (a, b) entry yields {a}A-{b}B and {b}A-{a}B.
+    """
+    desired = []
+    for a, b in cross_connects.items():
+        a = str(a)
+        b = str(b)
+        desired.append({'id': '{}A-{}B'.format(a, b), 'a_side': '{}A'.format(a), 'b_side': '{}B'.format(b)})
+        desired.append({'id': '{}A-{}B'.format(b, a), 'a_side': '{}A'.format(b), 'b_side': '{}B'.format(a)})
+    return desired
+
+
+def get_invalid_desired_ids(desired):
+    """Return derived desired IDs that do not match the expected xconn format."""
+    return [x['id'] for x in desired if not XCONN_ID_RE.match(x['id'])]
+
+
+def get_invalid_cross_connect_pairs(cross_connects):
+    """Return (a, b) entries whose ports are not bare numeric values."""
+    invalid = []
+    for a, b in cross_connects.items():
+        sa = str(a)
+        sb = str(b)
+        if not NUMERIC_PORT_RE.match(sa) or not NUMERIC_PORT_RE.match(sb):
+            invalid.append({'a': sa, 'b': sb})
+    return invalid
+
+
+def parse_config(stdout):
+    """Parse "show ocs cross-connect config" output.
+
+    Table format: "id  a_side  b_side". Skip the header ("a_side") and separator ("---") rows.
+    """
+    xconns = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        if 'a_side' in line or '---' in line:
+            continue
+        cols = line.split()
+        if len(cols) < 3 or not XCONN_ID_RE.match(cols[0]):
+            continue
+        xconns.append({'id': cols[0], 'a_side': cols[1], 'b_side': cols[2]})
+    return xconns
+
+
+def parse_status_ids(stdout):
+    """Parse the cross-connect ids (first column) from "show ocs cross-connect status".
+
+    Status table format: "id  a_side  b_side  a_side_status  b_side_status".
+    """
+    ids = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        if 'a_side' in line or '---' in line:
+            continue
+        cols = line.split()
+        if not cols or not XCONN_ID_RE.match(cols[0]):
+            continue
+        ids.append(cols[0])
+    return ids
+
+
+def parse_tuned_ids(stdout):
+    """Return the ids whose status row reports "tuned" on both sides."""
+    tuned = []
+    for line in stdout.splitlines():
+        norm = ' '.join(line.split())
+        if norm.endswith('tuned tuned'):
+            tuned.append(norm.split(' ', 1)[0])
+    return tuned
+
+
+def compute_changes(desired, current, status_ids):
+    """Compute the stale-to-clear, conflicts-to-remove and to-add sets.
+
+    Returns (stale_to_clear, to_remove, to_add).
+    """
+    def _port_num(side):
+        return side[:-1] if side and side[-1] in ('A', 'B') else side
+
+    desired_ids = [x['id'] for x in desired]
+    current_ids = [x['id'] for x in current]
+    desired_port_nums = set([_port_num(x['a_side']) for x in desired] + [_port_num(x['b_side']) for x in desired])
+
+    # Add = desired cross-connects not already present in config. Computed up front so
+    # that stale/conflict removals are computed independently from add operations.
+    to_add = [x for x in desired if x['id'] not in current_ids]
+
+    # Stale = id present in hardware status but absent from config. Keep only those whose
+    # A or B port number blocks a port number a desired connect uses.
+    stale_to_clear = []
+    for sid in status_ids:
+        if sid in current_ids or not XCONN_ID_RE.match(sid):
+            continue
+        parts = sid.split('-')
+        if _port_num(parts[0]) in desired_port_nums or _port_num(parts[1]) in desired_port_nums:
+            if sid not in stale_to_clear:
+                stale_to_clear.append(sid)
+
+    # Conflict = a currently configured cross-connect that is not a desired pairing but
+    # occupies a port number (A side or B side) that a desired cross-connect uses.
+    to_remove = []
+    seen_remove = set()
+    for x in current:
+        if x['id'] in desired_ids:
+            continue
+        if _port_num(x['a_side']) in desired_port_nums or _port_num(x['b_side']) in desired_port_nums:
+            if x['id'] not in seen_remove:
+                seen_remove.add(x['id'])
+                to_remove.append(x)
+
+    return stale_to_clear, to_remove, to_add
+
+
+def run_or_fail(module, cmd, failed_cmds):
+    """Run a command, recording it on non-zero return code."""
+    rc, out, err = module.run_command(cmd, use_unsafe_shell=True)
+    if rc != 0:
+        failed_cmds.append({'cmd': cmd, 'rc': rc, 'stderr': err.strip()})
+    return rc, out, err
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            cross_connects=dict(required=True, type='dict'),
+            clear_stale=dict(required=False, type='bool', default=True),
+            verify=dict(required=False, type='bool', default=True),
+            verify_retries=dict(required=False, type='int', default=12),
+            verify_delay=dict(required=False, type='int', default=5),
+        ),
+        supports_check_mode=True,
+    )
+    p = module.params
+
+    invalid_pairs = get_invalid_cross_connect_pairs(p['cross_connects'])
+    if invalid_pairs:
+        module.fail_json(
+            msg="Invalid cross_connects mapping; expected bare numeric ports for both sides.",
+            invalid_pairs=invalid_pairs)
+
+    desired = build_desired(p['cross_connects'])
+    invalid = get_invalid_desired_ids(desired)
+    if invalid:
+        module.fail_json(
+            msg="Invalid cross-connect mapping; expected bare numeric ports. Invalid id(s): {}".format(invalid),
+            invalid=invalid)
+    desired_ids = [x['id'] for x in desired]
+
+    # Read current config and live status.
+    rc, config_out, err = module.run_command(SHOW_CONFIG_CMD, use_unsafe_shell=True)
+    if rc != 0:
+        module.fail_json(msg="Failed to read OCS cross-connect config: {}".format(err.strip()))
+    rc, status_out, err = module.run_command(SHOW_STATUS_CMD, use_unsafe_shell=True)
+    if rc != 0:
+        module.fail_json(msg="Failed to read OCS cross-connect status: {}".format(err.strip()))
+
+    current = parse_config(config_out)
+    status_ids = parse_status_ids(status_out)
+
+    stale_to_clear, to_remove, to_add = compute_changes(desired, current, status_ids)
+    remove_ids = [x['id'] for x in to_remove]
+    add_ids = [x['id'] for x in to_add]
+
+    result = dict(
+        desired=desired_ids,
+        cleared_stale=stale_to_clear,
+        removed=remove_ids,
+        added=add_ids,
+    )
+
+    changed = bool(stale_to_clear or to_remove or to_add)
+
+    if module.check_mode:
+        module.exit_json(changed=changed, **result)
+
+    add_tmpl = ADD_CMD_TMPL
+    del_tmpl = DEL_CMD_TMPL
+    failed_cmds = []
+
+    # A status-only ("stale") entry cannot be deleted directly; adding it to config first
+    # lets the subsequent delete clear it from hardware status. Run before removing config
+    # conflicts and adding the desired connects so the blocked ports are freed first.
+    if p['clear_stale']:
+        for xid in stale_to_clear:
+            run_or_fail(module, add_tmpl.replace('{id}', xid), failed_cmds)
+            run_or_fail(module, del_tmpl.replace('{id}', xid), failed_cmds)
+
+    for xid in remove_ids:
+        run_or_fail(module, del_tmpl.replace('{id}', xid), failed_cmds)
+
+    for xid in add_ids:
+        run_or_fail(module, add_tmpl.replace('{id}', xid), failed_cmds)
+
+    if failed_cmds:
+        module.fail_json(msg="One or more OCS cross-connect commands failed",
+                         failed_cmds=failed_cmds, **result)
+
+    # Operational status: a healthy cross-connect reports "tuned" for both status columns.
+    # Poll until every desired cross-connect is tuned on both sides.
+    if p['verify'] and desired_ids:
+        pending = list(desired_ids)
+        for attempt in range(p['verify_retries']):
+            rc, status_out, err = module.run_command(SHOW_STATUS_CMD, use_unsafe_shell=True)
+            tuned = parse_tuned_ids(status_out)
+            pending = [d for d in desired_ids if d not in tuned]
+            if not pending:
+                break
+            if attempt < p['verify_retries'] - 1:
+                time.sleep(p['verify_delay'])
+        if pending:
+            module.fail_json(
+                msg="OCS cross-connects not tuned after {} retries: {}".format(p['verify_retries'], pending),
+                pending=pending, **result)
+
+    module.exit_json(changed=changed, **result)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -490,7 +490,7 @@ r, ".* ERR swss\d*#orchagent:.*getPortLinkTrainingFailure: Failed to get LT fail
 # https://github.com/sonic-net/sonic-mgmt/issues/24023
 r, ".* ERR syncd\d*#syncd:.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn:\d+ RX signal detect status get \d+ attrib \d+ failed with error Feature unavailable \(0xfffffff0\).*"
 r, ".* ERR syncd\d*#syncd:.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn:\d+ bcm_port_phy_control_get rx snr failed with error Feature unavailable \(0xfffffff0\).*"
-r, ".* ERR syncd\d*#syncd: :- collectData: Failed to get port attr for VID 0x[0-9a-fA-F]+, RID:0x[0-9a-fA-F]+: -2.*"
+r, ".* ERR syncd\d*#syncd: :- collectData: Failed to get port attr for VID 0x[0-9a-fA-F]+, RID:0x[0-9a-fA-F]+: -\d+.*"
 
 # https://github.com/sonic-net/sonic-mgmt/issues/19347
 r, ".* ERR auditd.*: queue to plugins is full - dropping event"

--- a/ansible/roles/testbed/nut/tasks/l1_apply_cross_connects.yml
+++ b/ansible/roles/testbed/nut/tasks/l1_apply_cross_connects.yml
@@ -1,0 +1,47 @@
+---
+# Reconcile OCS cross-connects on an L1 (FanoutL1Sonic) switch using the live CLI,
+# instead of building a JSON patch and reloading the config.
+#
+# All of the parsing and set math lives in the ocs_cross_connect Python module
+# (ansible/library/ocs_cross_connect.py); this task is a single declarative call.
+# The reconcile is idempotent. A "config save" step is run after successful changes
+# so cross-connect updates are explicitly written to config DB.
+#
+# Tunables (override with -e):
+#   l1_xconnect_dry_run     (default false): only compute the planned changes, do not apply.
+#   l1_xconnect_clear_stale (default true):  clear status-only entries that block a desired port.
+#   l1_xconnect_verify      (default true):  verify status is "tuned" after applying.
+#   l1_xconnect_save_config (default true):  run "config save -y" after applying changes.
+#   l1_xconnect_verify_retries / l1_xconnect_verify_delay: status polling controls.
+#   ocs_xconn_show_config_cmd / ocs_xconn_show_status_cmd: show command overrides.
+#   ocs_xconn_add_cmd / ocs_xconn_del_cmd: command templates with an "{id}" placeholder.
+
+- name: configure OCS cross-connects via live CLI
+  become: true
+  check_mode: "{{ l1_xconnect_dry_run | default(false) | bool }}"
+  ocs_cross_connect:
+    cross_connects: "{{ device_l1_cross_connects[inventory_hostname] | default({}) }}"
+    clear_stale: "{{ l1_xconnect_clear_stale | default(true) | bool }}"
+    verify: "{{ l1_xconnect_verify | default(true) | bool }}"
+    verify_retries: "{{ l1_xconnect_verify_retries | default(12) | int }}"
+    verify_delay: "{{ l1_xconnect_verify_delay | default(5) | int }}"
+  register: ocs_reconcile
+
+- name: show OCS cross-connect progress
+  debug:
+    msg:
+      - "desired={{ ocs_reconcile.desired | default([]) | length }}"
+      - "cleared_stale={{ ocs_reconcile.cleared_stale | default([]) | length }}"
+      - "removed={{ ocs_reconcile.removed | default([]) | length }}"
+      - "added={{ ocs_reconcile.added | default([]) | length }}"
+      - "cleared_stale_ids: {{ ocs_reconcile.cleared_stale | default([]) }}"
+      - "removed_ids: {{ ocs_reconcile.removed | default([]) }}"
+      - "added_ids: {{ ocs_reconcile.added | default([]) }}"
+
+- name: save config DB after OCS cross-connect apply
+  become: true
+  command: config save -y
+  when:
+    - ocs_reconcile is changed
+    - l1_xconnect_save_config | default(true) | bool
+    - not (l1_xconnect_dry_run | default(false) | bool)

--- a/ansible/roles/testbed/nut/tasks/main.yml
+++ b/ansible/roles/testbed/nut/tasks/main.yml
@@ -6,17 +6,23 @@
         device_info[inventory_hostname] is defined and
         device_info[inventory_hostname].Type == 'FanoutL1Sonic'
   block:
-  - import_tasks: l1_create_config_patch.yml
-  - import_tasks: device_prepare_config.yml
-  - import_tasks: device_apply_config.yml
-    when: deploy is defined and deploy|bool == true
+    - name: deploy L1 config via patch and reload
+      when: not (use_l1_ocs_cli | default(false) | bool)
+      block:
+        - import_tasks: l1_create_config_patch.yml
+        - import_tasks: device_prepare_config.yml
+        - import_tasks: device_apply_config.yml
+          when: deploy is defined and deploy|bool == true
+    - name: deploy L1 OCS cross-connects via live CLI
+      import_tasks: l1_apply_cross_connects.yml
+      when: use_l1_ocs_cli | default(false) | bool
 
 - name: config duts
   when: (config_duts is not defined or config_duts|bool == true) and
         device_info[inventory_hostname] is defined and
         device_info[inventory_hostname].Type != 'FanoutL1Sonic'
   block:
-  - import_tasks: dut_create_config_patch.yml
-  - import_tasks: device_prepare_config.yml
-  - import_tasks: device_apply_config.yml
-    when: deploy is defined and deploy|bool == true
+    - import_tasks: dut_create_config_patch.yml
+    - import_tasks: device_prepare_config.yml
+    - import_tasks: device_apply_config.yml
+      when: deploy is defined and deploy|bool == true

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -335,6 +335,13 @@
     become: yes
     when: dpu_targets is defined and dpu_targets | length > 0
 
+  - name: Don't accept ipv6 router advertisements on PTF mgmt interface if it exists
+    command: >
+      docker exec -i ptf_{{ vm_set_name }}
+      sh -c 'test ! -e /proc/sys/net/ipv6/conf/mgmt/accept_ra ||
+             sysctl -w net.ipv6.conf.mgmt.accept_ra=0'
+    become: yes
+
   - name: Change MAC address for PTF interfaces
     include_tasks: ptf_change_mac.yml
     when: topo != 'fullmesh'

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -137,6 +137,10 @@
     command: docker exec -i ptf_{{ vm_set_name }} sysctl -w net.ipv6.route.max_size=168000
     become: yes
 
+  - name: Don't accept ipv6 router advertisements for docker container ptf_{{ vm_set_name }}
+    command: docker exec -i ptf_{{ vm_set_name }} sysctl -w net.ipv6.conf.default.accept_ra=0
+    become: yes
+
   - name: Create file to store dut type in PTF
     command: docker exec -i ptf_{{ vm_set_name }} sh -c 'echo {{ hostvars[duts_name.split(',')[0]]['type'] }} > /sonic/dut_type.txt'
     when:
@@ -180,6 +184,13 @@
       max_fp_num: "{{ max_fp_num }}"
       netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
+    become: yes
+
+  - name: Don't accept ipv6 router advertisements on PTF mgmt interface if it exists
+    command: >
+      docker exec -i ptf_{{ vm_set_name }}
+      sh -c 'test ! -e /proc/sys/net/ipv6/conf/mgmt/accept_ra ||
+             sysctl -w net.ipv6.conf.mgmt.accept_ra=0'
     become: yes
 
   - name: Change MAC address for PTF interfaces

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -31,6 +31,7 @@ function usage
   echo "    $0 [options] (create-master | destroy-master) <k8s-server-name> <vault-password-file>"
   echo "    $0 [options] restart-ptf <testbed-name> <vault-password-file>"
   echo "    $0 [options] set-l2 <testbed-name> <vault-password-file>"
+  echo "    $0 [options] deploy-l1 <testbed-name> <inventory> <vault-password-file>"
   echo "    $0 [options] install-image <testbed-name> <inventory> <image-url>"
   echo "    $0 [options] collect-show-tech <testbed-name> <inventory> <vault-password-file>"
   echo
@@ -87,6 +88,7 @@ function usage
   echo "To destroy Kubernetes master on a server: $0 -m k8s_ubuntu destroy-master 'k8s-server-name' ~/.password"
   echo "To restart ptf of specified testbed: $0 restart-ptf 'testbed-name' ~/.password"
   echo "To set DUT of specified testbed to l2 switch mode: $0 set-l2 'testbed-name' ~/.password"
+  echo "To deploy L1 (OCS) config for a testbed: $0 deploy-l1 'testbed-name' 'inventory' ~/.password"
   echo "To install an image on all DUTs in a testbed: $0 install-image 'testbed-name' 'inventory' 'image-url'"
   echo "To collect show techsupport result of a testbed: $0 collect-show-tech 'testbed-name' 'inventory' ~/.password"
   echo "    collect-show-tech supports specify output path for dumped files"
@@ -742,7 +744,20 @@ function deploy_l1
   echo "Devices to generate config for: $devices"
   echo ""
 
-  ansible-playbook -i "$inventory" deploy_config_on_testbed.yml --vault-password-file="$passfile" -l "$devices" -e testbed_name="$testbed_name" -e testbed_file=$tbfile -e deploy=true -e save=true -e config_duts=false -e reset_previous_connection=false$@
+  # Toggle the OCS cross-connect CLI path. When true, reconcile
+  # cross-connects via the CLI and clear stale entries (the CLI persists
+  # automatically, no "config save" needed; l1_xconnect_clear_stale defaults
+  # to true). When false, fall back to the patch and reload path (gated by
+  # deploy=true) and reset previous connections. The CLI path and deploy=true
+  # are mutually exclusive.
+  use_l1_ocs_cli="${use_l1_ocs_cli:-true}"
+  if [[ "$use_l1_ocs_cli" == "true" ]]; then
+    ocs_options="-e use_l1_ocs_cli=true"
+  else
+    ocs_options="-e use_l1_ocs_cli=false -e deploy=true -e save=true -e reset_previous_connection=false"
+  fi
+
+  ansible-playbook -i "$inventory" deploy_config_on_testbed.yml --vault-password-file="$passfile" -l "$devices" -e testbed_name="$testbed_name" -e testbed_file=$tbfile -e config_duts=false $ocs_options "$@"
 
   echo Done
 }

--- a/ansible/vars/topo_t2_single_node_max_64p.yml
+++ b/ansible/vars/topo_t2_single_node_max_64p.yml
@@ -334,9 +334,7 @@ configuration_properties:
     tor_subnet_number: 8
     max_tor_subnet_number: 32
     tor_subnet_size: 128
-    dut_asn: 66000
-    dut_confed_asn: 65100
-    dut_confed_peers: 65300
+    dut_asn: 65100
     dut_type: UpperSpineRouter
     nhipv4: 10.10.246.254
     nhipv6: fc0a::ff
@@ -351,7 +349,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -375,7 +372,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -399,7 +395,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -423,7 +418,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -447,7 +441,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -471,7 +464,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -495,7 +487,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -519,7 +510,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -543,7 +533,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -567,7 +556,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -591,7 +579,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -615,7 +602,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -639,7 +625,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -663,7 +648,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -687,7 +671,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -711,7 +694,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -735,7 +717,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -759,7 +740,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -783,7 +763,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -807,7 +786,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -831,7 +809,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -855,7 +832,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -879,7 +855,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -903,7 +878,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -927,7 +901,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -951,7 +924,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -975,7 +947,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -999,7 +970,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1023,7 +993,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1047,7 +1016,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1071,7 +1039,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1095,7 +1062,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1119,11 +1085,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64600
       peers:
-        66000:
+        65100:
         - 10.0.0.128
         - fc00::101
     interfaces:
@@ -1142,11 +1106,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64610
       peers:
-        66000:
+        65100:
         - 10.0.0.130
         - fc00::105
     interfaces:
@@ -1165,11 +1127,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64620
       peers:
-        66000:
+        65100:
         - 10.0.0.132
         - fc00::109
     interfaces:
@@ -1188,11 +1148,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64630
       peers:
-        66000:
+        65100:
         - 10.0.0.134
         - fc00::10d
     interfaces:
@@ -1211,11 +1169,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64640
       peers:
-        66000:
+        65100:
         - 10.0.0.136
         - fc00::111
     interfaces:
@@ -1234,11 +1190,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64650
       peers:
-        66000:
+        65100:
         - 10.0.0.138
         - fc00::115
     interfaces:
@@ -1257,11 +1211,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64660
       peers:
-        66000:
+        65100:
         - 10.0.0.140
         - fc00::119
     interfaces:
@@ -1280,11 +1232,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64670
       peers:
-        66000:
+        65100:
         - 10.0.0.142
         - fc00::11d
     interfaces:
@@ -1303,11 +1253,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64680
       peers:
-        66000:
+        65100:
         - 10.0.0.144
         - fc00::121
     interfaces:
@@ -1326,11 +1274,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64690
       peers:
-        66000:
+        65100:
         - 10.0.0.146
         - fc00::125
     interfaces:
@@ -1349,11 +1295,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64700
       peers:
-        66000:
+        65100:
         - 10.0.0.148
         - fc00::129
     interfaces:
@@ -1372,11 +1316,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64710
       peers:
-        66000:
+        65100:
         - 10.0.0.150
         - fc00::12d
     interfaces:
@@ -1395,11 +1337,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64720
       peers:
-        66000:
+        65100:
         - 10.0.0.152
         - fc00::131
     interfaces:
@@ -1418,11 +1358,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64730
       peers:
-        66000:
+        65100:
         - 10.0.0.154
         - fc00::135
     interfaces:
@@ -1441,11 +1379,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64740
       peers:
-        66000:
+        65100:
         - 10.0.0.156
         - fc00::139
     interfaces:
@@ -1464,11 +1400,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64750
       peers:
-        66000:
+        65100:
         - 10.0.0.158
         - fc00::13d
     interfaces:
@@ -1487,11 +1421,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64760
       peers:
-        66000:
+        65100:
         - 10.0.0.160
         - fc00::141
     interfaces:
@@ -1510,11 +1442,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64770
       peers:
-        66000:
+        65100:
         - 10.0.0.162
         - fc00::145
     interfaces:
@@ -1533,11 +1463,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64780
       peers:
-        66000:
+        65100:
         - 10.0.0.164
         - fc00::149
     interfaces:
@@ -1556,11 +1484,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64790
       peers:
-        66000:
+        65100:
         - 10.0.0.166
         - fc00::14d
     interfaces:
@@ -1579,11 +1505,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64800
       peers:
-        66000:
+        65100:
         - 10.0.0.168
         - fc00::151
     interfaces:
@@ -1602,11 +1526,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64810
       peers:
-        66000:
+        65100:
         - 10.0.0.170
         - fc00::155
     interfaces:
@@ -1625,11 +1547,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64820
       peers:
-        66000:
+        65100:
         - 10.0.0.172
         - fc00::159
     interfaces:
@@ -1648,11 +1568,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64830
       peers:
-        66000:
+        65100:
         - 10.0.0.174
         - fc00::15d
     interfaces:
@@ -1671,11 +1589,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64840
       peers:
-        66000:
+        65100:
         - 10.0.0.176
         - fc00::161
     interfaces:
@@ -1694,11 +1610,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64850
       peers:
-        66000:
+        65100:
         - 10.0.0.178
         - fc00::165
     interfaces:
@@ -1717,11 +1631,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64860
       peers:
-        66000:
+        65100:
         - 10.0.0.180
         - fc00::169
     interfaces:
@@ -1740,11 +1652,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64870
       peers:
-        66000:
+        65100:
         - 10.0.0.182
         - fc00::16d
     interfaces:
@@ -1763,11 +1673,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64880
       peers:
-        66000:
+        65100:
         - 10.0.0.184
         - fc00::171
     interfaces:
@@ -1786,11 +1694,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64890
       peers:
-        66000:
+        65100:
         - 10.0.0.186
         - fc00::175
     interfaces:
@@ -1809,11 +1715,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64900
       peers:
-        66000:
+        65100:
         - 10.0.0.188
         - fc00::179
     interfaces:
@@ -1832,11 +1736,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64910
       peers:
-        66000:
+        65100:
         - 10.0.0.190
         - fc00::17d
     interfaces:

--- a/ansible/vars/topo_t2_single_node_max_64p_v2.yml
+++ b/ansible/vars/topo_t2_single_node_max_64p_v2.yml
@@ -329,15 +329,13 @@ topology:
 
 configuration_properties:
   common:
+    dut_asn: 65100
+    dut_type: UpperSpineRouter
     podset_number: 400
     tor_number: 16
     tor_subnet_number: 8
     max_tor_subnet_number: 32
     tor_subnet_size: 128
-    dut_asn: 66000
-    dut_confed_asn: 65100
-    dut_confed_peers: 65300
-    dut_type: UpperSpineRouter
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
   core:
@@ -351,7 +349,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -375,7 +372,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -399,7 +395,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -423,7 +418,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -447,7 +441,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -471,7 +464,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -495,7 +487,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -519,7 +510,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -543,7 +533,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -567,7 +556,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -591,7 +579,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -615,7 +602,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -639,7 +625,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -663,7 +648,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -687,7 +671,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -711,7 +694,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -735,7 +717,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -759,7 +740,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -783,7 +763,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -807,7 +786,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -831,7 +809,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -855,7 +832,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -879,7 +855,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -903,7 +878,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -927,7 +901,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -951,7 +924,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -975,7 +947,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -999,7 +970,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1023,7 +993,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1047,7 +1016,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1071,7 +1039,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1095,7 +1062,6 @@ configuration:
     - common
     - core
     bgp:
-      peer_in_bgp_confed: true
       asn: 65200
       peers:
         65100:
@@ -1119,11 +1085,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64600
       peers:
-        66000:
+        65100:
         - 10.0.0.128
         - fc00::101
     interfaces:
@@ -1142,11 +1106,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64610
       peers:
-        66000:
+        65100:
         - 10.0.0.130
         - fc00::105
     interfaces:
@@ -1165,11 +1127,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64620
       peers:
-        66000:
+        65100:
         - 10.0.0.132
         - fc00::109
     interfaces:
@@ -1188,11 +1148,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64630
       peers:
-        66000:
+        65100:
         - 10.0.0.134
         - fc00::10d
     interfaces:
@@ -1211,11 +1169,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64640
       peers:
-        66000:
+        65100:
         - 10.0.0.136
         - fc00::111
     interfaces:
@@ -1234,11 +1190,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64650
       peers:
-        66000:
+        65100:
         - 10.0.0.138
         - fc00::115
     interfaces:
@@ -1257,11 +1211,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64660
       peers:
-        66000:
+        65100:
         - 10.0.0.140
         - fc00::119
     interfaces:
@@ -1280,11 +1232,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64670
       peers:
-        66000:
+        65100:
         - 10.0.0.142
         - fc00::11d
     interfaces:
@@ -1303,11 +1253,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64680
       peers:
-        66000:
+        65100:
         - 10.0.0.144
         - fc00::121
     interfaces:
@@ -1326,11 +1274,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64690
       peers:
-        66000:
+        65100:
         - 10.0.0.146
         - fc00::125
     interfaces:
@@ -1349,11 +1295,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64700
       peers:
-        66000:
+        65100:
         - 10.0.0.148
         - fc00::129
     interfaces:
@@ -1372,11 +1316,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64710
       peers:
-        66000:
+        65100:
         - 10.0.0.150
         - fc00::12d
     interfaces:
@@ -1395,11 +1337,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64720
       peers:
-        66000:
+        65100:
         - 10.0.0.152
         - fc00::131
     interfaces:
@@ -1418,11 +1358,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64730
       peers:
-        66000:
+        65100:
         - 10.0.0.154
         - fc00::135
     interfaces:
@@ -1441,11 +1379,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64740
       peers:
-        66000:
+        65100:
         - 10.0.0.156
         - fc00::139
     interfaces:
@@ -1464,11 +1400,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64750
       peers:
-        66000:
+        65100:
         - 10.0.0.158
         - fc00::13d
     interfaces:
@@ -1487,11 +1421,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64760
       peers:
-        66000:
+        65100:
         - 10.0.0.160
         - fc00::141
     interfaces:
@@ -1510,11 +1442,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64770
       peers:
-        66000:
+        65100:
         - 10.0.0.162
         - fc00::145
     interfaces:
@@ -1533,11 +1463,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64780
       peers:
-        66000:
+        65100:
         - 10.0.0.164
         - fc00::149
     interfaces:
@@ -1556,11 +1484,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64790
       peers:
-        66000:
+        65100:
         - 10.0.0.166
         - fc00::14d
     interfaces:
@@ -1579,11 +1505,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64800
       peers:
-        66000:
+        65100:
         - 10.0.0.168
         - fc00::151
     interfaces:
@@ -1602,11 +1526,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64810
       peers:
-        66000:
+        65100:
         - 10.0.0.170
         - fc00::155
     interfaces:
@@ -1625,11 +1547,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64820
       peers:
-        66000:
+        65100:
         - 10.0.0.172
         - fc00::159
     interfaces:
@@ -1648,11 +1568,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64830
       peers:
-        66000:
+        65100:
         - 10.0.0.174
         - fc00::15d
     interfaces:
@@ -1671,11 +1589,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64840
       peers:
-        66000:
+        65100:
         - 10.0.0.176
         - fc00::161
     interfaces:
@@ -1694,11 +1610,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64850
       peers:
-        66000:
+        65100:
         - 10.0.0.178
         - fc00::165
     interfaces:
@@ -1717,11 +1631,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64860
       peers:
-        66000:
+        65100:
         - 10.0.0.180
         - fc00::169
     interfaces:
@@ -1740,11 +1652,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64870
       peers:
-        66000:
+        65100:
         - 10.0.0.182
         - fc00::16d
     interfaces:
@@ -1763,11 +1673,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64880
       peers:
-        66000:
+        65100:
         - 10.0.0.184
         - fc00::171
     interfaces:
@@ -1786,11 +1694,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64890
       peers:
-        66000:
+        65100:
         - 10.0.0.186
         - fc00::175
     interfaces:
@@ -1809,11 +1715,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64900
       peers:
-        66000:
+        65100:
         - 10.0.0.188
         - fc00::179
     interfaces:
@@ -1832,11 +1736,9 @@ configuration:
     - common
     - leaf
     bgp:
-      asn: 65300
-      confed_asn: 65100
-      confed_peers: 66000
+      asn: 64910
       peers:
-        66000:
+        65100:
         - 10.0.0.190
         - fc00::17d
     interfaces:

--- a/tests/common/cert_utils.py
+++ b/tests/common/cert_utils.py
@@ -163,6 +163,13 @@ class TlsCertificateGenerator:
                 ),
                 critical=True,
             )
+            # SubjectKeyIdentifier matches what `openssl req -x509` adds by
+            # default. Required so the CRL flow (which sets
+            # authorityKeyIdentifier=keyid:always) can resolve.
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+                critical=False,
+            )
             .sign(key, hashes.SHA256())
         )
 

--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -209,6 +209,14 @@ class AnsibleHostBase(object):
         if (hostname_res.is_failed or 'exception' in hostname_res) and not module_ignore_errors:
             raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), hostname_res)
 
+        # Ensure 'failed' key is always present for backward compatibility with code that
+        # accesses rc['failed'] directly. The _IGNORE hack above is no longer effective in
+        # ansible-core >= 2.21 where the post-processing behavior changed so that 'failed'
+        # is absent from successful command results. Normalizing here is a single robust fix
+        # that covers all call sites without requiring per-file changes.
+        if 'failed' not in hostname_res:
+            hostname_res['failed'] = hostname_res.is_failed
+
         return hostname_res
 
 

--- a/tests/common/gnmi_setup.py
+++ b/tests/common/gnmi_setup.py
@@ -15,6 +15,7 @@ import time
 
 import tests.common.gu_utils as gu_utils
 
+from tests.common.cert_utils import TlsCertificateGenerator
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from tests.common.utilities import wait_until
 from tests.common.helpers.ntp_helper import NtpDaemon, get_ntp_daemon_in_use   # noqa: F401
@@ -175,9 +176,17 @@ def recover_cert_config(duthost):
 
 def create_certificates(localhost, duthost_mgmt_ip, cert_path: Path):
     """
-    Create GNMI CA, server and client certificates
-    :param localhost: localhost fixture
-    :param duthost_mgmt_ip: DUT management IP
+    Create GNMI CA, server and client certificates.
+
+    Builds the test PKI in-process via cryptography (not openssl shell) so
+    that notBefore can be backdated by 7 days. This absorbs clock skew
+    between the sonic-mgmt runner, the DUT, and the PTF docker; otherwise
+    the TLS handshake fails with "certificate is not yet valid". The
+    openssl 3.0.x runtime on Ubuntu 24.04 has no CLI flag to set
+    notBefore on `req -x509` or `x509 -req` (added only in 3.5).
+
+    :param localhost: localhost fixture (unused; kept for backward compat)
+    :param duthost_mgmt_ip: DUT management IP (included in server cert SAN)
     :param cert_path: Path to store the certificates
     :return: True if successful, False otherwise
     """
@@ -200,105 +209,24 @@ def create_certificates(localhost, duthost_mgmt_ip, cert_path: Path):
         logger.error(f"Failed to create directory {dest_dir}: {e}")
         raise Exception(f"Failed to create directory {dest_dir}: {e}")
 
-    # Create CA key and certificate
-    logger.info("Creating CA key and certificate.")
-    key_file = str(dest_dir / 'gnmiCA.key')
-    out_file = str(dest_dir / 'gnmiCA.pem')
-    logger.debug(f"CA key file: {key_file}, CA certificate file: {out_file}")
-    local_command = f"openssl genrsa -out {key_file} 2048"
-    localhost.shell(local_command)
-    local_command = (
-        f"openssl req -x509 -new -nodes -key {key_file} "
-        f"-sha256 -days 1825 -subj '/CN=test.gnmi.sonic' "
-        f"-out {out_file}"
-    )
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create CA certificate {out['stderr']}")
-        return False
-
-    # Create server key
-    logger.info("Creating server key.")
-    key_file = str(dest_dir / 'gnmiserver.key')
-    logger.debug(f"Server key file: {key_file}")
-    local_command = f"openssl genrsa -out {key_file} 2048"
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create server key {out['stderr']}")
-        return False
-
-    # Create server CSR
-    logger.info("Creating server CSR.")
-    out_file = str(dest_dir / 'gnmiserver.csr')
-    logger.debug(f"Server CSR file: {out_file}")
-    local_command = (
-        f"openssl req -new -key {key_file} "
-        f"-subj '/CN=test.server.gnmi.sonic' -out {out_file}"
-    )
-    localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create server CSR {out['stderr']}")
-        return False
-
-    # Sign server certificate
-    logger.info("Signing server certificate.")
-    extfile_path = str(dest_dir / 'extfile.cnf')
-    logger.debug(f"Extension file path: {extfile_path}")
-    create_ext_conf(duthost_mgmt_ip, extfile_path)
-    ca_key = str(dest_dir / 'gnmiCA.key')
-    ca_pem = str(dest_dir / 'gnmiCA.pem')
-    in_file = str(dest_dir / 'gnmiserver.csr')
-    out_file = str(dest_dir / 'gnmiserver.crt')
-    logger.debug(f"CA key: {ca_key}, CA PEM: {ca_pem}, Input CSR: {in_file}, Output CRT: {out_file}")
-    local_command = (
-        f"openssl x509 -req -in {in_file} "
-        f"-CA {ca_pem} -CAkey {ca_key} -CAcreateserial "
-        f"-out {out_file} -days 825 -sha256 "
-        f"-extensions req_ext -extfile {extfile_path}"
-    )
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to sign server certificate {out['stderr']}")
-        return False
-
-    # Create client key
-    logger.info("Creating client key.")
-    key_file = str(dest_dir / 'gnmiclient.key')
-    logger.debug(f"Client key file: {key_file}")
-    local_command = f"openssl genrsa -out {key_file} 2048"
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create client key {out['stderr']}")
-        return False
-
-    # Create client CSR
-    logger.info("Creating client CSR.")
-    out_file = str(dest_dir / 'gnmiclient.csr')
-    logger.debug(f"Client CSR file: {out_file}")
-    local_command = (
-        f"openssl req -new -key {key_file} "
-        f"-subj '/CN=test.client.gnmi.sonic' -out {out_file}"
-    )
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to create client CSR {out['stderr']}")
-        return False
-
-    # Sign client certificate
-    logger.info("Signing client certificate.")
-    in_file = str(dest_dir / 'gnmiclient.csr')
-    ca_pem = str(dest_dir / 'gnmiCA.pem')
-    ca_key = str(dest_dir / 'gnmiCA.key')
-    out_file = str(dest_dir / 'gnmiclient.crt')
-    logger.debug(f"CA key: {ca_key}, CA PEM: {ca_pem}, Input CSR: {in_file}, Output CRT: {out_file}")
-    local_command = (
-        f"openssl x509 -req -in {in_file} "
-        f"-CA {ca_pem} -CAkey {ca_key} "
-        f"-CAcreateserial -out {out_file} -days 825 -sha256"
-    )
-    out = localhost.shell(local_command)
-    if out['rc'] != 0:
-        logger.error(f"Failed to sign client certificate {out['stderr']}")
+    try:
+        generator = TlsCertificateGenerator(
+            server_ip=duthost_mgmt_ip,
+            backdate_days=7,
+            dns_names=["hostname.com"],
+            ca_cn="test.gnmi.sonic",
+            server_cn="test.server.gnmi.sonic",
+            client_cn="test.client.gnmi.sonic",
+            ca_cert_name="gnmiCA.pem",
+            ca_key_name="gnmiCA.key",
+            server_cert_name="gnmiserver.crt",
+            server_key_name="gnmiserver.key",
+            client_cert_name="gnmiclient.crt",
+            client_key_name="gnmiclient.key",
+        )
+        generator.write_all(str(dest_dir))
+    except Exception as e:
+        logger.error(f"Failed to generate GNMI certificates: {e}")
         return False
 
     logger.info("Certificate creation process completed successfully.")

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -1,10 +1,62 @@
+import ipaddress
 import logging
+import re
+from datetime import datetime, timedelta, timezone
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.x509.oid import NameOID
 
 logger = logging.getLogger(__name__)
 
 
 GNMI_CERT_NAME = "test.client.gnmi.sonic"
+REVOKED_GNMICERT_NAME = "test.client.revoked.gnmi.sonic"
 TELEMETRY_CONTAINER = "telemetry"
+
+# Backdate notBefore on test certs to absorb clock skew between the
+# sonic-mgmt runner, the DUT, and the PTF docker. Without this, even a
+# few minutes of drift produces TLS handshake failures with
+# "certificate is not yet valid". We do the signing in-process via
+# cryptography because the openssl 3.0.x CLI on the runner has no flag
+# to set notBefore on `req -x509` / `x509 -req` (added only in 3.5).
+_CERT_BACKDATE_DAYS = 7
+
+
+def _cert_validity_period(days):
+    """notBefore is backdated by _CERT_BACKDATE_DAYS; notAfter is `days` from now."""
+    now = datetime.now(timezone.utc)
+    not_before = now - timedelta(days=_CERT_BACKDATE_DAYS)
+    not_after = now + timedelta(days=int(days))
+    return not_before, not_after
+
+
+def _load_pem_private_key(path):
+    with open(path, "rb") as f:
+        return serialization.load_pem_private_key(f.read(), password=None)
+
+
+def _load_pem_certificate(path):
+    with open(path, "rb") as f:
+        return x509.load_pem_x509_certificate(f.read())
+
+
+def _load_pem_csr(path):
+    with open(path, "rb") as f:
+        return x509.load_pem_x509_csr(f.read())
+
+
+def _write_pem_certificate(path, cert):
+    with open(path, "wb") as f:
+        f.write(cert.public_bytes(serialization.Encoding.PEM))
+
+
+def _parse_crl_dp_uri(extension_file):
+    """Extract the CRL distribution point URI written by create_ca_conf."""
+    with open(extension_file, "r") as f:
+        text = f.read()
+    match = re.search(r"crlDistributionPoints\s*=\s*URI:(\S+)", text)
+    return match.group(1) if match else None
 
 
 class GNMIEnvironment(object):
@@ -188,34 +240,16 @@ def get_ptf_crl_server_ip(duthost, ptfhost):
 
 
 def create_revoked_cert_and_crl(localhost, ptfhost, duthost=None):
-    # Create client key
-    local_command = "openssl genrsa -out gnmiclient.revoked.key 2048"
-    localhost.shell(local_command)
+    create_client_key(localhost, revoke=True)
 
-    # Create client CSR
-    local_command = "openssl req \
-                        -new \
-                        -key gnmiclient.revoked.key \
-                        -subj '/CN=test.client.revoked.gnmi.sonic' \
-                        -out gnmiclient.revoked.csr"
-    localhost.shell(local_command)
+    create_client_csr(localhost, revoke=True)
 
     # Sign client certificate
     # Get appropriate PTF IP address based on DUT management IP type
     ptf_ip = get_ptf_crl_server_ip(duthost, ptfhost) if duthost else ptfhost.mgmt_ip
     crl_url = "http://{}:1234/crl".format(ptf_ip)
     create_ca_conf(crl_url, "crlext.cnf")
-    local_command = "openssl x509 \
-                        -req \
-                        -in gnmiclient.revoked.csr \
-                        -CA gnmiCA.pem \
-                        -CAkey gnmiCA.key \
-                        -CAcreateserial \
-                        -out gnmiclient.revoked.crt \
-                        -days 825 \
-                        -sha256 \
-                        -extensions req_ext -extfile crlext.cnf"
-    localhost.shell(local_command)
+    sign_client_certificate(localhost, revoke=True, extension_file="crlext.cnf")
 
     # create crl config file
     local_command = "rm -f gnmi/crl/index.txt"
@@ -264,80 +298,179 @@ def create_gnmi_certs(duthost, localhost, ptfhost):
     '''
     Create GNMI client certificates
     '''
-    # Create Root key
+    prepare_root_cert(localhost)
+    prepare_server_cert(duthost, localhost)
+    prepare_client_cert(localhost)
+    create_revoked_cert_and_crl(localhost, ptfhost)
+    copy_certificate_to_dut(duthost)
+    copy_certificate_to_ptf(ptfhost)
+
+
+def prepare_root_cert(localhost, days="1825"):
+    create_root_key(localhost)
+    create_root_cert(localhost, days)
+
+
+def create_root_key(localhost):
     local_command = "openssl genrsa -out gnmiCA.key 2048"
     localhost.shell(local_command)
 
-    # Create Root cert
-    local_command = "openssl req \
-                        -x509 \
-                        -new \
-                        -nodes \
-                        -key gnmiCA.key \
-                        -sha256 \
-                        -days 1825 \
-                        -subj '/CN=test.gnmi.sonic' \
-                        -out gnmiCA.pem"
-    localhost.shell(local_command)
 
-    # Create server key
+def create_root_cert(localhost, days):
+    """Self-signed CA cert, backdated by _CERT_BACKDATE_DAYS.
+
+    Includes SubjectKeyIdentifier to match what `openssl req -x509`
+    used to add for free via the system openssl.cnf [v3_ca] section.
+    The CRL flow in create_revoked_cert_and_crl needs SKI here so its
+    `authorityKeyIdentifier=keyid:always` extension can resolve.
+    """
+    ca_key = _load_pem_private_key("gnmiCA.key")
+    subject = issuer = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "test.gnmi.sonic"),
+    ])
+    not_before, not_after = _cert_validity_period(days)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None),
+            critical=True,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(ca_key.public_key()),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    _write_pem_certificate("gnmiCA.pem", cert)
+
+
+def prepare_server_cert(duthost, localhost, days="825"):
+    create_server_key(localhost)
+    create_server_csr(localhost)
+    sign_server_certificate(duthost, localhost, days)
+
+
+def create_server_key(localhost):
     local_command = "openssl genrsa -out gnmiserver.key 2048"
     localhost.shell(local_command)
 
-    # Create server CSR
+
+def create_server_csr(localhost):
     local_command = "openssl req \
-                        -new \
-                        -key gnmiserver.key \
-                        -subj '/CN=test.server.gnmi.sonic' \
-                        -out gnmiserver.csr"
+                            -new \
+                            -key gnmiserver.key \
+                            -subj '/CN=test.server.gnmi.sonic' \
+                            -out gnmiserver.csr"
     localhost.shell(local_command)
 
-    # Sign server certificate
-    create_ext_conf(duthost.mgmt_ip, "extfile.cnf")
-    local_command = "openssl x509 \
-                        -req \
-                        -in gnmiserver.csr \
-                        -CA gnmiCA.pem \
-                        -CAkey gnmiCA.key \
-                        -CAcreateserial \
-                        -out gnmiserver.crt \
-                        -days 825 \
-                        -sha256 \
-                        -extensions req_ext -extfile extfile.cnf"
+
+def sign_server_certificate(duthost, localhost, days):
+    """Sign gnmiserver.csr with the CA, backdated, with SAN (hostname.com + DUT mgmt IP)."""
+    ca_cert = _load_pem_certificate("gnmiCA.pem")
+    ca_key = _load_pem_private_key("gnmiCA.key")
+    csr = _load_pem_csr("gnmiserver.csr")
+    not_before, not_after = _cert_validity_period(days)
+    san_entries = [
+        x509.DNSName("hostname.com"),
+        x509.IPAddress(ipaddress.ip_address(duthost.mgmt_ip)),
+    ]
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(csr.subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(csr.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(
+            x509.SubjectAlternativeName(san_entries),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    _write_pem_certificate("gnmiserver.crt", cert)
+
+
+def prepare_client_cert(localhost, days="825"):
+    create_client_key(localhost)
+    create_client_csr(localhost)
+    sign_client_certificate(localhost, days)
+
+
+def create_client_key(localhost, revoke=False):
+    revoke_suffix = "revoked." if revoke else ""
+    local_command = "openssl genrsa -out gnmiclient.{}key 2048".format(revoke_suffix)
     localhost.shell(local_command)
 
-    # Create client key
-    local_command = "openssl genrsa -out gnmiclient.key 2048"
-    localhost.shell(local_command)
 
-    # Create client CSR
+def create_client_csr(localhost, revoke=False):
+    revoke_suffix = "revoked." if revoke else ""
+    cn = REVOKED_GNMICERT_NAME if revoke else GNMI_CERT_NAME
     local_command = "openssl req \
-                        -new \
-                        -key gnmiclient.key \
-                        -subj '/CN={}' \
-                        -out gnmiclient.csr".format(GNMI_CERT_NAME)
+                            -new \
+                            -key gnmiclient.{}key \
+                            -subj '/CN={}' \
+                            -out gnmiclient.{}csr".format(revoke_suffix, cn, revoke_suffix)
     localhost.shell(local_command)
 
-    # Sign client certificate
-    local_command = "openssl x509 \
-                        -req \
-                        -in gnmiclient.csr \
-                        -CA gnmiCA.pem \
-                        -CAkey gnmiCA.key \
-                        -CAcreateserial \
-                        -out gnmiclient.crt \
-                        -days 825 \
-                        -sha256"
-    localhost.shell(local_command)
 
-    create_revoked_cert_and_crl(localhost, ptfhost)
+def sign_client_certificate(localhost, days="825", revoke=False, extension_file=None):
+    """Sign a (regular or revoked) client CSR with the CA, backdated.
 
+    `extension_file` is the cnf written by create_ca_conf when caller wants
+    a CRL Distribution Points extension on the cert; we parse the URI out
+    of it and add the extension via cryptography (we no longer hand the
+    file to openssl).
+    """
+    revoke_suffix = "revoked." if revoke else ""
+    csr_path = "gnmiclient.{}csr".format(revoke_suffix)
+    out_path = "gnmiclient.{}crt".format(revoke_suffix)
+    ca_cert = _load_pem_certificate("gnmiCA.pem")
+    ca_key = _load_pem_private_key("gnmiCA.key")
+    csr = _load_pem_csr(csr_path)
+    not_before, not_after = _cert_validity_period(days)
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(csr.subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(csr.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+    )
+    if extension_file:
+        crl_uri = _parse_crl_dp_uri(extension_file)
+        if crl_uri:
+            dp = x509.DistributionPoint(
+                full_name=[x509.UniformResourceIdentifier(crl_uri)],
+                relative_name=None,
+                reasons=None,
+                crl_issuer=None,
+            )
+            builder = builder.add_extension(
+                x509.CRLDistributionPoints([dp]),
+                critical=False,
+            )
+    cert = builder.sign(ca_key, hashes.SHA256())
+    _write_pem_certificate(out_path, cert)
+
+
+def copy_certificate_to_dut(duthost):
     # Copy CA certificate, server certificate and client certificate over to the DUT
     duthost.copy(src='gnmiCA.pem', dest='/etc/sonic/telemetry/')
     duthost.copy(src='gnmiserver.crt', dest='/etc/sonic/telemetry/')
     duthost.copy(src='gnmiserver.key', dest='/etc/sonic/telemetry/')
     duthost.copy(src='gnmiclient.crt', dest='/etc/sonic/telemetry/')
     duthost.copy(src='gnmiclient.key', dest='/etc/sonic/telemetry/')
+
+
+def copy_certificate_to_ptf(ptfhost):
     # Copy CA certificate and client certificate over to the PTF
     ptfhost.copy(src='gnmiCA.pem', dest='/root/')
     ptfhost.copy(src='gnmiclient.crt', dest='/root/')
@@ -348,7 +481,9 @@ def delete_gnmi_certs(localhost):
     '''
     Delete GNMI client certificates
     '''
-    local_command = "rm \
+    # -f because extfile.cnf is no longer always created on disk
+    # (sign_server_certificate now sets SAN in-process).
+    local_command = "rm -f \
                         extfile.cnf \
                         gnmiCA.* \
                         gnmiserver.* \

--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -658,7 +658,7 @@ def _get_storm_test_ports(storm_hndle):
 
 def verify_all_ports_pfc_storm_in_expected_state(dut, storm_hndle, expected_state, selected_test_ports,
                                                  baseline_counters=None, threshold_percentage=100,
-                                                 stormed_ports_list=None):
+                                                 stormed_ports_list=None, test_ports_info=None):
     """Verify if threshold percentage of ports reached expected PFC storm state."""
     if dut.facts['asic_type'] == 'vs':
         return True
@@ -680,6 +680,9 @@ def verify_all_ports_pfc_storm_in_expected_state(dut, storm_hndle, expected_stat
 
     # Verify each port
     ports_in_expected_state = 0
+    # Track per-port result so the duplicate-neighbor grouping below can recompute
+    # both the numerator and denominator consistently.
+    port_results = {}
     for test_port, queue_idx in ports_to_check:
         port_stats = pfcwd_stats_dict.get((test_port, queue_idx))
 
@@ -706,6 +709,8 @@ def verify_all_ports_pfc_storm_in_expected_state(dut, storm_hndle, expected_stat
             if ("storm" not in current_status) and (current_detect_count == current_restored_count):
                 is_in_expected_state = True
 
+        port_results[test_port] = port_results.get(test_port, False) or is_in_expected_state
+
         if is_in_expected_state:
             ports_in_expected_state += 1
             if expected_state == "storm" and stormed_ports_list is not None and test_port not in stormed_ports_list:
@@ -717,6 +722,49 @@ def verify_all_ports_pfc_storm_in_expected_state(dut, storm_hndle, expected_stat
     if total_ports == 0:
         logger.warning("No ports found to verify")
         return False
+
+    # On non-dualtor t0 topologies, setup_pfc_test assigns a single VLAN neighbor IP
+    # (self.vlan_nw) to every VLAN port, so at most one of those ports can actually
+    # receive PTF background traffic -- the DUT does one ND/ARP lookup and routes all
+    # traffic out a single port. Counting every such VLAN port individually against the
+    # storm threshold inflates the denominator and causes false failures.
+    #
+    # To keep the numerator and denominator consistent, group VLAN ports that share a
+    # test_neighbor_addr and treat each group as one "effective" port (success = any
+    # member reached the expected state). Non-VLAN ports (routed interfaces and
+    # PortChannel members, which also share a neighbor IP by design in parse_pc_list)
+    # are always counted individually. This adjustment only applies to the storm phase.
+    if expected_state == "storm" and test_ports_info:
+        vlan_ip_groups = {}
+        standalone_ports = []
+        seen_ports = set()
+        for port, _queue_idx in ports_to_check:
+            if port in seen_ports:
+                continue
+            seen_ports.add(port)
+            info = test_ports_info.get(port, {}) or {}
+            ip = info.get('test_neighbor_addr')
+            if info.get('test_port_type') == 'vlan' and ip:
+                vlan_ip_groups.setdefault(ip, []).append(port)
+            else:
+                standalone_ports.append(port)
+
+        # Only adjust when VLAN ports actually share an IP (the non-dualtor case).
+        if any(len(ports) > 1 for ports in vlan_ip_groups.values()):
+            effective_total = len(vlan_ip_groups) + len(standalone_ports)
+            effective_success = 0
+            for ip, ports in vlan_ip_groups.items():
+                if any(port_results.get(p, False) for p in ports):
+                    effective_success += 1
+            for port in standalone_ports:
+                if port_results.get(port, False):
+                    effective_success += 1
+            logger.info(
+                "Adjusting for duplicate VLAN neighbor IPs: ports_in_expected_state %d->%d, "
+                "total_ports %d->%d",
+                ports_in_expected_state, effective_success, total_ports, effective_total)
+            ports_in_expected_state = effective_success
+            total_ports = effective_total
 
     success_percentage = (ports_in_expected_state / total_ports) * 100
     logger.info(f"{ports_in_expected_state}/{total_ports} ports ({success_percentage:.1f}%) "

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -28,9 +28,9 @@ MARK_CONDITIONS_CONSTANTS = {
                      't1-lag', 't1-28-lag', 't1-48-lag', 't1-64-lag', 't1-56-lag',
                      't1-backend', 't1-isolated-d128', 't1-isolated-d32',
                      't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic',
-                     'lt2-p32o64', 'lt2-o128', 'ft2-64', 't2-single-node-min',
+                     'lt2-p32o64', 'lt2-o128', 'ft2-64', 't2-single-node-min', 't2_single_node_min',
                      't2_single_node_max', 't2_single_node_max_64p', 't2-single-node-max-64p',
-                     'topo_t2_single_node_max_64p_v2']
+                     't2_single_node_max_64p_v2']
 }
 
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -178,6 +178,7 @@ arp/test_arp_update.py::test_dut_ping_learns_mac:
     reason: "Skip test_dut_ping_learns_mac on dualtor"
     conditions:
       - "'dualtor' in topo_name"
+      - "'-v6-' in topo_name and https://github.com/sonic-net/sonic-mgmt/issues/24598"
 
 arp/test_arp_update.py::test_kernel_asic_mac_mismatch\[.*ipv4.*\]:
   regex: true

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3671,9 +3671,11 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info:
 
 platform_tests/test_reload_config.py::test_reload_configuration:
   xfail:
-    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
+    reason: "Test case has issue on the t0-isolated-d256u256s2 topo or smartswitch platform"
+    conditions_logical_operator: or
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
+      - "https://github.com/sonic-net/sonic-buildimage/issues/24543 and asic_type in ['mellanox'] and 'sn4280' in platform"
 
 platform_tests/test_reload_config.py::test_reload_configuration_checks:
   skip:
@@ -3681,9 +3683,11 @@ platform_tests/test_reload_config.py::test_reload_configuration_checks:
     conditions:
       - "asic_type in ['cisco-8000']"
   xfail:
-    reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
+    reason: "Test case has issue on the t0-isolated-d256u256s2 topo or smartswitch platform"
+    conditions_logical_operator: or
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
+      - "https://github.com/sonic-net/sonic-buildimage/issues/24543 and asic_type in ['mellanox'] and 'sn4280' in platform"
 
 #######################################
 #####     process_monitoring      #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5143,8 +5143,10 @@ vxlan/test_vnet_bgp_route_precedence.py:
       - "release in ['202411']"
   xfail:
     reason: "Testcase ignored due to github issue: https://github.com/sonic-net/sonic-buildimage/issues/23824"
+    conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/23824"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/21895 and '-v6-' in topo_name and asic_type in ['mellanox']"
 
 vxlan/test_vnet_decap.py::test_vnet_decap:
   xfail:

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -6,7 +6,9 @@ from tests.common.helpers.dut_utils import check_container_state
 from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config
 from tests.gnmi.helper import GNMI_SERVER_START_WAIT_TIME, check_ntp_sync_status
 from tests.common.gu_utils import create_checkpoint, rollback
-from tests.common.helpers.gnmi_utils import create_gnmi_certs, delete_gnmi_certs
+from tests.common.helpers.gnmi_utils import create_revoked_cert_and_crl, create_gnmi_certs, \
+    delete_gnmi_certs, prepare_root_cert, prepare_server_cert, prepare_client_cert, copy_certificate_to_dut, \
+    copy_certificate_to_ptf
 from tests.common.helpers.ntp_helper import setup_ntp_context
 
 
@@ -76,7 +78,12 @@ def setup_gnmi_rotated_server(duthosts, rand_one_dut_hostname, localhost, ptfhos
         check_container_state(duthost, gnmi_container(duthost), should_be_running=True),
         "Test was not supported on devices which do not support GNMI!"
     )
-    create_gnmi_certs(duthost, localhost, ptfhost)
+    prepare_root_cert(localhost)
+    prepare_server_cert(duthost, localhost)
+    prepare_client_cert(localhost)
+    copy_certificate_to_ptf(ptfhost)
+    create_revoked_cert_and_crl(localhost, ptfhost)
+    copy_certificate_to_dut(duthost)
 
 
 @pytest.fixture(scope="module")

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -96,7 +96,13 @@ def _check_monit_container_checker(duthost):
     After gNMI cert config recovery, monit needs time to re-evaluate
     container status. This function checks if container_checker has
     returned to a healthy state (OK or Status ok).
+
+    Trigger a focused container_checker refresh before reading the cached
+    monit status. This avoids failing post-test sanity on stale monit state
+    after telemetry was restarted by cert recovery.
     """
+    duthost.shell("sudo /usr/bin/container_checker", module_ignore_errors=True)
+    duthost.shell("sudo monit validate container_checker", module_ignore_errors=True)
     monit_services = duthost.get_monit_services_status()
     if not monit_services:
         return False
@@ -131,8 +137,9 @@ def recover_cert_config(duthost, stopped_programs=None):
     # Restart telemetry container if it was stopped during cert config change
     # apply_cert_config may trigger ctrmgrd to stop the telemetry container
     if not check_container_state(duthost, "telemetry", should_be_running=True):
-        logger.info("Telemetry container is not running after cert config recovery, restarting it")
-        duthost.shell("sudo systemctl restart telemetry", module_ignore_errors=True)
+        logger.info("Telemetry container is not running after cert config recovery, starting it")
+        duthost.shell("sudo systemctl reset-failed telemetry", module_ignore_errors=True)
+        duthost.shell("sudo systemctl start telemetry", module_ignore_errors=True)
 
     # Wait for monit container_checker to report healthy status.
     # After restarting processes/containers, monit needs time to re-evaluate

--- a/tests/gnmi/test_gnmi_2038.py
+++ b/tests/gnmi/test_gnmi_2038.py
@@ -1,0 +1,66 @@
+import pytest
+import logging
+import re
+from datetime import datetime, timezone
+from dateutil import parser
+
+from tests.common.helpers.gnmi_utils import gnmi_capabilities, prepare_root_cert, prepare_server_cert, \
+    prepare_client_cert, copy_certificate_to_dut, copy_certificate_to_ptf
+from .helper import apply_cert_config
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.disable_loganalyzer
+]
+
+ROOT_CERT_DAYS = 4850
+SERVER_CERT_DAYS = 4800
+CLIENT_CERT_DAYS = 4800
+
+
+def test_gnmi_capabilities_2038(duthosts, rand_one_dut_hostname, localhost, ptfhost):
+    '''
+    Verify certificate after 2038 year problem
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+
+    prepare_root_cert(localhost, days=ROOT_CERT_DAYS)
+    prepare_server_cert(duthost, localhost, days=SERVER_CERT_DAYS)
+    prepare_client_cert(localhost, days=CLIENT_CERT_DAYS)
+
+    copy_certificate_to_dut(duthost)
+    copy_certificate_to_ptf(ptfhost)
+
+    apply_cert_config(duthost)
+
+    # Verify certificate date on DUT
+    check_cert_date_on_dut(duthost)
+
+    # Verify GNMI capabilities to validate functionality
+    ret, msg = gnmi_capabilities(duthost, localhost)
+    assert ret == 0, msg
+    assert "sonic-db" in msg, msg
+    assert "JSON_IETF" in msg, msg
+
+
+def check_cert_date_on_dut(duthost):
+    cmd = "openssl x509 -in /etc/sonic/telemetry/gnmiCA.pem -text"
+    output = duthost.shell(cmd, module_ignore_errors=True)
+    not_after_line = re.search(r"Not After\s*:\s*(.*)", output['stdout'])
+    if not_after_line:
+        not_after_date_str = not_after_line.group(1).strip()
+        # Convert the date string to a datetime object
+        expiry_date = parser.parse(not_after_date_str)
+        if expiry_date.tzinfo is None:
+            expiry_date = expiry_date.replace(tzinfo=timezone.utc)
+        # comparison date is January 20, 2038, after the 2038 problem
+        after_2038_problem_date = datetime(2038, 1, 20, tzinfo=timezone.utc)
+
+        if expiry_date < after_2038_problem_date:
+            raise Exception("The expiry date {} is not after 2038 problem date".format(expiry_date))
+        else:
+            logger.info("The expiry date {} is after January 20, 2038.".format(expiry_date))
+    else:
+        raise Exception("The 'Not After' line with expiry date was not found")

--- a/tests/layer1/test_fec_error.py
+++ b/tests/layer1/test_fec_error.py
@@ -83,14 +83,15 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
         Expected format :
             * 0
             * 7.81e-10 (89%)
+            * 3.38e+00 (nan%)
         """
         # Pattern for just "0"
         if value_string == "0":
             return True
 
         # Pattern for scientific notation with required accuracy percentage
-        # e.g., "7.81e-10 (89%)"
-        pattern = r'^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)\s+\(\d+%\)$'
+        # e.g., "7.81e-10 (89%)" or "3.38e+00 (nan%)"
+        pattern = r'^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)\s+\((\d+|nan)%\)$'
         if re.match(pattern, value_string):
             return True
 

--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -458,9 +458,10 @@ def test_lldp_entry_table_after_all_batched_flap(
     asic_interface_map = group_interfaces_by_asic(duthost, testable_interfaces)
     lldpctl_lookup_map = _build_lldpctl_lookup_map(lldpctl_interfaces)
     for asic_str, asic_interfaces in asic_interface_map.items():
-        interface_list = ",".join(asic_interfaces)
-        logger.info("Flapping interfaces: {}".format(interface_list))
-        _shutdown_startup_interface(duthost, interface_list, asic_str)
+        logger.info("Flapping interfaces: {}".format(asic_interfaces))
+        # Interface range shutdown/startup is not supported in multi-asic platforms.
+        for interface in asic_interfaces:
+            _shutdown_startup_interface(duthost, interface, asic_str)
     # Single wait_until call checking all interfaces together
     _verify_interface_lldp_recovery(db_instance, testable_interfaces, lldpctl_lookup_map, delay=10)
 

--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -209,7 +209,7 @@ class TestPfcwdAllPortStorm(object):
     PFC_RESTORE_THRESHOLD_PERCENTAGE = 100
 
     def run_test(self, duthost, storm_hndle, expect_regex, syslog_marker, action, selected_test_ports,
-                 stormed_ports_list=None, tbinfo=None):
+                 stormed_ports_list=None, tbinfo=None, test_ports_info=None):
         """Storm generation/restoration on all ports and verification."""
         loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=syslog_marker)
         ignore_file = os.path.join(TEMPLATES_DIR, "ignore_pfc_wd_messages")
@@ -244,8 +244,9 @@ class TestPfcwdAllPortStorm(object):
                 timeout = max(timeout, 120)
             pytest_assert(
                 wait_until(timeout, 2, 5, verify_all_ports_pfc_storm_in_expected_state, duthost,
-                           storm_hndle, action, selected_test_ports, baseline_counters, threshold,
-                           stormed_ports_list),
+                           storm_hndle, action, selected_test_ports,
+                           baseline_counters=baseline_counters, threshold_percentage=threshold,
+                           stormed_ports_list=stormed_ports_list, test_ports_info=test_ports_info),
                 f"Not enough ports reached {action} state (threshold: {threshold}%)"
             )
 
@@ -294,10 +295,14 @@ class TestPfcwdAllPortStorm(object):
                           action="storm",
                           stormed_ports_list=stormed_ports_list,
                           selected_test_ports=selected_test_ports,
+                          test_ports_info=setup_pfc_test['test_ports'],
                           tbinfo=tbinfo)
 
         logger.info(f"--- {len(stormed_ports_list)} ports entered storm state ---")
         logger.info("--- Testing if PFC storm is restored on stormed ports ---")
+        # test_ports_info is intentionally not passed during restore: the duplicate-neighbor
+        # adjustment in verify_all_ports_pfc_storm_in_expected_state only applies to the storm
+        # phase, so it has no effect here.
         self.run_test(duthost, storm_hndle, expect_regex=[EXPECT_PFC_WD_RESTORE_RE],
                       syslog_marker="all_port_storm_restore", action="restore",
                       stormed_ports_list=stormed_ports_list,

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -347,6 +347,24 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
 
     # Group outlets/PDUs by PSU and toggle PDUs by PSU
     psu_to_pdus = get_grouped_pdus_by_psu(pdu_ctrl)
+    # Safety check: there must be at least 2 distinct PDU outlets across all PSUs, so that
+    # turning one PSU's outlet off still leaves another PSU powered. If every PSU hangs off
+    # a single shared outlet (e.g. both PSUs of a 2-PSU DUT on one outlet, as seen when the
+    # PDU connection graph maps PSU1 and PSU2 to the same outlet), turning it off removes
+    # all power from the DUT and reboots it
+    distinct_outlets = set()
+    for outlets in psu_to_pdus.values():
+        for outlet in outlets:
+            distinct_outlets.add("{}/{}".format(outlet.get('pdu_name'), outlet.get('outlet_id')))
+    if len(distinct_outlets) < 2:
+        logging.warning(
+            "All PSUs on %s share a single PDU outlet %s; turning it off would power off the "
+            "whole DUT. Please fix the PDU cabling/connection graph so each PSU has its own "
+            "outlet.", duthost.hostname, sorted(distinct_outlets))
+    pytest_require(
+        len(distinct_outlets) >= 2,
+        "Skip the test: all PSUs on {} share PDU outlet(s) {}; toggling would power off the "
+        "whole DUT.".format(duthost.hostname, sorted(distinct_outlets)))
 
     # Get list of PSUs to skip from inventory configuration
     skip_psu_list = get_skip_mod_list(duthost, ['psus'])

--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -94,10 +94,13 @@ class TestAutoTechSupport:
         self.set_test_dockers_list()
 
         logger.info('Waiting until existing(if exist) techsupport processes finish')
-        wait_until(300, 10, 0, is_techsupport_generation_in_expected_state, self.duthost, False)
+        if not wait_until(300, 10, 0, is_techsupport_generation_in_expected_state, self.duthost, False):
+            logger.warning('Existing techsupport generation processes did not finish; cleaning them up')
+            clear_techsupport_generation_processes(self.duthost)
 
         clear_auto_techsupport_history(self.duthost)
         self.duthost.shell('sudo mkdir /var/dump/', module_ignore_errors=True)
+        clear_techsupport_generation_processes(self.duthost)
         clear_folders(self.duthost)
 
         create_core_file_generator_script(self.duthost)
@@ -105,6 +108,7 @@ class TestAutoTechSupport:
         yield
 
         clear_auto_techsupport_history(self.duthost)
+        clear_techsupport_generation_processes(self.duthost)
         clear_folders(self.duthost)
 
     @pytest.fixture(autouse=True, scope='class')
@@ -687,15 +691,10 @@ def is_techsupport_generation_in_expected_state(duthost, expected_in_progress=Tr
     :return: True in case when techsupport generation in progress
     """
     with allure.step('Checking techsupport generation process'):
-        techsupport_in_progress = False
-        processes_to_be_ignored = 2
-        get_running_tech_procs_cmd = 'ps -aux | grep "coredump_gen_handler"'
-        # Need to ignore 2 lines: one line with "grep...", another line with ansible module which call "grep..."
-        num_of_process = len(duthost.shell(get_running_tech_procs_cmd)['stdout_lines']) - processes_to_be_ignored
+        running_processes = get_running_techsupport_generation_processes(duthost)
+        num_of_process = len(running_processes)
         logger.info('Number of running autotechsupport processes: {}'.format(num_of_process))
-
-        if num_of_process >= 1:
-            techsupport_in_progress = True
+        techsupport_in_progress = num_of_process >= 1
 
         is_in_expected_state = False
         if expected_in_progress:
@@ -706,6 +705,34 @@ def is_techsupport_generation_in_expected_state(duthost, expected_in_progress=Tr
                 is_in_expected_state = True
 
         return is_in_expected_state
+
+
+def get_running_techsupport_generation_processes(duthost):
+    """
+    Get coredump handler PIDs. These handlers own auto-techsupport generation.
+    :param duthost: duthost object
+    :return: list of PIDs as strings
+    """
+    cmd = "ps -eo pid=,cmd= | awk '/[c]oredump_gen_handler.py/ {print $1}'"
+    output = duthost.shell(cmd, module_ignore_errors=True)['stdout_lines']
+    return [line.strip() for line in output if line.strip().isdigit()]
+
+
+def clear_techsupport_generation_processes(duthost):
+    """
+    Stop stale coredump handlers so a previous failed run cannot block the next one.
+    :param duthost: duthost object
+    """
+    pids = get_running_techsupport_generation_processes(duthost)
+    if not pids:
+        return
+
+    logger.warning('Stopping stale auto-techsupport generation processes: {}'.format(', '.join(pids)))
+    duthost.shell('sudo kill {}'.format(' '.join(pids)), module_ignore_errors=True)
+    if not wait_until(30, 2, 0, is_techsupport_generation_in_expected_state, duthost, False):
+        pids = get_running_techsupport_generation_processes(duthost)
+        if pids:
+            duthost.shell('sudo kill -9 {}'.format(' '.join(pids)), module_ignore_errors=True)
 
 
 def validate_core_files_inside_techsupport(duthost, techsupport_folder, expected_core_files_list):

--- a/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
@@ -26,7 +26,7 @@ pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 # sent to see the marked packets at the end of the flow.
 ECN_PARAMS_BY_ASIC = {
     'default':  {'ecn_params': {'kmin': 50000, 'kmax': 51000, 'pmax': 100}, 'pkt_count': 101},
-    'broadcom': {'ecn_params': {'kmin': 40000, 'kmax': 51000, 'pmax': 100}, 'pkt_count': 301},
+    'broadcom': {'ecn_params': {'kmin': 40000, 'kmax': 168000, 'pmax': 100}, 'pkt_count': 301},
 }
 
 

--- a/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -150,6 +150,31 @@ def get_expected_bg_loss_percent(egress_duthost,
     return sum(losses) / len(losses)
 
 
+def get_expected_total_drop_percent(test_flow_rate_percent,
+                                    bg_prio_list,
+                                    bg_flow_rate_percent,
+                                    expected_bg_loss_percent):
+    """Compute expected overall drop percent from offered-load mix.
+
+    The total drop is background-offered-share multiplied by the expected
+    background loss percent, normalized by total offered load.
+    """
+    pytest_assert(bg_flow_rate_percent, "FAIL: bg_flow_rate_percent must be non-empty")
+    pytest_assert(
+        len(set(bg_flow_rate_percent)) == 1,
+        "FAIL: bg_flow_rate_percent entries must be equal, got {}".format(bg_flow_rate_percent))
+
+    bg_flow_count = len(bg_prio_list)
+    bg_rate_per_flow = bg_flow_rate_percent[0]
+    total_bg_offered_percent = bg_flow_count * bg_rate_per_flow
+    total_test_offered_percent = sum(test_flow_rate_percent)
+    total_offered_percent = total_bg_offered_percent + total_test_offered_percent
+    pytest_assert(total_offered_percent > 0,
+                  "FAIL: total offered percent must be > 0 (got {})".format(total_offered_percent))
+
+    return total_bg_offered_percent * expected_bg_loss_percent / total_offered_percent
+
+
 def run_m2o_fluctuating_lossless_test(api,
                                       testbed_config,
                                       port_config_list,
@@ -277,8 +302,6 @@ def run_m2o_fluctuating_lossless_test(api,
         pkt_drop = get_interface_stats(egress_duthost, dut_tx_port)[egress_duthost.hostname][dut_tx_port]['tx_drp']
         drop_percentage = (100 * pkt_drop) / total_rx_pkts
 
-    pytest_assert(abs(drop_percentage - 8) < 1, 'FAIL: Drop packets must be around 8 percent')
-
     expected_bg_loss_percent = get_expected_bg_loss_percent(
         egress_duthost=egress_duthost,
         test_prio_list=test_prio_list,
@@ -287,6 +310,18 @@ def run_m2o_fluctuating_lossless_test(api,
         bg_flow_rate_percent=BG_FLOW_AGGR_RATE_PERCENT,
         asic_value=rx_port.get('asic_value'),
         port=dut_tx_port)
+
+    expected_drop_percentage = get_expected_total_drop_percent(
+        test_flow_rate_percent=TEST_FLOW_AGGR_RATE_PERCENT,
+        bg_prio_list=bg_prio_list,
+        bg_flow_rate_percent=BG_FLOW_AGGR_RATE_PERCENT,
+        expected_bg_loss_percent=expected_bg_loss_percent)
+
+    pytest_assert(
+        abs(drop_percentage - expected_drop_percentage) < 1,
+        'FAIL: Drop packets must be around {:.2f}% (got {:.2f}%)'.format(
+            expected_drop_percentage, drop_percentage))
+
     logger.info('Expected per-Background-Flow loss: {:.2f}% (tolerance +/- {}%)'.format(
         expected_bg_loss_percent, BG_LOSS_TOLERANCE_PERCENT))
 

--- a/tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/unit_tests/pfc/unit_test_m2o_fluctuating_lossless_helper.py
@@ -37,7 +37,10 @@ import pytest
 MODULE_PATH = (Path(__file__).resolve().parents[3] /
                "snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py")
 
-FUNCTION_NAMES = ("get_expected_bg_loss_percent",)
+FUNCTION_NAMES = (
+    "get_expected_bg_loss_percent",
+    "get_expected_total_drop_percent",
+)
 
 
 def _load_functions(names):
@@ -174,3 +177,28 @@ def test_expected_bg_loss_matches_analytical_dwrr_split(
     )
 
     assert result == pytest.approx(expected_loss, abs=0.01)
+
+
+@pytest.mark.parametrize(
+    "test_rate,bg_prio,bg_rates,bg_loss,expected_total_drop",
+    [
+        # m2o fluctuating-lossless default: total offered = 110%,
+        # bg offered = 80%, bg loss ~= 11.2676% => total drop ~= 8.1946%
+        ([20, 10], [0, 1, 2, 5], [20, 20, 20, 20], 11.2676, 8.1946),
+        # Uniform-weight reference: bg loss = 10% => total drop ~= 7.2727%
+        ([20, 10], [0, 1, 2, 5], [20, 20, 20, 20], 10.0, 7.2727),
+        # Mix-weight from Cisco-8102: bg_prio_list=[2,1,5,6]
+        ([20, 10], [2, 1, 5, 6], [20, 20, 20, 20], 11.2676, 8.1946),
+    ],
+)
+def test_expected_total_drop_percent_matches_weighted_formula(
+        helper_ns, test_rate, bg_prio, bg_rates, bg_loss, expected_total_drop):
+    """Overall drop must equal weighted BG-loss contribution over total load."""
+    result = helper_ns["get_expected_total_drop_percent"](
+        test_flow_rate_percent=test_rate,
+        bg_prio_list=bg_prio,
+        bg_flow_rate_percent=bg_rates,
+        expected_bg_loss_percent=bg_loss,
+    )
+
+    assert result == pytest.approx(expected_total_drop, abs=0.01)

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -2,12 +2,25 @@ import logging
 import pytest
 import json
 import re
+from datetime import datetime, timedelta, timezone
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 
 from pkg_resources import parse_version
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 
 logger = logging.getLogger(__name__)
+
+# Backdate rotated telemetry cert notBefore so it survives clock skew
+# between the sonic-mgmt runner and the DUT. Cryptography lib here
+# instead of openssl shell because openssl 3.0.x has no CLI flag to
+# set notBefore on `req -x509` (added only in 3.5).
+_TELEMETRY_CERT_BACKDATE_DAYS = 7
+_TELEMETRY_CERT_VALIDITY_DAYS = 365
 
 METHOD_GET = "get"
 METHOD_SUBSCRIBE = "subscribe"
@@ -173,27 +186,43 @@ def archive_telemetry_certs(duthost):
             duthost.shell(cmd)
 
 
+def _mint_self_signed_telemetry_cert(common_name, cert_path, key_path):
+    """Generate a backdated self-signed leaf cert + key on the sonic-mgmt runner."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    now = datetime.now(timezone.utc)
+    not_before = now - timedelta(days=_TELEMETRY_CERT_BACKDATE_DAYS)
+    not_after = now + timedelta(days=_TELEMETRY_CERT_VALIDITY_DAYS)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .sign(key, hashes.SHA256())
+    )
+    with open(key_path, "wb") as f:
+        f.write(key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        ))
+    with open(cert_path, "wb") as f:
+        f.write(cert.public_bytes(serialization.Encoding.PEM))
+
+
 def rotate_telemetry_certs(duthost, localhost):
     path = "/etc/sonic/telemetry/"
-    # Create new certs to rotate
-    cmd = "openssl req \
-              -x509 \
-              -sha256 \
-              -nodes \
-              -newkey rsa:2048 \
-              -keyout streamingtelemetryserver.key \
-              -subj '/CN=ndastreamingservertest' \
-              -out streamingtelemetryserver.cer"
-    localhost.shell(cmd)
-    cmd = "openssl req \
-              -x509 \
-              -sha256 \
-              -nodes \
-              -newkey rsa:2048 \
-              -keyout dsmsroot.key \
-              -subj '/CN=ndastreamingclienttest' \
-              -out dsmsroot.cer"
-    localhost.shell(cmd)
+    # Mint fresh self-signed certs locally with a backdate so the rotated
+    # PKI survives clock skew between the sonic-mgmt runner and the DUT.
+    _mint_self_signed_telemetry_cert(
+        "ndastreamingservertest", "streamingtelemetryserver.cer", "streamingtelemetryserver.key",
+    )
+    _mint_self_signed_telemetry_cert(
+        "ndastreamingclienttest", "dsmsroot.cer", "dsmsroot.key",
+    )
 
     # Rotate certs
     duthost.copy(src="streamingtelemetryserver.cer", dest=path)

--- a/tests/vxlan/test_vnet_decap.py
+++ b/tests/vxlan/test_vnet_decap.py
@@ -33,16 +33,34 @@ def find_ptf_dest_port(duthost, minigraph_facts, except_interfaces=[]):
     """
     Finds an Ethernet port that is operationally UP and does not appear in except_interfaces
     and also is not a member of any PortChannel interface that appears in except_interfaces.
-    Returns the PTF index of that Ethernet port (if such port is found).
+    Returns the PTF index of that Ethernet port and the port name (if such port is found).
     """
     dut_interfaces = duthost.get_interfaces_status()
     ptf_indices = minigraph_facts["minigraph_ptf_indices"]
     except_ports = ecmp_utils.get_ethernet_ports(except_interfaces, minigraph_facts)
     for intf_name, intf_info in dut_interfaces.items():
         if intf_info["oper"] == "up" and intf_name.startswith("Ethernet") and intf_name not in except_ports:
-            return ptf_indices[intf_name]
+            return ptf_indices[intf_name], intf_name
     pytest.skip("No suitable Ethernet port could be found on the DUT for receiving packets from PTF.")
-    return -1
+    return -1, None
+
+
+def get_dest_mac(duthost, tbinfo, minigraph_facts, ingress_intf, router_mac):
+    """
+    Returns the destination MAC that an IP-in-IP packet must carry to be L3-terminated
+    (and therefore decapsulated) when it ingresses on 'ingress_intf'.
+
+    On t1 the server/downlink ports are routed (L3) interfaces, so the global router MAC
+    is the termination MAC. On t0/dualtor the server ports are VLAN member ports; routing
+    for that subnet is done by the VLAN SVI, whose MAC may differ from the router MAC
+    (on dualtor it is the shared gateway MAC). Using the router MAC on such a port leaves
+    the frame at L2 and it gets flooded in the VLAN instead of being decapsulated.
+    """
+    if tbinfo["topo"]["type"] == "t0" and ingress_intf is not None:
+        for vlan_name, vlan_info in minigraph_facts.get("minigraph_vlans", {}).items():
+            if ingress_intf in vlan_info.get("members", []):
+                return duthost.get_dut_iface_mac(vlan_name)
+    return router_mac
 
 
 @pytest.fixture(scope="module", params=[4, 6], ids=["inner_ipv4", "inner_ipv6"])
@@ -100,9 +118,12 @@ def setup(request, duthosts, rand_one_dut_hostname, tbinfo, inner_ip_version, ou
                                                               dest_net_prefix=DESTINATION_PREFIX,
                                                               nexthop_prefix=ENDPOINT_PREFIX,
                                                               nh_af=outer_ip_version_str)
-    ptf_port_index = find_ptf_dest_port(duthost, minigraph_facts, except_interfaces=[vnet_interface])
+    ptf_port_index, ingress_intf = find_ptf_dest_port(duthost, minigraph_facts, except_interfaces=[vnet_interface])
     data = {}  # test data
     data["router_mac"] = router_mac
+    # On t0/dualtor the ingress port may be a VLAN member, in which case the L3 termination
+    # (decap) MAC is the VLAN SVI MAC rather than the global router MAC.
+    data["dest_mac"] = get_dest_mac(duthost, tbinfo, minigraph_facts, ingress_intf, router_mac)
     data["outer_ip_version"] = outer_ip_version
     data["inner_ip_version"] = inner_ip_version
     data["vxlan_src_ip"] = ecmp_utils.get_dut_loopback_address(duthost, minigraph_facts, outer_ip_version_str)
@@ -235,6 +256,8 @@ def extract_inner_ip_pkt(outer_pkt, inner_ip_version, outer_ip_version):
         return packet.IPv6(outer_pkt_bytes[outer_ip_header_size:])
 
 
+@pytest.mark.dualtor_active_standby_toggle_to_random_tor
+@pytest.mark.dualtor_active_active_setup_standby_on_random_unselected_tor
 def test_vnet_decap(setup, ptfadapter):
     """
     We send an IP-in-IP packet to the DUT:
@@ -246,6 +269,7 @@ def test_vnet_decap(setup, ptfadapter):
     """
     data = setup
     router_mac = data["router_mac"]
+    dest_mac = data["dest_mac"]
     outer_ip_version = data["outer_ip_version"]
     inner_ip_version = data["inner_ip_version"]
     vxlan_src_ip = data["vxlan_src_ip"]
@@ -256,7 +280,7 @@ def test_vnet_decap(setup, ptfadapter):
 
     inner_ip_pkt = get_inner_ip_packet(vnet_dest, inner_ip_version)  # Does not have the Ethernet header
     ptf_mac = ptfadapter.dataplane.get_mac(0, ptf_port_index)
-    test_pkt = get_outer_packet(ptf_mac, router_mac, vxlan_src_ip, inner_ip_pkt, outer_ip_version)
+    test_pkt = get_outer_packet(ptf_mac, dest_mac, vxlan_src_ip, inner_ip_pkt, outer_ip_version)
     expected_pkt = get_expected_vxlan_packet(outer_ip_version, router_mac, vxlan_src_ip, vnet_endpoint, inner_ip_pkt)
     ptfadapter.dataplane.flush()
     testutils.send(ptfadapter, ptf_port_index, test_pkt)

--- a/tests/vxlan/test_vxlan_decap_ttl.py
+++ b/tests/vxlan/test_vxlan_decap_ttl.py
@@ -127,6 +127,24 @@ def select_ingress_port(duthost):
     pytest.skip("No oper UP Ethernet interface found on the DUT to be used as ingress port.")
 
 
+def get_dest_mac(duthost, tbinfo, minigraph_facts, ingress_intf, router_mac):
+    """
+        Returns the destination MAC the outer VxLAN packet must carry to be L3-terminated
+        (and therefore decapsulated) when it ingresses on 'ingress_intf'.
+
+        On t1 the server/downlink ports are routed (L3) interfaces, so the global router MAC
+        is the termination MAC. On t0/dualtor the server ports are VLAN member ports; routing
+        for that subnet is done by the VLAN SVI, whose MAC may differ from the router MAC
+        (on dualtor it is the shared gateway MAC). Using the router MAC on such a port leaves
+        the frame at L2 and it gets flooded in the VLAN instead of being decapsulated.
+    """
+    if tbinfo["topo"]["type"] == "t0" and ingress_intf is not None:
+        for vlan_name, vlan_info in minigraph_facts.get("minigraph_vlans", {}).items():
+            if ingress_intf in vlan_info.get("members", []):
+                return duthost.get_dut_iface_mac(vlan_name)
+    return router_mac
+
+
 def select_egress_ip_and_ports(duthost, minigraph_facts, inner_ip_version, exclude_ports=[]):
     """
         Returns a tuple of (egress_ip, egress_port_list) to be used in tests.
@@ -218,6 +236,8 @@ def get_expected_packet_mask(inner_pkt, inner_ip_version):
         return get_expected_packet_mask_ipv6(inner_pkt)
 
 
+@pytest.mark.dualtor_active_standby_toggle_to_upper_tor
+@pytest.mark.dualtor_active_active_setup_standby_on_lower_tor
 def test_vxlan_decap_ttl(duthost, tbinfo, ptfadapter, create_vnet, outer_ip_version, inner_ip_version):  # noqa F811
     """
         In this test, the DUT acts as a VNET endpoint and decapulates VxLAN packets sent to it that match
@@ -235,9 +255,14 @@ def test_vxlan_decap_ttl(duthost, tbinfo, ptfadapter, create_vnet, outer_ip_vers
     egress_port_indices = [ptf_indices[port] for port in egress_ports]
     ptf_src_mac = ptfadapter.dataplane.get_mac(0, ptf_indices[ingress_port])
 
+    # On t0/dualtor the ingress port may be a VLAN member, in which case the outer packet must be
+    # addressed to the VLAN SVI MAC (the L3 termination MAC) to be decapsulated rather than flooded.
+    # The inner frame's dst MAC stays the router MAC, which is the configured vxlan_router_mac.
+    outer_dst_mac = get_dest_mac(duthost, tbinfo, minigraph_facts, ingress_port, router_mac)
+
     inner_pkt = get_inner_packet(dst_mac=router_mac, src_mac=ptf_src_mac, ip_version=inner_ip_version,
                                  dst_ip=inner_dst_ip, ttl=2)
-    outer_pkt = get_outer_packet(eth_dst=router_mac, eth_src=ptf_src_mac, ip_version=outer_ip_version,
+    outer_pkt = get_outer_packet(eth_dst=outer_dst_mac, eth_src=ptf_src_mac, ip_version=outer_ip_version,
                                  ip_dst=vnet_endpoint, inner_pkt=inner_pkt)
 
     exp_pkt_mask = get_expected_packet_mask(inner_pkt, inner_ip_version)


### PR DESCRIPTION
```
* 8cddb8a163 - Revert "[action] [PR:24091] Adding confed configuration to topo_t2_single_node_max_64p.yml" (#25563) (2026-06-25) [Yatish]
* a868c79e45 - [action] [PR:23090] Fix interface range shutdown/startup not supported on multi-asic (#25670) (2026-06-26) [mssonicbld]
* cb7ac111f4 - [action] [PR:25482] Fix AnsibleHostBase._run: normalize 'failed' key for ansible-core >= 2.21 (#25671) (2026-06-26) [mssonicbld]
* f063e52ac4 - [ci][202511] wire PTF image tag through impacted-area PR tests (#25653) (2026-06-26) [yijingyan2]
* 922c7b3b61 - [action] [PR:25529] [vxlan][dualtor][t0] Fix test_vnet_decap on dualtor/t0 (#25650) (2026-06-25) [mssonicbld]
* 74c125eeaa - [action] [PR:25065] Ensure Router Advertisements are disabled on renumber_topo as well as existing mgmt interface (#25659) (2026-06-25) [mssonicbld]
* 6cc8f49c25 - [action] [PR:25317] [platform_tests] Skip PSU on/off test when all PSUs share one PDU outlet to avoid rebooting the DUT (#25660) (2026-06-25) [mssonicbld]
* f4afece49a - [action] [PR:25555] [vxlan][dualtor] Fix test_vxlan_decap_ttl on dualtor/t0 (#25651) (2026-06-25) [mssonicbld]
* 983d440415 - [action] [PR:25285] [test] Fix FEC predicted FLR validation to accept nan% accuracy (#25644) (2026-06-25) [mssonicbld]
* cfc33e7937 - [action] [PR:25147] [pfcwd] Workaround: exclude duplicate-neighbor VLAN ports from PFCWD storm threshold denominator (#25645) (2026-06-25) [mssonicbld]
* 8565e4822b - [action] [PR:25533] Clean stale auto-techsupport handlers before tests (#25621) (2026-06-24) [mssonicbld]
* 5e57c2ac3b - [202511] Stabilize gNMI cert recovery container check (#25423) (2026-06-24) [Xichen96]
* 7d95929e23 - [action] [PR:24972] Fix golden config losing BGP confederation on multi-ASIC T2 devices (#25601) (2026-06-24) [mssonicbld]
* c055030269 - [action] [PR:25573] Adjust Broadcom ECN kmax threshold with 500-cell distance from kmin (#25611) (2026-06-24) [mssonicbld]
* d3feddafe9 - [202511] Backport: cryptography-based gnmi/telemetry cert generation with notBefore backdate (#24607, #15770) (#25404) (2026-06-22) [Dawei Huang]
* 9e6eb8b796 - [202511 backport PR24610] Fix the names of the qos-capable topologies (#25502) (2026-06-22) [Peter Bailey]
* 3cbc1a963e - [action] [PR:25425] Use ocs cross-connect CLI in Python module for L1 deploy instead of patch and reload  (#25538) (2026-06-22) [mssonicbld]
* 6dfda56497 - [action] [PR:25427] [snappi/pfc]: Dynamically compute the total drop expectation in m2o test (#25539) (2026-06-22) [mssonicbld]
* 10fe709d21 - [action] [PR:21393] Disable default route in dpu (#22413) (2026-06-19) [mssonicbld]
* 1975d7c039 - [action] [PR:21937] Xfail fail test_vnet_bgp_route_precedence.py due to not support on v6 only topo (#23687) (2026-06-19) [mssonicbld]
* a360eda363 - [action] [PR:22277] Add github issue 24543 in condition mark (#23783) (2026-06-19) [mssonicbld]
* 7504efbae0 - [action] [PR:25458] Fix loganalyzer to ignore port attr errors with any exit code (#25470) (2026-06-19) [mssonicbld]
* 297497a5fb - [action] [PR:24777] Skip test_dut_ping_learns_mac on v6-only topology, as this topology does not support the test. (#25454) (2026-06-19) [mssonicbld]
```
