### PR TITLE
ci: disable KVM PR tests on 202506, keep pre-test checks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,8 @@ stages:
 
 - stage: Test
   dependsOn: Pre_test
-  condition: and(succeeded(), not(canceled()), in(dependencies.Pre_test.result, 'Succeeded'))
+  # KVM/Elastictest PR tests disabled on 202506; Pre_test checks still run.
+  condition: false
   variables:
   - group: SONiC-Elastictest
   - name: inventory


### PR DESCRIPTION
Set the Elastictest KVM `Test` stage `condition: false` so PRs targeting 202506 no longer run the impacted-area KVM tests, while the `Pre_test` stage (pre-commit and test-case validation) still runs. 