### PR TITLE
[action] [PR:25946] Skip test_snmp_queue_counter on C0 topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4642,10 +4642,10 @@ snmp/test_snmp_queue.py:
 snmp/test_snmp_queue_counters.py:
   skip:
     conditions_logical_operator: OR
-    reason: "Have an known issue on kvm testbed / Unsupported in M* topos"
+    reason: "Have an known issue on kvm testbed / Unsupported in M* and C0 topos"
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/14007"
-      - "topo_type in ['m0', 'mx', 'm1']"
+      - "topo_type in ['m0', 'mx', 'm1', 'c0']"
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md
-->
### Description of PR

Cherry-pick of upstream [sonic-net/sonic-mgmt#25946](https://github.com/sonic-net/sonic-mgmt/pull/25946) to `202603`.

Summary: Skip `tests/snmp/test_snmp_queue_counters.py` on `c0` topo. This feature is not required on C0.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: N/A

### Approach
#### What is the motivation for this PR?

`test_snmp_queue_counters.py` is not a required feature on C0 topology. Add `c0` to the `topo_type` skip list in `tests_mark_conditions.yaml`.

#### How did you do it?

Extended the existing skip condition for `snmp/test_snmp_queue_counters.py`:

- `topo_type in ['m0', 'mx', 'm1']` → `topo_type in ['m0', 'mx', 'm1', 'c0']`
- Updated the accompanying `reason` string to mention C0.

#### How did you verify/test it?

Change is confined to conditional-mark yaml; no runtime code change. The upstream PR was merged to `sonic-net/sonic-mgmt:master` after review.

#### Any platform specific information?

None — topology-based skip.

#### Supported testbed topology if it's a new test case?

N/A (existing test).

### Cherry-pick notes

Upstream cherry-pick to `msft-202603` conflicted (label `Cherry Pick Conflict_msft-202603` was applied on the upstream PR). Root cause: `master` already contains an unrelated Mellanox `#17929` skip condition for the same test that hasn't been ported to `202603`. This cherry-pick keeps only the PR 25946 intent (adding `c0` to the skip list) and does **not** pull in the unrelated Mellanox condition.

Original commit: `707d11172fc79c58ffb72d0beec83afa02bbaae0`

### Documentation

N/A.
