### PR TITLE
syslog: accept standard rsyslogd rate-limit message in test_syslog_rate_limit (#25494)

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -21,8 +21,13 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 LOCAL_LOG_GENERATOR_FILE = os.path.join(BASE_DIR, 'log_generator.py')
 REMOTE_LOG_GENERATOR_FILE = os.path.join('/tmp', 'log_generator.py')
 DOCKER_LOG_GENERATOR_FILE = '/log_generator.py'
-# rsyslogd prints this log when rate-limiting reached
-LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = '.*rate-limit-test>: begin to drop messages due to rate-limiting.*'
+# rsyslogd emits one of two messages depending on version when rate-limiting kicks in:
+#   - "begin to drop messages due to rate-limiting"  (logged when drops start)
+#   - "N messages lost due to rate-limiting (M allowed within K seconds)"  (logged as summary)
+# Both indicate that rate limiting is working. The exact form and frequency are
+# rsyslogd-version-dependent, so only a presence check is performed (not an exact count).
+LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = \
+    r'.*rate-limit-test>: (?:begin to drop messages|messages lost) due to rate-limiting.*'
 # Log pattern for tests/syslog/log_generator.py
 LOG_EXPECT_LAST_MESSAGE = '.*{}rate-limit-test: This is a test log:.*'
 
@@ -158,9 +163,9 @@ def verify_container_rate_limit(rand_selected_dut, ignore_containers=[]):
                                              'syslog_rate_limit_{}-interval_{}_burst_{}'.format(service_name,
                                                                                                 RATE_LIMIT_INTERVAL,
                                                                                                 RATE_LIMIT_BURST),
-                                             [LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED,
-                                              LOG_EXPECT_LAST_MESSAGE.format(container_name + '#')],
-                                             RATE_LIMIT_BURST + 1)
+                                             [LOG_EXPECT_LAST_MESSAGE.format(container_name + '#')],
+                                             RATE_LIMIT_BURST,
+                                             presence_log_regex=[LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED])
 
         rsyslog_pid = get_rsyslogd_pid(rand_selected_dut, container_name)
         rand_selected_dut.command('config syslog rate-limit-container {} -b {} -i {}'.format(service_name, 0, 0))
@@ -206,8 +211,9 @@ def verify_host_rate_limit(rand_selected_dut):
                                          'host',
                                          'syslog_rate_limit_host_interval_{}_burst_{}'.format(RATE_LIMIT_INTERVAL,
                                                                                               RATE_LIMIT_BURST),
-                                         [LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED, LOG_EXPECT_LAST_MESSAGE.format('')],
-                                         RATE_LIMIT_BURST + 1,
+                                         [LOG_EXPECT_LAST_MESSAGE.format('')],
+                                         RATE_LIMIT_BURST,
+                                         presence_log_regex=[LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED],
                                          is_host=True)
 
     with expect_host_rsyslog_restart(rand_selected_dut):
@@ -240,20 +246,33 @@ def verify_config_rate_limit_fail(duthost, service_name):
 
 
 def verify_rate_limit_with_log_generator(duthost, service_name, log_marker, expect_log_regex, expect_log_matches,
-                                         is_host=False):
+                                         presence_log_regex=None, is_host=False):
     """Generator syslog with a script and verify that syslog rate limit reached
 
     Args:
         duthost (object): DUT host object
         service_name (str): Service name
         log_marker (str): Log start marker
-        expect_log_regex (list): A list of expected log message regular expression
-        expect_log_matches (int): Number of log lines matches the expect_log_regex
+        expect_log_regex (list): A list of expected log message regular expressions; the total
+            number of matching lines must equal expect_log_matches.
+        expect_log_matches (int): Exact number of log lines expected to match expect_log_regex.
+            Set to 0 to skip the exact count check (only verifies at least one match).
+        presence_log_regex (list, optional): Patterns that must appear at least once in the
+            log window.  Verified via a separate LogAnalyzer pass so their (variable) count
+            does not skew the expect_log_matches tally.  Defaults to None.
         is_host (bool, optional): Verify on host side or container side. Defaults to False.
     """
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=log_marker)
     loganalyzer.expect_regex = expect_log_regex
     loganalyzer.expected_matches_target = expect_log_matches
+
+    # Initialise the presence-check analyzer before entering the window so both
+    # analyzers capture the same log section.
+    if presence_log_regex:
+        presence_analyzer = LogAnalyzer(ansible_host=duthost,
+                                        marker_prefix=log_marker + '_presence')
+        presence_analyzer.expect_regex = presence_log_regex
+        presence_marker = presence_analyzer.init()
 
     if is_host:
         run_generator_cmd = "python3 {}".format(REMOTE_LOG_GENERATOR_FILE)
@@ -266,6 +285,9 @@ def verify_rate_limit_with_log_generator(duthost, service_name, log_marker, expe
         # to the host syslog. Without this, the notification may arrive after the
         # LogAnalyzer end marker, causing intermittent test failures.
         time.sleep(5)
+
+    if presence_log_regex:
+        presence_analyzer.analyze(presence_marker)
 
 
 def get_host_rsyslogd_pid(duthost):


### PR DESCRIPTION
### Description of PR
Summary:
Cherry-pick of sonic-net/sonic-mgmt#25494 to Azure/sonic-mgmt.msft:202512.

Fixes `test_syslog_rate_limit` failure on platforms where rsyslogd emits a different rate-limit message.

rsyslogd emits two different messages depending on version when rate-limiting triggers:
- `"begin to drop messages due to rate-limiting"` — logged when drops **start** (transition 0→1)
- `"N messages lost due to rate-limiting (M allowed within K seconds)"` — logged as a **summary** when the rate-limit window ends

Both are standard rsyslogd messages from `ratelimit.c`. The test only matched the first form, so it failed on rsyslogd versions that emit the summary form instead.

**Note on adaptation:** This branch does not yet have upstream PR #24239 (STP container `additional_files` handling) or #25424 (wait-for-forwarded-logs refactor), so this cherry-pick was manually adapted to avoid pulling in unrelated changes from those PRs. The regex fix keeps the existing `rate-limit-test>:` tag prefix used on this branch, and the existing `time.sleep(5)`-based wait is preserved. An earlier, simpler attempt at this same fix (#1247) was reverted (#1249) because it broke the exact-match-count assertion; this version avoids that by checking the rate-limit notification via a separate `presence_log_regex` pass (presence-only, not counted), same as the upstream fix.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512

### Approach
#### What is the motivation for this PR?
Fix flaky/failing `test_syslog_rate_limit` on platforms whose rsyslogd emits the summary-form rate-limit message instead of the "begin to drop" message.

#### How did you do it?
Cherry-picked sonic-net/sonic-mgmt#25494 (commit ad3e8e0), resolving conflicts by adapting the fix to this branch's existing code structure (no `additional_files`/STP handling, no `_wait_expected_logs_forwarded`), while preserving the core fix: regex alternation + separate presence-only check for the rate-limit notification.

#### How did you verify/test it?
Verified the resolved file has no leftover conflict markers, passes `python3 -m py_compile` / AST parse, and passes `flake8 --max-line-length=120`.

#### Any platform specific information?
Generic — affects any testbed running an rsyslogd version that emits the summary form of the rate-limit message.

#### Supported testbed topology if it's a new test case?
N/A — existing test case, topology unchanged.

### Documentation
N/A
