### PR TITLE
[Cherry-pick][TH6-128][QoS] Qos yaml and qos test update to support broadcom-TH6 p…

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -28,9 +28,9 @@ MARK_CONDITIONS_CONSTANTS = {
                      't1-lag', 't1-28-lag', 't1-48-lag', 't1-64-lag', 't1-56-lag',
                      't1-backend', 't1-isolated-d128', 't1-isolated-d32',
                      't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic',
-                     'lt2-p32o64', 'lt2-o128', 'ft2-64', 't2-single-node-min',
-                     't2_single_node_max', 't2_single_node_max_64p', 't2-single-node-max-64p',
-                     'topo_t2_single_node_max_64p_v2']
+                     'lt2-p32o64', 'lt2-o128', 'ft2-64', 'ft2-16', 't2_one_hwsku_min', 't2_one_hwsku_max', 't2-single-node-min',
+                     't2_single_node_min', 't2_single_node_max', 't2_single_node_max_64p', 't2-single-node-max-64p',
+                     'topo_t2_single_node_max_64p_v2', 'urh_min', 'lrh_min', 'lt2-o224', 'lt2-o32', 'lt2-o256-u32d224']
 }
 
 

--- a/tests/qos/files/qos_params.th6.yaml
+++ b/tests/qos/files/qos_params.th6.yaml
@@ -1,0 +1,641 @@
+qos_params:
+    th6:
+        topo-lt2-o224:
+            400000_30m:
+                hdrm_pool_size:
+                    dscps:
+                        - 3
+                        - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 4
+                    pgs:
+                        - 3
+                        - 4
+                    pgs_num: 22
+                    pkts_num_hdrm_full: 4474
+                    pkts_num_hdrm_partial: 3326
+                    pkts_num_trig_pfc: 108469
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 108443
+                pkts_num_egr_mem: 714
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 112944
+                    pkts_num_trig_pfc: 108469
+                wm_pg_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 34
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 108469
+                wm_pg_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 108443
+                wm_q_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 112944
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 108443
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 112944
+                    pkts_num_trig_pfc: 108469
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 112944
+                    pkts_num_trig_pfc: 108469
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 108469
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 108469
+            400000_500m:
+                hdrm_pool_size:
+                    dscps:
+                        - 3
+                        - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 4
+                    pgs:
+                        - 3
+                        - 4
+                    pgs_num: 22
+                    pkts_num_hdrm_full: 4474
+                    pkts_num_hdrm_partial: 3326
+                    pkts_num_trig_pfc: 227170
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 50
+                    pkts_num_trig_egr_drp: 26600
+                pkts_num_egr_mem: 523
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 229162
+                    pkts_num_trig_pfc: 227170
+                wm_pg_shared_lossless:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 20
+                    pkts_num_margin: 50
+                    pkts_num_trig_pfc: 227170
+                wm_pg_shared_lossy:
+                    cell_size: 420
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 50
+                    pkts_num_trig_egr_drp: 26600
+                wm_q_shared_lossless:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 200
+                    pkts_num_trig_ingr_drp: 229162
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 420
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 200
+                    pkts_num_trig_egr_drp: 26600
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 50
+                    pkts_num_trig_ingr_drp: 229162
+                    pkts_num_trig_pfc: 227170
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 50
+                    pkts_num_trig_ingr_drp: 229162
+                    pkts_num_trig_pfc: 227170
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 9
+                    pkts_num_margin: 50
+                    pkts_num_trig_pfc: 227170
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 9
+                    pkts_num_margin: 50
+                    pkts_num_trig_pfc: 227170
+            cell_size: 420
+            hdrm_pool_wm_multiplier: 1
+            wrr:
+                ecn: 1
+                limit: 80
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                q7_num_of_pkts: 140
+            wrr_chg:
+                ecn: 1
+                limit: 80
+                lossless_weight: 30
+                lossy_weight: 8
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                q7_num_of_pkts: 80
+        topo-lt2-o32:
+            400000_30m:
+                hdrm_pool_size:
+                    dscps:
+                        - 3
+                        - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 4
+                    pgs:
+                        - 3
+                        - 4
+                    pgs_num: 22
+                    pkts_num_hdrm_full: 4474
+                    pkts_num_hdrm_partial: 3326
+                    pkts_num_trig_pfc: 108469
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 108443
+                pkts_num_egr_mem: 714
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 112944
+                    pkts_num_trig_pfc: 108469
+                wm_pg_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 34
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 108469
+                wm_pg_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 108443
+                wm_q_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 112944
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 108443
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 112944
+                    pkts_num_trig_pfc: 108469
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 112944
+                    pkts_num_trig_pfc: 108469
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 108469
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 108469
+            400000_500m:
+                hdrm_pool_size:
+                    dscps:
+                        - 3
+                        - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 4
+                    pgs:
+                        - 3
+                        - 4
+                    pgs_num: 22
+                    pkts_num_hdrm_full: 4474
+                    pkts_num_hdrm_partial: 3326
+                    pkts_num_trig_pfc: 108469
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 108443
+                pkts_num_egr_mem: 714
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 112944
+                    pkts_num_trig_pfc: 108469
+                wm_pg_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 34
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 108469
+                wm_pg_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 108443
+                wm_q_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 112944
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 108443
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 112944
+                    pkts_num_trig_pfc: 108469
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 112944
+                    pkts_num_trig_pfc: 108469
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 108469
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 108469
+            cell_size: 254
+            hdrm_pool_wm_multiplier: 1
+            wrr:
+                ecn: 1
+                limit: 80
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                q7_num_of_pkts: 140
+            wrr_chg:
+                ecn: 1
+                limit: 80
+                lossless_weight: 30
+                lossy_weight: 8
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                q7_num_of_pkts: 80
+        topo-lt2-o256-u32d224:
+            400000_30m:
+                hdrm_pool_size:
+                    dscps:
+                        - 3
+                        - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 4
+                    pgs:
+                        - 3
+                        - 4
+                    pgs_num: 22
+                    pkts_num_hdrm_full: 4474
+                    pkts_num_hdrm_partial: 3326
+                    pkts_num_trig_pfc: 226618
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 50
+                    pkts_num_trig_egr_drp: 226598
+                pkts_num_egr_mem: 521
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 227843
+                    pkts_num_trig_pfc: 226618
+                wm_pg_shared_lossless:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 20
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 226618
+                wm_pg_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 226598
+                wm_q_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 20
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 227843
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 226598
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 227843
+                    pkts_num_trig_pfc: 226618
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 227843
+                    pkts_num_trig_pfc: 226618
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 10
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 226618
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 10
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 226618
+            400000_500m:
+                hdrm_pool_size:
+                    dscps:
+                        - 3
+                        - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 4
+                    pgs:
+                        - 3
+                        - 4
+                    pgs_num: 22
+                    pkts_num_hdrm_full: 4474
+                    pkts_num_hdrm_partial: 3326
+                    pkts_num_trig_pfc: 226618
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 50
+                    pkts_num_trig_egr_drp: 226498
+                pkts_num_egr_mem: 521
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 228610
+                    pkts_num_trig_pfc: 226618
+                wm_pg_shared_lossless:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 20
+                    pkts_num_margin: 50
+                    pkts_num_trig_pfc: 226618
+                wm_pg_shared_lossy:
+                    cell_size: 420
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 50
+                    pkts_num_trig_egr_drp: 226498
+                wm_q_shared_lossless:
+                    cell_size: 420
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 200
+                    pkts_num_trig_ingr_drp: 228610
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 420
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 200
+                    pkts_num_trig_egr_drp: 226498
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 50
+                    pkts_num_trig_ingr_drp: 228610
+                    pkts_num_trig_pfc: 226618
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 50
+                    pkts_num_trig_ingr_drp: 228610
+                    pkts_num_trig_pfc: 226618
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 10
+                    pkts_num_margin: 20
+                    pkts_num_trig_pfc: 226618
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 10
+                    pkts_num_margin: 20
+                    pkts_num_trig_pfc: 226618
+            cell_size: 420
+            hdrm_pool_wm_multiplier: 1
+            wrr:
+                ecn: 1
+                limit: 80
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                q7_num_of_pkts: 140
+            wrr_chg:
+                ecn: 1
+                limit: 80
+                lossless_weight: 30
+                lossy_weight: 8
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                q7_num_of_pkts: 80

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -37,6 +37,7 @@ from tests.common.snappi_tests.qos_fixtures import get_pfcwd_config, reapply_pfc
 from tests.common.snappi_tests.common_helpers import \
         stop_pfcwd, disable_packet_aging, enable_packet_aging
 from tests.common.utilities import is_ipv6_only_topology
+from tests.common.broadcom_data import is_broadcom_device as isBroadcomDevice
 
 
 logger = logging.getLogger(__name__)
@@ -60,8 +61,8 @@ class QosBase:
                           "t1-isolated-d56u1-lag", "t1-isolated-v6-d56u1-lag", "t1-isolated-d128", "t1-isolated-d32",
                           "t1-isolated-d448u15-lag", "t1-isolated-v6-d448u15-lag"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
-    SUPPORTED_ASIC_LIST = ["pac", "gr", "gr2", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "spc5",
-                           "td3", "th3", "j2c+", "jr2", "th5", "q3d"]
+    SUPPORTED_ASIC_LIST = ["pac", "gr", "gr2", "gb", "p200", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "spc5",
+                           "spc6", "td3", "th3", "j2c+", "jr2", "th5", "th6", "q3d"]
 
     BREAKOUT_SKUS = ['Arista-7050-QX-32S']
     LOW_SPEED_PORT_SKUS = ['Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32C-C28S4']
@@ -1062,6 +1063,8 @@ class QosSaiBase(QosBase):
             if isMellanoxDevice(src_dut):
                 # The last port is used for up link from DUT switch
                 testPortIds[src_dut_index][src_asic_index] -= {len(src_mgFacts["minigraph_ptf_indices"]) - 1}
+            if isBroadcomDevice(src_dut):
+                testPortIds[src_dut_index][src_asic_index] = set(dutLagInterfaces)
             testPortIds[src_dut_index][src_asic_index] = sorted(testPortIds[src_dut_index][src_asic_index])
             pytest_require(len(testPortIds[src_dut_index][src_asic_index]) != 0,
                            "Skip test since no ports are available for testing")
@@ -1073,6 +1076,8 @@ class QosSaiBase(QosBase):
             dualTorPortIndexes[src_dut_index][src_asic_index] = []
             if 'backend' in topo:
                 intf_map = src_mgFacts["minigraph_vlan_sub_interfaces"]
+            elif isBroadcomDevice(src_dut):
+                intf_map = src_mgFacts["minigraph_portchannel_interfaces"]
             else:
                 intf_map = src_mgFacts["minigraph_interfaces"]
 
@@ -1081,6 +1086,9 @@ class QosSaiBase(QosBase):
                 intf = portConfig["attachto"].split(".")[0]
                 portIndex = src_mgFacts["minigraph_ptf_indices"][intf]
                 if ipaddress.ip_interface(portConfig['peer_addr']).ip.version == ip_version:
+                    if isBroadcomDevice(src_dut):
+                        if intf in src_mgFacts["minigraph_portchannels"]:
+                            intf = src_mgFacts["minigraph_portchannels"][portConfig["attachto"]]['members'][0]
                     if portIndex in testPortIds[src_dut_index][src_asic_index]:
                         portIpMap = {'peer_addr': portConfig["peer_addr"]}
                         if 'vlan' in portConfig:
@@ -2911,7 +2919,7 @@ class QosSaiBase(QosBase):
             return
 
         if ('platform_asic' in dutTestParams["basicParams"] and
-                dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx"):
+                dutTestParams["basicParams"]["platform_asic"] in ["broadcom-dnx", "broadcom"]):
             dst_dut = get_src_dst_asic_and_duts['dst_dut']
             dst_mgfacts = dst_dut.get_extended_minigraph_facts(tbinfo)
             dst_interfaces = []
@@ -2935,7 +2943,14 @@ class QosSaiBase(QosBase):
                 neighbor_lag_intfs = [vm_neighbors[po_intf]['port'] for po_intf in po_interfaces]
                 neigh_intf = next(iter(po_interfaces.keys()))
                 peer_device = vm_neighbors[neigh_intf]['name']
-                vm_host = nbrhosts[peer_device]['host']
+                peer_info = nbrhosts[peer_device]
+                vm_host = peer_info['host']
+                if peer_info['is_multi_vrf_peer']:
+                    multi_vrf_data = nbrhosts[peer_device]['multi_vrf_data']
+                    orig_port = multi_vrf_data['orig_intf_map'][neighbor_lag_intfs[0]]
+                    logger.info("original port: {}".format(orig_port))
+                    neighbor_lag_intfs = []
+                    neighbor_lag_intfs.append(orig_port)
                 vm_host_neighbor_lag_members[vm_host] = []
                 num = 600
                 for neighbor_lag_member in neighbor_lag_intfs:
@@ -2947,7 +2962,7 @@ class QosSaiBase(QosBase):
 
         yield
         if ('platform_asic' in dutTestParams["basicParams"] and
-                dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx"):
+                dutTestParams["basicParams"]["platform_asic"] in ["broadcom-dnx", "broadcom"]):
             for vm_host, neighbor_lag_intfs in vm_host_neighbor_lag_members.items():
                 for neighbor_lag_member in neighbor_lag_intfs:
                     logger.info(

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1014,6 +1014,10 @@ class TestQosSai(QosSaiBase):
         src_asic_index = get_src_dst_asic_and_duts['src_asic_index']
         dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
 
+        if ('platform_asic' in dutTestParams["basicParams"] and
+                dutTestParams["basicParams"]["platform_asic"] == "broadcom"):
+            pytest.skip("No enough test ports on this DUT")
+
         if dutTestParams["basicParams"].get("platform_asic") == 'broadcom-dnx' \
                 and get_src_dst_asic_and_duts['src_dut'].facts.get('modular_chassis'):
             # for 100G port speed the number of ports required to fill headroom is huge,
@@ -2152,7 +2156,8 @@ class TestQosSai(QosSaiBase):
         skip_test_on_no_lossless_pg(portSpeedCableLength)
         if dutTestParams["basicParams"]["sonic_asic_type"] == 'cisco-8000' or \
                 ('platform_asic' in dutTestParams["basicParams"] and
-                 dutTestParams["basicParams"]["platform_asic"] in ["broadcom-dnx", "mellanox", "marvell-teralynx"]):
+                 dutTestParams["basicParams"]["platform_asic"] in ["broadcom-dnx", "broadcom",
+                                                                   "mellanox", "marvell-teralynx"]):
             disableTest = False
         if disableTest:
             pytest.skip("DSCP to PG mapping test disabled")

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2357,6 +2357,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         pkts_num_egr_mem = None
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
+        else:
+            pkts_num_egr_mem = 0
 
         # generate pkts_num_egr_mem in runtime
         if 'cisco-8000' in asic_type and src_dst_asic_diff:
@@ -2395,6 +2397,12 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
                                                      pkts_num_trig_pfc) // cell_occupancy - 2 - margin)
                 pkt_count = (pkts_num_leak_out +
                              pkts_num_trig_pfc) // cell_occupancy - 2 - margin
+            elif platform_asic and platform_asic == "broadcom":
+                # send packets short of trigger pfc
+                send_packet(self, src_port_id, pkt, (pkts_num_leak_out + pkts_num_egr_mem +
+                                                     pkts_num_trig_pfc) // cell_occupancy - 1 - margin)
+                pkt_count = (pkts_num_leak_out + pkts_num_egr_mem +
+                             pkts_num_trig_pfc) // cell_occupancy - 1 - margin
             else:
                 # send packets short of triggering pfc
                 send_packet(self, src_port_id, pkt, (pkts_num_leak_out +
@@ -2436,7 +2444,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # & may give inconsistent test results
             # Adding COUNTER_MARGIN to provide room to 2 pkt incase, extra traffic received
             for cntr in ingress_counters:
-                margin_asics = ["broadcom-dnx", "marvell-teralynx", "cisco-8000"]
+                margin_asics = ["broadcom-dnx", "marvell-teralynx", "cisco-8000", "broadcom"]
                 counter_margin = COUNTER_MARGIN if (
                     platform_asic and platform_asic in margin_asics) else 0
                 # Check if ingress drop is caused by environmental non-unicast noise
@@ -2445,7 +2453,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
                         recv_counters, recv_counters_base, cntr,
                         counter_margin=counter_margin):
                     # Legitimate ingress drop, should fail test
-                    if platform_asic and platform_asic in ["broadcom-dnx", "marvell-teralynx", "cisco-8000"]:
+                    if platform_asic and platform_asic in ["broadcom-dnx", "marvell-teralynx",
+                                                           "cisco-8000", "broadcom"]:
                         qos_test_assert(
                             self, recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN,
                             'unexpectedly RX drop counter increase, {}'.format(test_stage))
@@ -2489,7 +2498,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # & may give inconsistent test results
             # Adding COUNTER_MARGIN to provide room to 2 pkt incase, extra traffic received
             for cntr in ingress_counters:
-                margin_asics = ["broadcom-dnx", "marvell-teralynx", "cisco-8000"]
+                margin_asics = ["broadcom-dnx", "marvell-teralynx", "cisco-8000", "broadcom"]
                 counter_margin = COUNTER_MARGIN if (
                     platform_asic and platform_asic in margin_asics) else 0
                 # Check if ingress drop is caused by environmental non-unicast noise
@@ -2498,7 +2507,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
                         recv_counters, recv_counters_base, cntr,
                         counter_margin=counter_margin):
                     # Legitimate ingress drop, should fail test
-                    if platform_asic and platform_asic in ["broadcom-dnx", "marvell-teralynx", "cisco-8000"]:
+                    if platform_asic and platform_asic in ["broadcom-dnx", "marvell-teralynx",
+                                                           "cisco-8000", "broadcom"]:
                         qos_test_assert(
                             self, recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN,
                             'unexpectedly RX drop counter increase, {}'.format(test_stage))
@@ -2545,7 +2555,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # & may give inconsistent test results
             # Adding COUNTER_MARGIN to provide room to 2 pkt incase, extra traffic received
             for cntr in ingress_counters:
-                margin_asics = ["broadcom-dnx", "marvell-teralynx", "cisco-8000"]
+                margin_asics = ["broadcom-dnx", "marvell-teralynx", "cisco-8000", "broadcom"]
                 counter_margin = COUNTER_MARGIN if (
                     platform_asic and platform_asic in margin_asics) else 0
                 # Check if ingress drop is caused by environmental non-unicast noise
@@ -2555,7 +2565,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
                         counter_margin=counter_margin):
                     # Legitimate ingress drop, should fail test
                     if (platform_asic and
-                            platform_asic in ["broadcom-dnx", "marvell-teralynx", "cisco-8000"]):
+                            platform_asic in ["broadcom-dnx", "marvell-teralynx", "cisco-8000", "broadcom"]):
                         qos_test_assert(
                             self, recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN,
                             'unexpectedly RX drop counter increase, {}'.format(test_stage))
@@ -2597,7 +2607,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # recv port ingress drop
             if self.hwsku not in ['Cisco-8800-LC-48H-C48']:
                 for cntr in ingress_counters:
-                    if platform_asic and platform_asic == "broadcom-dnx":
+                    if platform_asic and platform_asic == "broadcom-dnx" or "broadcom":
                         if cntr == 1:
                             qos_test_assert(
                                 self, recv_counters[cntr] > recv_counters_base[cntr],
@@ -3237,7 +3247,8 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             if check_leackout_compensation_support(asic_type, hwsku):
                 pkts_num_leak_out = 0
 
-            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' in hwsku:
+            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' \
+                    or 'Nokia-IXR7220-H6' in hwsku:
                 send_packet(
                     self, src_port_id, pkt,
                     (pkts_num_egr_mem + pkts_num_leak_out + pkts_num_trig_pfc -
@@ -3256,7 +3267,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                 send_packet(
                     self, src_port_id, pkt,
                     (pkts_num_leak_out + pkts_num_trig_pfc -
-                        pkts_num_dismiss_pfc - hysteresis) // cell_occupancy - margin
+                     pkts_num_dismiss_pfc - hysteresis) // cell_occupancy - margin
                 )
                 log_message(
                     'send_packet(src_port_id, pkt, ({} + {} - {} - {}) // {})\n'.format(
@@ -3279,7 +3290,8 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_2_counters_base, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_2_id]
             )
-            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' in hwsku:
+            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' \
+                    or 'Nokia-IXR7220-H6' in hwsku:
                 send_packet(
                     self, src_port_id, pkt2,
                     (pkts_num_egr_mem + pkts_num_leak_out + pkts_num_dismiss_pfc +
@@ -3330,7 +3342,8 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             log_message('step {}: {}\n'.format(step_id, step_desc), to_stderr=True)
             xmit_3_counters_base, _ = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_3_id])
-            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' in hwsku:
+            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' \
+                    or 'Nokia-IXR7220-H6' in hwsku:
                 send_packet(self, src_port_id, pkt3,
                             pkts_num_egr_mem + pkts_num_leak_out + 1)
             elif 'cisco-8000' in asic_type:
@@ -3381,7 +3394,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             # Adding COUNTER_MARGIN to provide room to 2 pkt incase, extra traffic received
             for cntr in ingress_counters:
                 margin_asics = [
-                    "broadcom-dnx", "cisco-8000", "marvell-teralynx"]
+                    "broadcom-dnx", "cisco-8000", "marvell-teralynx", "broadcom"]
                 counter_margin = COUNTER_MARGIN if (
                     platform_asic and platform_asic in margin_asics
                 ) else 0
@@ -3392,7 +3405,7 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                         counter_margin=counter_margin):
                     # Legitimate ingress drop, should fail test
                     if (platform_asic and
-                            platform_asic in ["broadcom-dnx", "cisco-8000", "marvell-teralynx"]):
+                            platform_asic in ["broadcom-dnx", "cisco-8000", "marvell-teralynx", "broadcom"]):
                         qos_test_assert(
                             self, recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN,
                             'unexpectedly ingress drop on recv port (counter: {}), at step {} {}'.format(
@@ -3483,10 +3496,16 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             recv_counters, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
 
             for cntr in ingress_counters:
-                qos_test_assert(
-                    self, recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN,
-                    'unexpectedly ingress drop on recv port (counter: {}), at step {} {}'.format(
-                        port_counter_fields[cntr], step_id, step_desc))
+                counter_margin = COUNTER_MARGIN
+                # Check if ingress drop is caused by environmental non-unicast noise
+                if not ignore_ingress_drop_caused_by_nonunicast_noise(
+                        self.src_client, port_list['src'][src_port_id],
+                        recv_counters, recv_counters_base, cntr,
+                        counter_margin=counter_margin):
+                    qos_test_assert(
+                        self, recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN,
+                        'unexpectedly ingress drop on recv port (counter: {}), at step {} {}'.format(
+                            port_counter_fields[cntr], step_id, step_desc))
             recv_counters_base = recv_counters
 
             step_id += 1
@@ -5078,6 +5097,8 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
+        else:
+            pkts_num_egr_mem = 0
 
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
@@ -5097,7 +5118,8 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                         int(self.test_params['pg']), asic_type))
 
             # send packets short of triggering egress drop
-            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' in hwsku:
+            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' in hwsku \
+                    or 'Nokia-IXR7220-H6' in hwsku:
                 # send packets short of triggering egress drop
                 send_packet(self, src_port_id, pkt, pkts_num_egr_mem +
                             pkts_num_leak_out + pkts_num_trig_egr_drp - 1 - margin)
@@ -5149,7 +5171,7 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             # & may give inconsistent test results
             # Adding COUNTER_MARGIN to provide room to 2 pkt incase, extra traffic received
             for cntr in ingress_counters:
-                margin_asics = ["broadcom-dnx", "marvell-teralynx", "cisco-8000"]
+                margin_asics = ["broadcom-dnx", "marvell-teralynx", "cisco-8000", "broadcom"]
                 counter_margin = COUNTER_MARGIN if (
                     platform_asic and platform_asic in margin_asics) else 0
                 # Check if ingress drop is caused by environmental non-unicast noise
@@ -5158,7 +5180,7 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                         recv_counters, recv_counters_base, cntr,
                         counter_margin=counter_margin):
                     if (platform_asic and
-                            platform_asic in ["broadcom-dnx", "marvell-teralynx", "cisco-8000"]):
+                            platform_asic in ["broadcom-dnx", "marvell-teralynx", "cisco-8000", "broadcom"]):
                         if cntr == 1:
                             log_message("recv_counters_base: {}, recv_counters: {}".format(
                                 recv_counters_base[cntr], recv_counters[cntr]), to_stderr=True)
@@ -5209,7 +5231,7 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                     pg, recv_counters[pg], pg, recv_counters_base[pg]))
             # recv port no ingress drop
             for cntr in ingress_counters:
-                if platform_asic and platform_asic == "broadcom-dnx":
+                if platform_asic and platform_asic == "broadcom-dnx" or "broadcom":
                     if cntr == 1:
                         if dut_asic == 'q3d':
                             qos_test_assert(
@@ -5635,7 +5657,7 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
         else:
-            pkts_num_egr_mem = None
+            pkts_num_egr_mem = 0
 
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
         pg_cntrs_base = sai_thrift_read_pg_counters(self.src_client, port_list['src'][src_port_id])
@@ -5671,6 +5693,9 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             elif 'cisco-8000' in asic_type:
                 fill_leakout_plus_one(
                     self, src_port_id, dst_port_id, pkt, pg, asic_type, pkts_num_egr_mem)
+            elif platform_asic and platform_asic == "broadcom":
+                pg_min_pkts_num = pkts_num_leak_out + pkts_num_fill_min + pkts_num_egr_mem
+                send_packet(self, src_port_id, pkt, pg_min_pkts_num)
             else:
                 pg_min_pkts_num = pkts_num_leak_out + pkts_num_fill_min
                 send_packet(self, src_port_id, pkt, pg_min_pkts_num)
@@ -5703,6 +5728,8 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 if platform_asic and platform_asic == "broadcom-dnx":
                     assert (pg_shared_wm_res[pg] <=
                             ((pkts_num_leak_out + pkts_num_fill_min) * (packet_length + internal_hdr_size)))
+                elif platform_asic and platform_asic == "broadcom":
+                    assert (pg_shared_wm_res[pg] <= margin * cell_size)
                 elif 'Arista-7060X6' in hwsku:
                     assert (pg_shared_wm_res[pg] <= margin * cell_size)
                 else:
@@ -5774,6 +5801,14 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                     assert (pg_shared_wm_res[pg] <=
                             ((pkts_num_leak_out + pkts_num_fill_min + expected_wm + margin)
                              * (packet_length + internal_hdr_size)))
+                elif platform_asic and platform_asic == "broadcom":
+                    msg = "lower bound: %d, actual value: %d, upper bound (+%d): %d" % (
+                        expected_wm * cell_size,
+                        pg_shared_wm_res[pg],
+                        margin,
+                        (expected_wm + margin) * cell_size)
+                    assert pg_shared_wm_res[pg] <= (
+                            pkts_num_leak_out + pkts_num_fill_min + expected_wm + margin) * cell_size, msg
                 else:
                     msg = "lower bound (-%d): %d, actual value: %d, upper bound (+%d): %d" % (
                         margin_lower_bound,
@@ -5812,6 +5847,12 @@ class PGSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                     pg_shared_wm_res[pg]), file=sys.stderr)
                 assert (expected_wm * (packet_length + internal_hdr_size) <= (
                         expected_wm + margin + cell_occupancy) * (packet_length + internal_hdr_size))
+            elif platform_asic and platform_asic == "broadcom":
+                print("exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (
+                    pkts_num, ((expected_wm + cell_occupancy) * cell_size),
+                    pg_shared_wm_res[pg]), file=sys.stderr)
+                assert (expected_wm * cell_size <= (
+                        expected_wm + margin + cell_occupancy) * cell_size)
             else:
                 print("exceeded pkts num sent: %d, expected watermark: %d, actual value: %d" % (
                     pkts_num, ((expected_wm + cell_occupancy) * cell_size), pg_shared_wm_res[pg]), file=sys.stderr)
@@ -5894,6 +5935,8 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
+        else:
+            pkts_num_egr_mem = 0
 
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
@@ -5907,7 +5950,8 @@ class PGHeadroomWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 pkts_num_leak_out = 0
 
             # send packets to trigger pfc but not trek into headroom
-            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' in hwsku:
+            if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' in hwsku \
+                    or 'Nokia-IXR7220-H6' in hwsku:
                 send_packet(self, src_port_id, pkt, (pkts_num_egr_mem +
                                                      pkts_num_leak_out + pkts_num_trig_pfc) // cell_occupancy - margin)
             elif 'cisco-8000' in asic_type:
@@ -6278,6 +6322,8 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
         # For TH3, some packets stay in egress memory and doesn't show up in shared buffer or leakout
         if 'pkts_num_egr_mem' in list(self.test_params.keys()):
             pkts_num_egr_mem = int(self.test_params['pkts_num_egr_mem'])
+        else:
+            pkts_num_egr_mem = 0
 
         recv_counters_base, _ = sai_thrift_read_port_counters(self.src_client, asic_type, port_list['src'][src_port_id])
         xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
@@ -6308,7 +6354,8 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             # so if queue min is zero, it will directly trek into shared pool by 1
             # TH2 uses scheduler-based TX enable, this does not require sending packets
             # to leak out
-            if hwsku in ('DellEMC-Z9332f-O32', 'DellEMC-Z9332f-M-O16C64') or 'Arista-7060X6' in hwsku:
+            if hwsku in ('DellEMC-Z9332f-O32', 'DellEMC-Z9332f-M-O16C64') or 'Arista-7060X6' in hwsku \
+                    or 'Nokia-IXR7220-H6' in hwsku:
                 que_min_pkts_num = pkts_num_egr_mem + pkts_num_leak_out + pkts_num_fill_min
                 send_packet(self, src_port_id, pkt, que_min_pkts_num)
             else:
@@ -6350,6 +6397,8 @@ class QSharedWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                 if platform_asic and platform_asic == "broadcom-dnx":
                     logging.info("On J2C+ don't support SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES " +
                                  "stat - so ignoring this step for now")
+                elif platform_asic and platform_asic == "broadcom":
+                    assert (q_wm_res[queue] <= (margin + 1) * cell_size)
                 else:
                     assert (q_wm_res[queue] <= 1 * cell_size)
 


### PR DESCRIPTION
…latform (#24668)

This PR includes:
-Qos yaml file updated with qos params for th6 -lt2 topo supporting buffer profiles (400000_30m &400000_500m)
-Sonic-mgmt qos test update to include Tomahawk6