### PR TITLE
[TH6-128] Increase announce routes networks for lt2-o256-u32d224 topo

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1507,17 +1507,20 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes=None):
     group_nums = int(math.ceil(float(len(t1_vms)) / T1_GROUP_SIZE))
     t1_route_per_group = int(math.ceil(ROUTE_NUMBER_T1 / T1_GROUP_SIZE / group_nums))
 
-    # 32 routes each x 8 to support up to 256 T1 VMs
-    extra_ipv4_t1 = itertools.chain(
-        ipaddress.ip_network("192.168.0.0/27"),
-        ipaddress.ip_network("192.169.0.0/27"),
-        ipaddress.ip_network("192.170.0.0/27"),
-        ipaddress.ip_network("192.171.0.0/27"),
-        ipaddress.ip_network("192.172.0.0/27"),
-        ipaddress.ip_network("192.173.0.0/27"),
-        ipaddress.ip_network("192.174.0.0/27"),
-        ipaddress.ip_network("192.175.0.0/27"),
+    # 32 addresses per /27; need ceil(len(t1_vms)/32) blocks (min 4).
+    # 224 T1 (needs 7); build enough 192.(168+i).0.0/27 nets.
+    num_extra = max(4, int(math.ceil(float(len(t1_vms)) / 32)))
+    # Second octet 168+i must stay <= 255, so i <= 87 and num_extra <= 88 (~2816 T1 VMs).
+    assert num_extra <= 88, (
+        "fib_lt2_routes: num_extra={} ({} T1 VMs) exceeds scheme limit 88 for 192.(168+i).0.0/27"
+        .format(num_extra, len(t1_vms))
     )
+    extra_networks = []
+    for i in range(num_extra):
+        extra_networks.append(
+            ipaddress.ip_network(UNICODE_TYPE("192.{}.0.0/27".format(168 + i)))
+        )
+    extra_ipv4_t1 = itertools.chain(*extra_networks)
 
     for group in range(group_nums):
         selected_v4_subnets = all_subnetv4[group * t1_route_per_group: group * t1_route_per_group + t1_route_per_group]


### PR DESCRIPTION
### Description of PR

Cherry-pick of sonic-net/sonic-mgmt#24665 to 202512, per @bingwang-ms's note that sonic-mgmt 202512 backports land in this repo. Original author: @sanjair-git.

- Fixes the *Announce routes* task failure during add-topo for LT2 DUTs with more T1 VMs.
- *lt2-o256-u32d224* has 224 T1 VMs; the current code supports only 110.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Approach

Cherry-picked sonic-net/sonic-mgmt#24665. It applied cleanly on 202512 — the existing 8-network hardcode (192.168-192.175.0.0/27) matches the source PR's base — so the result is the dynamic scheme it introduced: `num_extra = max(4, ceil(len(t1_vms) / 32))` building `192.(168+i).0.0/27`, matching current master. Backward-compatible: any topo with <=128 T1 VMs yields the same blocks as before; it expands (7 blocks for the 224-T1 topo) only where more networks are needed.

Verified the resulting `fib_lt2_routes` matches master's post-#24665 shape and that the module compiles; relying on 202512 CI for the functional run.
