### PR TITLE
[code sync] Merge code from sonic-net/sonic-mgmt:202511 to 202603

### DIFF
--- a/.azure-pipelines/cancel-previous-elastictest-testplan.yml
+++ b/.azure-pipelines/cancel-previous-elastictest-testplan.yml
@@ -75,7 +75,7 @@ steps:
       set -e
       echo "Step: cancel previous testplans for PR"
 
-      pip install PyYAML
+      sudo uv pip install --system PyYAML
 
       rm -f new_test_plan_id.txt
 

--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -66,8 +66,7 @@ steps:
 - script: |
     set -x
 
-    pip install azure-kusto-data
-    pip install azure-kusto-data azure-identity
+    sudo uv pip install --system azure-kusto-data azure-identity
 
     INSTANCE_NUMBER=$(python ./.azure-pipelines/impacted_area_testing/calculate_instance_number.py --scripts $(SCRIPTS) --topology ${{ parameters.TOPOLOGY }} --branch ${{ parameters.BUILD_BRANCH }} --prepare_time ${{ parameters.PREPARE_TIME }} --target_pr_test_time $(TARGET_PR_TEST_TIME))
 

--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -61,8 +61,7 @@ steps:
       echo "##vso[task.setvariable variable=TEST_SCRIPTS;isOutput=true]$TEST_SCRIPTS"
       exit 0
     fi
-    pip install PyYAML
-    pip install natsort
+    sudo uv pip install --system PyYAML natsort
 
     FINAL_FEATURES=""
     IFS=' ' read -ra FEATURES_LIST <<< "$(DIFF_FOLDERS)"

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -70,6 +70,10 @@ parameters:
   type: string
   default: $(BUILD_BRANCH)
 
+- name: KVM_BUILD_ID
+  type: string
+  default: ""
+
 jobs:
   - job: get_impacted_area
     displayName: "Get impacted area"
@@ -133,6 +137,7 @@ jobs:
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
           KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+          KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
           MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
           COMMON_EXTRA_PARAMS: "--disable_sai_validation "
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
@@ -218,6 +223,7 @@ jobs:
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
           KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+          KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
           MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
           COMMON_EXTRA_PARAMS: "--disable_sai_validation "
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
@@ -440,6 +446,7 @@ jobs:
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
           KVM_IMAGE_BRANCH: ${{ parameters.KVM_IMAGE_BRANCH }}
+          KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
           MGMT_BRANCH: ${{ parameters.MGMT_BRANCH }}
           COMMON_EXTRA_PARAMS: "--disable_sai_validation "
           ${{ each param in parameters.OVERRIDE_PARAMS }}:

--- a/.azure-pipelines/pre_defined_pr_test.yml
+++ b/.azure-pipelines/pre_defined_pr_test.yml
@@ -34,6 +34,10 @@ parameters:
   type: object
   default: {}
 
+- name: KVM_BUILD_ID
+  type: string
+  default: ""
+
 stages:
 - stage: Test
   variables:
@@ -54,3 +58,4 @@ stages:
         TEST_PLAN_STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
         IMPACT_AREA_INFO: ${{ parameters.IMPACT_AREA_INFO }}
+        KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -270,8 +270,7 @@ steps:
       set -e
       echo "Step: Trigger Test"
 
-
-      pip install PyYAML
+      sudo uv pip install --system PyYAML
 
       rm -f new_test_plan_id.txt
 

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -192,6 +192,10 @@ parameters:
     type: string
     default: ""
 
+  - name: KVM_BUILD_ID
+    type: string
+    default: ""
+
   - name: EXPECTED_RESULT
     type: string
     default: ""
@@ -284,8 +288,8 @@ steps:
       --max-worker ${{ parameters.MAX_WORKER }} \
       --lock-wait-timeout-seconds ${{ parameters.LOCK_WAIT_TIMEOUT_SECONDS }} \
       --test-set ${{ parameters.TEST_SET }} \
-      --kvm-build-id $(KVM_BUILD_ID) \
-      --kvm-image-branch "${{ parameters.KVM_IMAGE_BRANCH }}" \
+      --kvm-build-id ${{ parameters.KVM_BUILD_ID }} \
+      --kvm-image-branch ${{ parameters.KVM_IMAGE_BRANCH }} \
       --setup-container-params "${{ parameters.SETUP_CONTAINER_PARAMS }}" \
       --kvm-image-build-pipeline-id ${{ parameters.KVM_IMAGE_BUILD_PIPELINE_ID }} \
       --skip-remove-add-topo-for-nightly ${{ parameters.SKIP_REMOVE_ADD_TOPO_FOR_NIGHTLY }} \

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -331,6 +331,9 @@ class TestPlanManager(object):
         if BUILDIMAGE_REPO_FLAG in kwargs.get("source_repo"):
             kvm_image_build_id = build_id
             kvm_image_branch = ""
+        # kvm_image_build_id and kvm_image_branch are mutually exclusive; build id takes precedence
+        if kvm_image_build_id:
+            kvm_image_branch = ""
         affinity = json.loads(kwargs.get("affinity", "[]"))
         payload = {
             "name": test_plan_name,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: check-ast
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
         args: ["--max-line-length=120"]

--- a/ansible/module_utils/debug_utils.py
+++ b/ansible/module_utils/debug_utils.py
@@ -1,7 +1,7 @@
 import os
 import re
 import logging
-from ansible.module_utils.basic import datetime
+import datetime
 
 MAX_LOG_FILES_PER_MODULE = 10
 

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -401,7 +401,6 @@ class HashTest(BaseTest):
         '''
         @summary: Check IPv4 route works.
         '''
-        class_name = self.__class__.__name__
         ip_src = self.src_ip_interval.get_random_ip(
         ) if hash_key == 'src-ip' else self.src_ip_interval.get_first_ip()
         ip_dst = self.dst_ip_interval.get_random_ip(
@@ -450,7 +449,7 @@ class HashTest(BaseTest):
             ip_dst=ip_dst,
             ip_proto=ip_proto
         )
-        if class_name == 'HashTest':
+        if isinstance(self, HashTest):
             rcvd_port, rcvd_pkt = retry_call(
                 self.send_and_verify_packets,
                 fargs=[src_port, pkt, masked_exp_pkt, dst_port_lists, logs],
@@ -465,7 +464,6 @@ class HashTest(BaseTest):
         '''
         @summary: Check IPv6 route works.
         '''
-        class_name = self.__class__.__name__
         ip_src = self.src_ip_interval.get_random_ip(
         ) if hash_key == 'src-ip' else self.src_ip_interval.get_first_ip()
         ip_dst = self.dst_ip_interval.get_random_ip(
@@ -516,7 +514,7 @@ class HashTest(BaseTest):
             ip_proto=ip_proto,
             version='IPv6'
         )
-        if class_name == 'HashTest':
+        if isinstance(self, HashTest):
             rcvd_port, rcvd_pkt = retry_call(
                 self.send_and_verify_packets,
                 fargs=[src_port, pkt, masked_exp_pkt, dst_port_lists, logs],

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -200,12 +200,26 @@ class AnsibleLogAnalyzer:
         '''
         @summary: Place marker into '/dev/log'.
         @param marker: Marker to be placed into syslog.
+
+        Flush rsyslog's internal queues *before* writing the marker so that
+        the reload (which briefly closes and reopens log files) does not race
+        with the marker message sitting in rsyslog's buffer.  After the marker
+        is sent we only need a short sleep for rsyslog to write it out under
+        normal (non-reload) conditions.
         '''
+
+        # Flush any previously buffered messages first, so the reload
+        # does not interfere with the marker we are about to write.
+        self.flush_rsyslogd()
 
         syslogger = self.init_sys_logger()
         syslogger.info(marker)
         syslogger.info('\n')
-        self.flush_rsyslogd()
+
+        # Give rsyslog time to write the marker to disk.
+        # Do NOT call flush_rsyslogd() here — a reload right after writing
+        # can cause the marker message to be dropped (see #23562).
+        time.sleep(2)
 
     def wait_for_marker(self, marker, timeout=120, polling_interval=10):
         '''

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -234,7 +234,7 @@ r, ". *ERR swss#orchagent.*Failed to get port by bridge port ID.*"
 # https://github.com/Azure/sonic-sairedis/issues/582
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_PORT_ATTR_ISOLATION_GROUP"
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_ATTR_UNKNOWN_UNICAST_FLOOD_GROUP"
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_ATTR_UNKNOWN_MULTICAST_FLOOD_GROUP
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_ATTR_UNKNOWN_MULTICAST_FLOOD_GROUP"
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_ATTR_BROADCAST_FLOOD_GROUP"
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- get_dispatch_attribs_handler: Failed getting attrib SAI_BRIDGE_PORT_ATTR_PORT_ID"
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- sai_get_attributes: Failed attribs dispatch"
@@ -353,7 +353,8 @@ r, ".* ERR ntpd\[\d*\]: nss_tacplus: .*"
 r, ".* ERR chronyd\[\d*\]: nss_tacplus: .*"
 
 # ignore iptable nss_tacplus error, some change iptable operations may temporarily disrupt the DUT-to-PTF network connection, which triggers the error. It is safe to ignore this message during such transitions.
-r, ".* ERR iptables: nss_tacplus: failed to connect TACACS+ server .*"
+r, ".* ERR iptables: nss_tacplus: failed to connect TACACS\+ server .*"
+r, ".* ERR iptables: tac_connect_single: connection to .* failed: Network is unreachable.*"
 
 # ignore leap second file NTP daemon (ntpd) is using has passed its expiration date
 r, ".* ERR ntpd\[\d*\]:.*leapsecond file \('/usr/share/zoneinfo/leap-seconds\.list'\): expired.*"

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -242,12 +242,12 @@ r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- sai_get_attribu
 r, ".* ERR syncd#SDK: \[SAI_BRIDGE.ERR\].*mlnx_sai_bridge.c\[\d+\]- mlnx_bridge_port_isolation_group_get: Isolation group is only supported for bridge port type port"
 r, ".* ERR syncd#SDK: \[SAI_BRIDGE.ERR\].*mlnx_sai_bridge.c\[\d+\]- mlnx_bridge_1d_oid_to_data: Unexpected bridge type 0 is not 1D"
 r, ".* ERR syncd#SDK: \[SAI_BRIDGE.ERR\].*mlnx_sai_bridge.c\[\d+\]- mlnx_bridge_port_lag_or_port_get: Invalid port type - 2"
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- sai_get_attributes: Failed to get attribute*."
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, PORT_ID, key:BRIDGE_PORT \[OID:.*\] \[bridge_ports_db.*"
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, ISOLATION_GROUP, key:BRIDGE_PORT \[OID:.*\] \[bridge_ports_db.*"
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, UNKNOWN_UNICAST_FLOOD_GROUP, key:BRIDGE \[OID:.*\] \[Type:.* sx_bridge_id.*"
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, UNKNOWN_MULTICAST_FLOOD_GROUP, key:BRIDGE \[OID:.*Type:.*sx_bridge_id.*"
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, BROADCAST_FLOOD_GROUP, key:BRIDGE \[OID:.*Type:.*sx_bridge_id.*"
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- sai_get_attributes: Failed to get attribute*."
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, PORT_ID, key:BRIDGE_PORT \[OID:.*\] \[bridge_ports_db.*"
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, ISOLATION_GROUP, key:BRIDGE_PORT \[OID:.*\] \[bridge_ports_db.*"
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, UNKNOWN_UNICAST_FLOOD_GROUP, key:BRIDGE \[OID:.*\] \[Type:.* sx_bridge_id.*"
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, UNKNOWN_MULTICAST_FLOOD_GROUP, key:BRIDGE \[OID:.*Type:.*sx_bridge_id.*"
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, BROADCAST_FLOOD_GROUP, key:BRIDGE \[OID:.*Type:.*sx_bridge_id.*"
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*get_dispatch_attribs_handler:.*(INGRESS_SAMPLE_MIRROR_SESSION|EGRESS_SAMPLE_MIRROR_SESSION).*"
 
 # https://github.com/sonic-net/sonic-buildimage/issues/27327

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,8 @@ stages:
     displayName: "Static Analysis"
     timeoutInMinutes: 10
     continueOnError: false
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
     - template: .azure-pipelines/pre-commit-check.yml
 
@@ -55,7 +56,8 @@ stages:
     displayName: "Validate Test Cases"
     timeoutInMinutes: 30
     continueOnError: false
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
     - template: .azure-pipelines/pytest-collect-only.yml
       parameters:
@@ -64,21 +66,24 @@ stages:
   - job: dependency_check
     displayName: "Dependency Check"
     timeoutInMinutes: 10
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
       - template: .azure-pipelines/dependency-check.yml
 
   - job: markers_check
     displayName: "Markers Check"
     timeoutInMinutes: 10
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
       - template: .azure-pipelines/markers-check.yml
 
   - job: meta_check
     displayName: "Meta check"
     timeoutInMinutes: 10
-    pool: sonic-ubuntu-1c
+    pool:
+      vmImage: ubuntu-latest
     steps:
       - template: .azure-pipelines/meta-check.yml
 

--- a/tests/common/devices/arista.py
+++ b/tests/common/devices/arista.py
@@ -101,7 +101,7 @@ class AristaHost(AnsibleHostBase):
             else:
                 command = "show lldp neighbors | json"
             output = self.commands(commands=[command])
-            return output["stdout_lines"][0] if output["failed"] is False else False
+            return output["stdout_lines"][0] if output.get("failed", False) is False else False
         except Exception as e:
             logger.error("command {} failed. exception: {}".format(command, repr(e)))
             return False
@@ -228,7 +228,7 @@ class AristaHost(AnsibleHostBase):
             logger.info("Gathering LLDP details")
             command = "show lldp neighbors | json"
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 for row in json_output["stdout_lines"][0]["lldpNeighbors"]:
                     lldp_details.update(
                         {
@@ -262,7 +262,7 @@ class AristaHost(AnsibleHostBase):
         command = "show lldp neighbors {} detail | json".format(physical_port)
         try:
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout_lines"][0]
             return "Failed to get lldp neighbor details due to {}".format(json_output)
         except Exception as e:
@@ -276,7 +276,7 @@ class AristaHost(AnsibleHostBase):
         try:
             command = "show lldp local-info | json"
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout_lines"][0]["chassisId"]
             return "Failed to get chassis id due to {}".format(json_output)
         except Exception as e:
@@ -289,7 +289,7 @@ class AristaHost(AnsibleHostBase):
         try:
             command = "show lldp local-info | json"
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout_lines"][0]["managementAddresses"][0]["address"]
             return "Failed to get mgmt IP due to {}".format(json_output)
         except Exception as e:
@@ -302,7 +302,7 @@ class AristaHost(AnsibleHostBase):
         try:
             command = "show version | json"
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout_lines"][0]["modelName"]
             return "Failed to get platform info due to {}".format(json_output)
         except Exception as e:
@@ -315,7 +315,7 @@ class AristaHost(AnsibleHostBase):
         try:
             command = "show version | json"
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout_lines"][0]["version"]
             return "Failed to get platform info due to {}".format(json_output)
         except Exception as e:
@@ -440,7 +440,7 @@ class AristaHost(AnsibleHostBase):
             pc_on = pc_name.replace("Port-Channel", "")
             command = "show lacp {} aggregates | json".format(pc_on)
             json_output = self.commands(commands=[command])
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout_lines"][0]["portChannels"][pc_name]["bundledPorts"]
             return "Failed to get interfaces in port chancel due to {}".format(json_output)
         except Exception as e:
@@ -460,7 +460,7 @@ class AristaHost(AnsibleHostBase):
         try:
             success_criteria = "line protocol is up"
             intf_status_output = self.commands(commands=[command])
-            if not intf_status_output["failed"]:
+            if not intf_status_output.get("failed", False):
                 logger.info("Interface status check: {} sent to {}".format(command, self.hostname))
                 is_up = success_criteria in intf_status_output["stdout"][0].lower()
                 return is_up, intf_status_output["stdout_lines"][0]
@@ -475,7 +475,7 @@ class AristaHost(AnsibleHostBase):
             logger.info("Gathering ISIS adjacency details")
             command = "show isis neighbors| json"
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 isis_instances = output["stdout"][0]["vrfs"]["default"]["isisInstances"].keys()
                 for instance in isis_instances:
                     for key, line in output["stdout"][0]["vrfs"]["default"]["isisInstances"][instance][
@@ -515,7 +515,7 @@ class AristaHost(AnsibleHostBase):
             command = "show isis database"
             output = self.commands(commands=[command])
             lsp_entries = {}
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "00-0" in line:
                         outline = line.strip().split()
@@ -540,7 +540,7 @@ class AristaHost(AnsibleHostBase):
         try:
             output = self.commands(commands=[command])
             bgp_status = {}
-            if not output["failed"]:
+            if not output.get("failed", False):
                 bgp_peer_info = output["stdout"][0]["vrfs"]["default"]["peers"]
                 for peer_ip, peer_info in bgp_peer_info.items():
                     bgp_status[peer_ip] = peer_info["peerState"]
@@ -569,7 +569,7 @@ class AristaHost(AnsibleHostBase):
         """
         try:
             bgp_peer_details = self.get_bgp_session_details(peer_ip)
-            if not bgp_peer_details["failed"]:
+            if not bgp_peer_details.get("failed", False):
                 bgp_session_status = bgp_peer_details["stdout"][0]["vrfs"]["default"]["peerList"][0]["state"]
 
             else:
@@ -588,7 +588,7 @@ class AristaHost(AnsibleHostBase):
         try:
             json_output = self.commands(commands=[command])
             prefix_adv_status = False
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 bgp_route_entries = json_output["stdout"][0]["vrfs"]["default"]["bgpRouteEntries"]
                 if len(bgp_route_entries) > 0 and prefix in bgp_route_entries:
                     prefix_adv_status = True
@@ -611,7 +611,7 @@ class AristaHost(AnsibleHostBase):
             command = "show mpls ldp neighbor summary | json"
             json_output = self.commands(commands=[command])
             ldp_op_list = []
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 for neighbor in json_output["stdout"][0]["vrfs"]["default"]["neighbors"]:
                     if "state" in neighbor and neighbor["state"] == "stateOperational":
                         ldp_op_list.append(neighbor["tcpPeerIp"]["ip"])
@@ -637,7 +637,7 @@ class AristaHost(AnsibleHostBase):
             for ldpneighbor in ldp_op_list:
                 command = "show ip route {}".format(ldpneighbor)
                 output = self.commands(commands=[command])
-                if not output["failed"]:
+                if not output.get("failed", False):
                     for line in output["stdout_lines"][0]:
                         if "Port-Channel" in line:
                             ldp_int_list.append(line.split(",")[1].strip())
@@ -751,7 +751,7 @@ class AristaHost(AnsibleHostBase):
             commands = ["mka session rekey-period {}".format(rekey_period_value)]
             parents = ["mac security", "profile {}".format(profile_name)]
             output = self.config(lines=commands, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to set rekey period due to {}".format(output)
         except Exception as e:
@@ -768,7 +768,7 @@ class AristaHost(AnsibleHostBase):
             """example of output:
             mac security profile macsec-profile-juniper-256-64CKN-64CAK-fallback
             """
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output["stdout_lines"][0][-1].split()[-1]
             return False, "Failed to get macsec profile due to {}".format(output)
         except Exception as e:
@@ -788,7 +788,7 @@ class AristaHost(AnsibleHostBase):
                 return True, "Device {} not support {} log".format(self.hostname, log_type)
             command = "show logging all | grep MKA | grep {} | grep {}".format(interface, log_type)
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return len(output["stdout_lines"][0]) > 0, output["stdout"][0]
             return False, "Failed to get macsec status logs due to {}".format(output)
         except Exception as e:
@@ -848,7 +848,7 @@ class AristaHost(AnsibleHostBase):
             """example of output:
             mac security profile macsec-profile-juniper-256-64CKN-64CAK-fallback
             """
-            if not output["failed"]:
+            if not output.get("failed", False):
                 # Returning only MACSEC config.
                 for config in output["stdout_lines"][0]:
                     if "security" in config:
@@ -873,7 +873,7 @@ class AristaHost(AnsibleHostBase):
                     list_command.append(line[1])
             if len(list_command) > 0:
                 output = self.config(lines=commands, parents=parents)
-                if not output["failed"]:
+                if not output.get("failed", False):
                     return True, output
                 return False, "Failed to apply macsec interface config due to {}".format(output)
             return False, "Failed to apply macsec interface config due to no commmand available."
@@ -889,7 +889,7 @@ class AristaHost(AnsibleHostBase):
             parents = ["interface {}".format(interface)]
             commands = ["no mac security profile"]
             output = self.config(lines=commands, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to delete macsec interface config due to {}".format(output)
         except Exception as e:
@@ -930,7 +930,7 @@ class AristaHost(AnsibleHostBase):
                 }
             }
             """
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 counter = json_output["stdout"][0]["interfaces"][interface]
                 validated_bytes = counter["countersDetail"]["inPktsOK"]
                 decrypted_bytes = counter["inPktsDecrypted"]
@@ -975,7 +975,7 @@ class AristaHost(AnsibleHostBase):
         try:
             command = "show running-config interfaces loopback 99"
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "ip address" in line:
                         lb_ipv4_addr = line.split()[-1].strip("/32")
@@ -995,7 +995,7 @@ class AristaHost(AnsibleHostBase):
             command = ["no channel-group"]
             parents = ["interface {}".format(interface)]
             output = self.config(lines=command, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "remove interface {} from ether-bundle {}".format(interface, pcnum)
             else:
                 return False, "Failed to remove interface {} from ether-bundle {}".format(interface, pcnum)
@@ -1015,7 +1015,7 @@ class AristaHost(AnsibleHostBase):
             command = ["channel-group {} mode active".format(pcnum)]
             parents = ["interface {}".format(interface)]
             output = self.config(lines=command, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "Added interface {} from channel-group  {}".format(interface, pcnum)
             else:
                 return False, "Failed to add interface {} to channel-group {}".format(interface, pcnum)
@@ -1035,7 +1035,7 @@ class AristaHost(AnsibleHostBase):
             parents = []
             command = ["alias testversion show version"]
             output = self.config(lines=command, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 rollback_command = "no alias testversion"
                 self.config(lines=[rollback_command], parents=parents)
                 return True, output
@@ -1099,7 +1099,7 @@ class AristaHost(AnsibleHostBase):
             command = "show ip route aggregate | include {}".format(agg_prefix)
             agg_route_gen_status = False
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if agg_prefix in line:
                         agg_route_gen_status = True
@@ -1113,7 +1113,7 @@ class AristaHost(AnsibleHostBase):
             packets_exported = 0
             command = "show flow tracking sampled counters | include messages"
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "messages" in line:
                         counter = line.split()[1].lstrip("(").rstrip(")")
@@ -1137,7 +1137,7 @@ class AristaHost(AnsibleHostBase):
             parents = ["interface {}".format(interface)]
             commands = ["flow tracker sampled {}".format(filter_name)]
             output = self.config(lines=commands, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -1147,7 +1147,7 @@ class AristaHost(AnsibleHostBase):
         try:
             command = "reload all now"
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:

--- a/tests/common/devices/cisco.py
+++ b/tests/common/devices/cisco.py
@@ -187,7 +187,9 @@ class CiscoHost(AnsibleHostBase):
                     commands=[command],
                     module_ignore_errors=True)
             logger.debug('cisco lldp output: %s' % (output))
-            return output['stdout_lines'][0]['Response']['Get']['Operational'] if output['failed'] is False else False
+            if output.get('failed', False):
+                return False
+            return output['stdout_lines'][0]['Response']['Get']['Operational']
         except Exception as e:
             logger.error('command {} failed. exception: {}'.format(command, repr(e)))
         return False
@@ -239,7 +241,9 @@ class CiscoHost(AnsibleHostBase):
             command = 'ping {} count 5'.format(dest)
             output = self.commands(commands=[command])
             logger.debug('ping result: %s' % (output))
-            return re.search('!!!!!', output['stdout'][0]) is not None if output['failed'] is False else False
+            if output.get('failed', False):
+                return False
+            return re.search('!!!!!', output['stdout'][0]) is not None
         except Exception as e:
             logger.error('command {} failed. exception: {}'.format(command, repr(e)))
         return False
@@ -387,7 +391,7 @@ class CiscoHost(AnsibleHostBase):
             header_line = "Device ID       Local Intf                      Hold-time  Capability      Port ID"
             end_line = "Total entries displayed:"
             content_idx = 0
-            if not output['failed']:
+            if not output.get('failed', False):
                 output = [line.strip() for line in output['stdout_lines'][0] if len(line) > 0]
                 for idx, line in enumerate(output):
                     if end_line in line:
@@ -413,7 +417,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "show lldp neigh {} detail".format(physical_port)
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output['failed']:
+            if not output.get('failed', False):
                 logger.debug('cisco lldp output: %s' % (output))
                 return output['stdout_lines'][0]
             return "Failed to get lldp detail info for {} due to {}".format(physical_port, output)
@@ -427,7 +431,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "show version | i ^cisco | utility head -n 1"
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output['failed']:
+            if not output.get('failed', False):
                 logger.debug('cisco lldp output: %s' % (output))
                 return output['stdout_lines'][0][0].split()[1]
             return "Failed to get platform info due to {}".format(output)
@@ -441,7 +445,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = 'show version | in "Version      :"'
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output['failed']:
+            if not output.get('failed', False):
                 logger.debug('cisco lldp output: %s' % (output))
                 return output['stdout'][0].split()[-1].strip()
             return "Failed to get version info due to {}".format(output)
@@ -455,7 +459,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "show lldp | i Chassis ID:"
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output['failed']:
+            if not output.get('failed', False):
                 logger.debug('cisco lldp output: %s' % (output))
                 return output['stdout_lines'][0][0].split()[-1]
             return "Failed to get chassis id info due to {}".format(output)
@@ -625,7 +629,7 @@ class CiscoHost(AnsibleHostBase):
             pc_name = self.convert_pc_to_be(pc_name)
             command = "show lacp {} | begin eceive".format(pc_name)
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 logger.debug("cisco lldp output: %s" % (output))
                 interface = [
                     self.elongate_cisco_interface(line.split()[0])
@@ -651,7 +655,7 @@ class CiscoHost(AnsibleHostBase):
             command = "show interfaces {}".format(pc_name)
             success_criteria = "line protocol is up"
             intf_status_output = self.commands(commands=[command], module_ignore_errors=True)
-            if not intf_status_output["failed"]:
+            if not intf_status_output.get("failed", False):
                 logger.info("Interface status check: {} sent to {}".format(command, self.hostname))
                 is_up = success_criteria in intf_status_output["stdout"][0].lower()
                 return is_up, intf_status_output["stdout_lines"][0]
@@ -668,7 +672,7 @@ class CiscoHost(AnsibleHostBase):
             logger.info("Gathering ISIS adjacency details")
             command = "show isis adjacency"
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for row in output["stdout_lines"][0][3:-2]:
                     row = row.split()
                     isis_details[row[0]] = dict()
@@ -706,7 +710,7 @@ class CiscoHost(AnsibleHostBase):
             command = "show isis database"
             output = self.commands(commands=[command], module_ignore_errors=True)
             lsp_entries = {}
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "*" in line:
                         outline = line.replace("*", "").split()
@@ -737,7 +741,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             output = self.commands(commands=[command], module_ignore_errors=True)
             bgp_status = {}
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0][1:]:
                     line = line.strip().split()
                     if line[-1].isdigit():
@@ -770,7 +774,7 @@ class CiscoHost(AnsibleHostBase):
         """
         bgp_peer_details = self.get_bgp_session_details(peer_ip)
         try:
-            if not bgp_peer_details["failed"]:
+            if not bgp_peer_details.get("failed", False):
                 for line in bgp_peer_details["stdout_lines"][0]:
                     if "BGP state" in line:
                         bgp_session_status = line.strip().split()[3].strip(",")
@@ -792,7 +796,7 @@ class CiscoHost(AnsibleHostBase):
             command = "show bgp advertised neighbor {} summary | in {}".format(peer_ip, prefix)
             output = self.commands(commands=[command], module_ignore_errors=True)
             prefix_adv_status = False
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if prefix in line:
                         prefix_adv_status = True
@@ -810,7 +814,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = 'show mpls ldp neighbor | include "Peer LDP Identifier:|State:"'
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 ldp_op_list = []
                 for idx in range(0, len(output["stdout_lines"][0]), 2):
                     line1 = output["stdout_lines"][0][idx]
@@ -830,7 +834,7 @@ class CiscoHost(AnsibleHostBase):
             command = "show route {} | include via".format(destination_ip)
             output = self.commands(commands=[command], module_ignore_errors=True)
             interface_list = []
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "via" in line:
                         next_hop = line.split("via")[-1].strip()
@@ -873,7 +877,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "show mpls traffic-eng tunnels name {} | include Hop0".format(lsp_name)
             output = self.commands(commands=[command], module_ignore_errors=True)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 list_of_interface = []
                 for line in output["stdout_lines"][0]:
                     if "Hop0" in line:
@@ -963,7 +967,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "macsec-policy {} sak-rekey-interval seconds {}".format(profile_name, rekey_period_value)
             output = self.config(lines=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -984,7 +988,7 @@ class CiscoHost(AnsibleHostBase):
             macsec psk-keychain ptx10k-64hexCAK fallback-psk-keychain ptx10k-64hexCAK-fallback policy macsec-xpn-256
             !
             """
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output['stdout_lines'][0][1].split()[-1].strip()
             return False, output
         except Exception as e:
@@ -1007,7 +1011,7 @@ class CiscoHost(AnsibleHostBase):
                 return True, "log {} not supported on device {}".format(log_type, self.hostname)
             command = "show logging last {} | include {} | include {}".format(last_count, log_type, interface)
             output = self.commands(commands=[command])["stdout"][0]
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return len(output["stdout_lines"][0]) > 0, output["stdout"][0]
             return False, str(output)
         except Exception as e:
@@ -1099,7 +1103,7 @@ class CiscoHost(AnsibleHostBase):
             command = "show running-config formal interface {} macsec psk-keychain".format(interface)
             output = self.commands(commands=[command])
             # Returning only MACSEC config.
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for config in output["stdout_lines"][0]:
                     if "psk" in config:
                         return True, config
@@ -1115,7 +1119,7 @@ class CiscoHost(AnsibleHostBase):
         """
         try:
             output = self.config(lines=commands)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -1129,7 +1133,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "no interface {} macsec ".format(interface)
             output = self.config(lines=command)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -1186,7 +1190,7 @@ class CiscoHost(AnsibleHostBase):
             command = ["no bundle id"]
             parents = ["interface {}".format(interface)]
             output = self.config(lines=command, parents=parents)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "remove interface {} from ether-bundle {}".format(interface, pcnum)
             else:
                 return False, "Failed to remove interface {} from ether-bundle {}".format(interface, pcnum)
@@ -1205,7 +1209,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = ["interface {} bundle id {} mode active".format(interface, pcnum)]
             output = self.config(lines=command)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "Added interface {} from ether-bundle {}".format(interface, pcnum)
             else:
                 return False, "Failed to add interface {} from ether-bundle {}".format(interface, pcnum)
@@ -1224,7 +1228,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = ["alias testversion show version"]
             output = self.config(lines=command)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 rollback_command = ["no alias testversion"]
                 self.config(lines=rollback_command)
                 return True, output
@@ -1292,7 +1296,7 @@ class CiscoHost(AnsibleHostBase):
             command = "show route | include {}".format(agg_prefix)
             agg_route_gen_status = False
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if agg_prefix in line:
                         agg_route_gen_status = True
@@ -1305,7 +1309,7 @@ class CiscoHost(AnsibleHostBase):
         command = "show platform | include NSHUT | include CPU | exclude RP"
         output = self.commands(commands=[command])
         location_list = []
-        if not output["failed"]:
+        if not output.get("failed", False):
             for line in output["stdout_lines"][0]:
                 if "CPU" in line:
                     location_list.append(line.split()[0])
@@ -1316,7 +1320,7 @@ class CiscoHost(AnsibleHostBase):
             packets_exported = 0
             command = 'show flow exporter IPFIX_MSAZ location {} | include "Packets exported:"'.format(location)
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "Packets exported:" in line:
                         packets_exported += int(line.split()[2])
@@ -1350,7 +1354,7 @@ class CiscoHost(AnsibleHostBase):
                 interface, filter_name, filter_name
             )
             output = self.config(lines=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -1360,7 +1364,7 @@ class CiscoHost(AnsibleHostBase):
         try:
             command = "admin hw-module location all reload noprompt"
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -202,7 +202,7 @@ class EosHost(AnsibleHostBase):
         # FIXME: out['failed'] will be False even when a command is deprecated, so we have to check out['changed']
         # However, if the lacp rate is already in expected state, out['changed'] will be False and treated as
         # error.
-        if out['failed'] is True or out['changed'] is False:
+        if out.get('failed', False) is True or out['changed'] is False:
             # new eos deprecate lacp rate and use lacp timer command
             out = self.eos_config(
                 lines=['lacp timer %s' % mode],
@@ -587,7 +587,7 @@ class EosHost(AnsibleHostBase):
             lines=['lacp timer multiplier %d' % multiplier],
             parents='interface %s' % interface_name)
 
-        if out['failed'] is True or out['changed'] is False:
+        if out.get('failed', False) is True or out['changed'] is False:
             logging.warning("Unable to set interface [%s] lacp timer multiplier to [%d]" % (interface_name, multiplier))
         else:
             logging.info("Set interface [%s] lacp timer to [%d]" % (interface_name, multiplier))

--- a/tests/common/devices/juniper.py
+++ b/tests/common/devices/juniper.py
@@ -239,7 +239,7 @@ class JuniperHost(AnsibleHostBase):
             nh_result = []
             command = "show route {} table {} active-path exact".format(prefix, table)
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 prefix_info = json_output["stdout"][0]["route-information"][0]["route-table"][0]["rt"][0]
                 if prefix in prefix_info["rt-destination"][0]["data"]:
                     nh_info = {"nh_ip": None, "nh_interface": None, "nh_label_info": None, "nh_lsp_name": None}
@@ -298,7 +298,7 @@ class JuniperHost(AnsibleHostBase):
         command = "show chassis hardware | match fpc | except CPU"
         output = self.commands(session_type="network_cli", commands=[command], display="text")
         fpc_list = []
-        if not output["failed"]:
+        if not output.get("failed", False):
             for line in output["stdout_lines"][0]:
                 if "FPC" in line:
                     fpc_list.append(line.split()[1])
@@ -309,7 +309,7 @@ class JuniperHost(AnsibleHostBase):
             ipfix_export_data = {"count": 0}
             command = "show services accounting flow inline-jflow fpc-slot {}".format(fpc_no)
             output = self.commands(commands=[command], display="json")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 ipfix_export_data["count"] = output["stdout"][0]["services-accounting-information"][0][
                     "inline-jflow-flow-information"
                 ][0]["inline-flows-exported"][0]["data"]
@@ -347,7 +347,7 @@ class JuniperHost(AnsibleHostBase):
             configs = []
             configs.append("set interfaces {} unit 0 family inet filter input {}".format(interface, filter_name))
             output = self.config(lines=configs, comment="push ipfix configs")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -585,7 +585,7 @@ class JuniperHost(AnsibleHostBase):
             command = "show isis adjacency"
             json_output = self.commands(commands=[command], display="json")
             isis_adj_info = {}
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 for line in json_output["stdout"][0]["isis-adjacency-information"][0]["isis-adjacency"]:
                     isis_adj_info.update(
                         {
@@ -621,7 +621,7 @@ class JuniperHost(AnsibleHostBase):
             command = "show isis database"
             json_output = self.commands(commands=[command], display="json")
             lsp_entries = {}
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 for entry in json_output["stdout"][0]["isis-database-information"][0]["isis-database"][1][
                     "isis-database-entry"
                 ]:
@@ -740,7 +740,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show lldp neighbors"
             output = self.commands(commands=[command], display="json")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for lines in output["stdout"][0]["lldp-neighbors-information"][0]["lldp-neighbor-information"]:
                     lldp_details.update(
                         {
@@ -794,7 +794,7 @@ class JuniperHost(AnsibleHostBase):
             command = "show interfaces {}".format(pc_name)
             success_criteria = "physical link is up"
             intf_status_output = self.commands(session_type="network_cli", commands=[command], display="text")
-            if not intf_status_output["failed"]:
+            if not intf_status_output.get("failed", False):
                 logger.info("Interface status check: {} sent to {}".format(command, self.hostname))
                 is_up = success_criteria in intf_status_output["stdout"][0].lower()
                 return is_up, intf_status_output["stdout"][0]
@@ -814,7 +814,7 @@ class JuniperHost(AnsibleHostBase):
         command = "show lacp interfaces {}".format(pc_name)
         try:
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 interfaces_data = self.extract_val_from_json(json_output["stdout"][0], "lag-lacp-protocol")[0]
                 interfaces = [line["name"][0]["data"] for line in interfaces_data]
                 return interfaces
@@ -830,7 +830,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show lldp neighbor interface {}".format(physical_port)
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 return json_output["stdout"][0]
             return json_output
         except Exception as e:
@@ -844,7 +844,7 @@ class JuniperHost(AnsibleHostBase):
         command = "show lldp local-information"
         try:
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 chassis_id = json_output["stdout"][0]["lldp-local-info"][0]["lldp-local-chassis-id"][0]["data"]
                 return chassis_id
             return "Failed to get chassis info due to {}".format(json_output)
@@ -860,7 +860,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show lldp local-information"
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 mgmt_ip = json_output["stdout"][0]["lldp-local-info"][0]["lldp-local-management-address-address"][0][
                     "data"
                 ]
@@ -876,7 +876,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show lldp local-information"
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 system_description = json_output["stdout"][0]["lldp-local-info"][0]["lldp-local-system-description"][
                     0
                 ]["data"]
@@ -894,7 +894,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show version"
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 version = json_output["stdout"][0]["software-information"][0]["junos-version"][0]["data"]
                 return version
             return "Failed to get version due to {}".format(json_output)
@@ -1034,7 +1034,7 @@ class JuniperHost(AnsibleHostBase):
                 last_count, log_type
             )
             output = self.commands(session_type="network_cli", commands=[command], display="text")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return len(output["stdout_lines"][0]) > 0, output["stdout"][0]
             return False, "Failed to get macsec status logs due to {}".format(output)
         except Exception as e:
@@ -1054,7 +1054,7 @@ class JuniperHost(AnsibleHostBase):
             example of output:
             set security macsec interfaces et-2/0/14 connectivity-association macsec-xpn-256-ae16
             """
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output["stdout"][0].split()[-1]
             return False, "Failed to get macsec profile due to {}".format(output)
         except Exception as e:
@@ -1090,7 +1090,7 @@ class JuniperHost(AnsibleHostBase):
                 test_msg = "Key type {} not supported".format(key_type)
                 output = {"failed": True, "msg": test_msg}
 
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, str(output)
             return False, "Failed to set macsec key due to {}".format(output)
         except Exception as e:
@@ -1133,7 +1133,7 @@ class JuniperHost(AnsibleHostBase):
             ...
             Output trimmed
             """
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 sc_dict_out = json_output["stdout"][0]["macsec-statistics"][0]["secure-channel-received"][0]
                 validated_bytes = sc_dict_out["validated-bytes"][0]["data"]
                 decrypted_bytes = sc_dict_out["decrypted-bytes"][0]["data"]
@@ -1166,7 +1166,7 @@ class JuniperHost(AnsibleHostBase):
             commands.append("deactivate security macsec interfaces {}".format(interface))
         try:
             output = self.config(lines=commands, comment="deactivate macsec interface")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to deactivate macsec interface due to {}".format(output)
         except Exception as e:
@@ -1182,7 +1182,7 @@ class JuniperHost(AnsibleHostBase):
             commands.append("activate security macsec interfaces {}".format(interface))
         try:
             output = self.config(lines=commands, comment="activate macsec interface")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to activate macsec interface due to {}".format(output)
         except Exception as e:
@@ -1202,7 +1202,7 @@ class JuniperHost(AnsibleHostBase):
             example of output:
             set security macsec interfaces et-2/0/14 connectivity-association macsec-xpn-256-ae16
             """
-            if not output["failed"]:
+            if not output.get("failed", False):
                 # strip to remove extra /n with string
                 return True, output["stdout"][0].strip()
             return False, "Failed to get macsec config due to {}".format(output)
@@ -1216,7 +1216,7 @@ class JuniperHost(AnsibleHostBase):
         """
         output = self.config(lines=commands, comment="apply_macsec_interface_config")
         try:
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to apply macsec interface config due to {}".format(output)
         except Exception as e:
@@ -1230,7 +1230,7 @@ class JuniperHost(AnsibleHostBase):
         command = "delete security macsec interfaces {}".format(interface)
         try:
             output = self.config(lines=[command], comment="remove MACSEC from physical interface")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to delete macsec interface config due to {}".format(output)
         except Exception as e:
@@ -1247,7 +1247,7 @@ class JuniperHost(AnsibleHostBase):
                 profile_name, rekey_period_value
             )
             output = self.config(lines=[command], comment="rekey macsec interval")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to set rekey period due to {}".format(output)
         except Exception as e:
@@ -1265,7 +1265,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "set system location building microsoft"
             output = self.config(lines=[command], comment="test configure command")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 rollback_command = "del system location building microsoft"
                 self.config(lines=[rollback_command], comment="rollback test configure command")
                 return True, output
@@ -1280,7 +1280,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show configuration system tacplus-server | display set | match source-address"
             output = self.commands(session_type="network_cli", commands=[command], display="text")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if "source-address" in line:
                         return line.split()[-1]
@@ -1369,7 +1369,7 @@ class JuniperHost(AnsibleHostBase):
         )
         try:
             output = self.config(lines=prod_configs, confirm=2)
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "prod configs pushed to lab router, will rollback by itself in 2 minutes"
             return False, "Failed to apply prod tacacs config due to {}".format(output)
         except Exception as e:
@@ -1410,7 +1410,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show bgp summary"
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 json_output_dict = json_output["stdout"][0]["bgp-information"][0]["bgp-peer"]
                 bgp_status = {}
                 for bgp_speak in json_output_dict:
@@ -1440,7 +1440,7 @@ class JuniperHost(AnsibleHostBase):
         """
         try:
             bgp_peer_details = self.get_bgp_session_details(peer_ip)
-            if not bgp_peer_details["failed"]:
+            if not bgp_peer_details.get("failed", False):
                 session_status = bgp_peer_details["stdout"][0]["bgp-information"][0]["bgp-peer"][0]["peer-state"][0][
                     "data"
                 ]
@@ -1458,7 +1458,7 @@ class JuniperHost(AnsibleHostBase):
             command = "show route protocol aggregate {} exact".format(agg_prefix)
             agg_route_gen_status = False
             output = self.commands(session_type="network_cli", commands=[command], display="text")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 for line in output["stdout_lines"][0]:
                     if agg_prefix in line:
                         agg_route_gen_status = True
@@ -1477,7 +1477,7 @@ class JuniperHost(AnsibleHostBase):
             command = "show route advertising-protocol bgp {} {} exact".format(peer_ip, prefix)
             json_output = self.commands(commands=[command], display="json")
             prefix_adv_status = False
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 route_table = json_output["stdout"][0]["route-information"][0]["route-table"][0]["rt"]
                 for element in route_table:
                     if "rt-destination" in element:
@@ -1502,7 +1502,7 @@ class JuniperHost(AnsibleHostBase):
                 "deactivate protocols bgp group IPV6-ICR-SWAN",
             ]
             output = self.config(lines=commands, comment="deactivate bgp with ser")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True
             return False
         except Exception as e:
@@ -1522,7 +1522,7 @@ class JuniperHost(AnsibleHostBase):
                 "activate protocols bgp group IPV6-ICR-SWAN",
             ]
             output = self.config(lines=commands, comment="activate bgp with ser")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True
             return False
         except Exception as e:
@@ -1536,7 +1536,7 @@ class JuniperHost(AnsibleHostBase):
         """
         try:
             output = self.config(lines=["deactivate protocols rsvp"], comment="deactivate protocol rsvp")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, "Failed to deactivate rsvp protocol due to {}".format(output)
         except Exception as e:
@@ -1550,7 +1550,7 @@ class JuniperHost(AnsibleHostBase):
         """
         try:
             output = self.config(lines=["activate protocols rsvp"], comment="activate protocol rsvp")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             else:
                 return False, "Failed to activate rsvp protocol due to {}".format(output)
@@ -1562,7 +1562,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "show route {} table {} active-path exact".format(prefix_with_mask, table)
             json_output = self.commands(commands=[command], display="json")
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 if "route-table" in json_output["stdout"][0]["route-information"][0]:
                     route_table = json_output["stdout"][0]["route-information"][0]["route-table"][0]
                     destination = route_table["rt"][0]["rt-destination"][0]["data"]
@@ -1585,7 +1585,7 @@ class JuniperHost(AnsibleHostBase):
                 "deactivate system extensions extension-service application file apcacertagent-junos",
             ]
             output = self.config(lines=commands, comment="deactivate swan agent")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -1602,7 +1602,7 @@ class JuniperHost(AnsibleHostBase):
                 "activate system extensions extension-service application file apcacertagent-junos",
             ]
             output = self.config(lines=commands, comment="activate swan agent")
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:
@@ -1662,7 +1662,7 @@ class JuniperHost(AnsibleHostBase):
                 ...
              Output trimmed
             """
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 rsvp_nbrs = json_output["stdout"][0]["rsvp-neighbor-information"][0]["rsvp-neighbor"]
                 for rsvp_nbr in rsvp_nbrs:
                     if str(rsvp_nbr["rsvp-neighbor-address"][0]["data"]) == str(neighbor):
@@ -1686,7 +1686,7 @@ class JuniperHost(AnsibleHostBase):
         command = "show configuration interfaces lo0"
         try:
             json_output = self.commands(commands=[command], display="json")["stdout"][0]
-            if not json_output["failed"]:
+            if not json_output.get("failed", False):
                 ipv4_addresses = json_output["configuration"]["interfaces"]["interface"][0]["unit"][0]["family"][
                     "inet"
                 ]["address"]
@@ -1710,7 +1710,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             commands = ["deactivate interfaces {} gigether-options 802.3ad".format(interface)]
             output = self.config(lines=commands, comment="deactivate interface {} from ae {}".format(interface, pcnum))
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "Deactivated interface {} from ae{}".format(interface, pcnum)
             return False, "Failed to deactivate interface {} from ae{}".format(interface, pcnum)
         except Exception as e:
@@ -1726,7 +1726,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             commands = ["activate interfaces {} gigether-options 802.3ad".format(interface)]
             output = self.config(lines=commands, comment="activate interface {} from ae {}".format(interface, pcnum))
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, "Activated interface {} from ae{}".format(interface, pcnum)
             return False, "Failed to activate interface {} from ae{}".format(interface, pcnum)
         except Exception as e:
@@ -1736,7 +1736,7 @@ class JuniperHost(AnsibleHostBase):
         try:
             command = "request system reboot both-routing-engines"
             output = self.commands(commands=[command])
-            if not output["failed"]:
+            if not output.get("failed", False):
                 return True, output
             return False, output
         except Exception as e:

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2427,7 +2427,7 @@ Totals               6450                 6449
             ))
         except RunAnsibleModuleFail:
             return False
-        return not rc['failed']
+        return not rc.get('failed', False)
 
     def ping_v6(self, ipv6, count=1, ns_arg=""):
         """
@@ -2453,7 +2453,7 @@ Totals               6450                 6449
             ))
         except RunAnsibleModuleFail:
             return False
-        return not rc['failed']
+        return not rc.get('failed', False)
 
     def is_backend_portchannel(self, port_channel, mg_facts):
         ports = mg_facts["minigraph_portchannels"].get(port_channel)

--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -285,7 +285,7 @@ class SonicAsic(object):
             ))
         except RunAnsibleModuleFail:
             return False
-        return not rc['failed']
+        return not rc.get('failed', False)
 
     def ping_v6(self, ipv6, count=1):
         """
@@ -307,7 +307,7 @@ class SonicAsic(object):
             ))
         except RunAnsibleModuleFail:
             return False
-        return not rc['failed']
+        return not rc.get('failed', False)
 
     def is_backend_portchannel(self, port_channel):
         mg_facts = self.sonichost.minigraph_facts(host=self.sonichost.hostname)['ansible_facts']

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_CONDITIONS_FILE = 'common/plugins/conditional_mark/tests_mark_conditions*.yaml'
 ASIC_NAME_PATH = '/../../../../ansible/group_vars/sonic/variables'
+ANSIBLE_LIBRARY_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), '../../../../ansible/library'))
 MARK_CONDITIONS_CONSTANTS = {
     "QOS_SAI_TOPO": ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-80',
                      't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256',
@@ -157,7 +158,9 @@ def load_dut_basic_facts(inv_name, dut_name):
     logger.info('Getting dut basic facts: {}'.format(dut_name))
     try:
         inv_full_path = os.path.join(os.path.dirname(__file__), '../../../../ansible', inv_name)
-        ansible_cmd = 'ansible -m dut_basic_facts -i {} {} -o'.format(inv_full_path, dut_name)
+        ansible_cmd = (
+            'ansible -M {} -m dut_basic_facts -i {} {} -o'
+            .format(ANSIBLE_LIBRARY_PATH, inv_full_path, dut_name))
 
         raw_output = subprocess.check_output(ansible_cmd.split()).decode('utf-8')
         logger.debug('raw dut basic facts:\n{}'.format(raw_output))
@@ -243,7 +246,10 @@ def load_minigraph_facts(inv_name, dut_name):
     logger.info('Getting minigraph basic facts: {}'.format(dut_name))
     try:
         # get minigraph basic faces
-        ansible_cmd = "ansible -m minigraph_facts -i ../ansible/{0} {1} -a host={1}".format(inv_name, dut_name)
+        ansible_cmd = (
+            "ansible -M {} -m minigraph_facts"
+            " -i ../ansible/{} {} -a host={}"
+            .format(ANSIBLE_LIBRARY_PATH, inv_name, dut_name, dut_name))
         raw_output = subprocess.check_output(ansible_cmd.split()).decode('utf-8')
         logger.debug('raw minigraph basic facts:\n{}'.format(raw_output))
         output_fields = raw_output.split('SUCCESS =>', 1)
@@ -275,7 +281,10 @@ def load_config_facts(inv_name, dut_name):
     logger.info('Getting config basic facts: {}'.format(dut_name))
     try:
         # get config basic faces
-        ansible_cmd = ['ansible', '-m', 'config_facts', '-i', '../ansible/{}'.format(inv_name),
+        ansible_cmd = [
+            'ansible', '-M', ANSIBLE_LIBRARY_PATH,
+            '-m', 'config_facts',
+            '-i', '../ansible/{}'.format(inv_name),
                        '{}'.format(dut_name), '-a', 'host={} source=\'persistent\''.format(dut_name)]
         raw_output = subprocess.check_output(ansible_cmd).decode('utf-8')
         logger.debug('raw config basic facts:\n{}'.format(raw_output))
@@ -316,7 +325,10 @@ def load_switch_capabilities_facts(inv_name, dut_name):
     logger.info('Getting switch capabilities basic facts: {}'.format(dut_name))
     try:
         # get switch capabilities basic faces
-        ansible_cmd = "ansible -m switch_capabilities_facts -i ../ansible/{} {}".format(inv_name, dut_name)
+        ansible_cmd = (
+            "ansible -M {} -m switch_capabilities_facts"
+            " -i ../ansible/{} {}"
+            .format(ANSIBLE_LIBRARY_PATH, inv_name, dut_name))
         raw_output = subprocess.check_output(ansible_cmd.split()).decode('utf-8')
         logger.debug('raw switch capabilities basic facts:\n{}'.format(raw_output))
         output_fields = raw_output.split('SUCCESS =>', 1)
@@ -345,7 +357,10 @@ def load_console_facts(inv_name, dut_name):
     logger.info('Getting console basic facts: {}'.format(dut_name))
     try:
         # get console basic faces
-        ansible_cmd = "ansible -m console_facts -i ../ansible/{} {}".format(inv_name, dut_name)
+        ansible_cmd = (
+            "ansible -M {} -m console_facts"
+            " -i ../ansible/{} {}"
+            .format(ANSIBLE_LIBRARY_PATH, inv_name, dut_name))
         raw_output = subprocess.check_output(ansible_cmd.split()).decode('utf-8')
         logger.debug('raw console basic facts:\n{}'.format(raw_output))
         output_fields = raw_output.split('SUCCESS =>', 1)
@@ -570,8 +585,9 @@ def evaluate_condition(dynamic_update_skip_reason, mark_details, condition, basi
         safe_globals = {}
         safe_globals.update(safe_facts)
 
-        for var in ["asic_type"]:
+        for var in ["asic_type", "platform", "hwsku", "asic_gen"]:
             if var not in safe_globals:
+                logger.warning("Variable %s not found in basic_facts, defaulting to None", var)
                 safe_globals[var] = None
 
         condition_result = bool(eval(condition_str, safe_globals))
@@ -668,8 +684,13 @@ def pytest_collection_modifyitems(session, config, items):
         json.dumps(basic_facts, indent=2)))
     dynamic_update_skip_reason = session.config.option.dynamic_update_skip_reason
     basic_facts['constants'] = MARK_CONDITIONS_CONSTANTS
+    # Normalize nodeids: strip root directory prefix if present (pytest 9.0+ includes it)
+    root_prefix = os.path.basename(str(session.config.rootpath)) + "/"
     for item in items:
-        all_matches = find_all_matches(item.nodeid, conditions, session, dynamic_update_skip_reason, basic_facts)
+        nodeid = item.nodeid
+        if nodeid.startswith(root_prefix):
+            nodeid = nodeid[len(root_prefix):]
+        all_matches = find_all_matches(nodeid, conditions, session, dynamic_update_skip_reason, basic_facts)
 
         if all_matches:
             logger.debug('Found match "{}" for test case "{}"'.format(all_matches, item.nodeid))

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1222,6 +1222,15 @@ platform_tests/test_advanced_reboot.py::test_warm_reboot_sad:
       - "is_smartswitch==True"
 
 #######################################
+#####   test_chassis_reboot.py  #####
+#######################################
+platform_tests/test_chassis_reboot.py:
+  skip:
+    reason: "Chassis reboot test is not supported on T2 single node topology"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
+#######################################
 #####   test_cont_warm_reboot.py  #####
 #######################################
 platform_tests/test_cont_warm_reboot.py:

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -312,7 +312,22 @@ class TestShowLLDP():
         dutHostGuest, mode, ifmode = setup_config_mode
         minigraph_neighbors = setup['minigraph_facts']['minigraph_neighbors']
 
-        lldp_table = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show lldp table'.format(ifmode))['stdout']
+        lldp_table_result = {}
+
+        def _lldp_table_ready():
+            lldp_table_result['output'] = dutHostGuest.shell(
+                'SONIC_CLI_IFACE_MODE={} show lldp table'.format(ifmode))['stdout']
+            expected_intfs = lldp_interfaces['alias'] if mode == 'alias' else lldp_interfaces['interface']
+            return all(re.search(re.escape(intf), lldp_table_result['output']) for intf in expected_intfs)
+
+        pytest_assert(
+            wait_until(ESTABLISH_LLDP_NEIGHBOR_TIMEOUT, 10, 0, _lldp_table_ready),
+            "LLDP table did not converge with all expected interfaces within {} seconds".format(
+                ESTABLISH_LLDP_NEIGHBOR_TIMEOUT
+            )
+        )
+
+        lldp_table = lldp_table_result['output']
         logger.info('lldp_table:\n{}'.format(lldp_table))
 
         vrf_map = {}

--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -763,67 +763,27 @@ qos_params:
                 q_list: [0, 1, 3, 4, 5, 6]
                 q_pkt_cnt: [80, 100, 300, 100, 100, 700]
         topo-t1-isolated-d128: &topo-t1-isolated-d128
-            200000_5m: &topo-t1-isolated-d128_200000_5m
+            400000_40m: &topo-t1-isolated-d128_400000_40m
                 hdrm_pool_size:
-                    dscps:
-                    - 3
-                    - 4
+                    dscps: [3, 4]
                     dst_port_id: 0
                     ecn: 1
-                    margin: 2
-                    pgs:
-                    - 3
-                    - 4
+                    margin: 4
+                    pgs: [3, 4]
                     pgs_num: 25
                     pkts_num_hdrm_full: 1755
                     pkts_num_hdrm_partial: 1208
-                    pkts_num_trig_pfc: 132925
-                    pkts_num_trig_pfc_multi:
-                    - 132925
-                    - 66500
-                    - 33287
-                    - 16680
-                    - 8377
-                    - 4226
-                    - 2150
-                    - 1112
-                    - 593
-                    - 333
-                    - 204
-                    - 139
-                    - 106
-                    - 90
-                    - 82
-                    - 78
-                    - 76
-                    - 75
-                    - 75
-                    - 74
-                    - 74
-                    - 74
-                    - 74
-                    - 74
-                    - 74
-                    src_port_ids:
-                    - 1
-                    - 2
-                    - 3
-                    - 4
-                    - 5
-                    - 6
-                    - 7
-                    - 8
-                    - 9
-                    - 10
-                    - 11
-                    - 12
-                    - 13
+                    pkts_num_trig_pfc: 133349
+                    pkts_num_trig_pfc_multi: [133349, 66711, 33393, 16733, 8404, 4239,
+                        2156, 1115, 595, 334, 204, 139, 107, 90, 82, 78, 76, 75, 75,
+                        74, 74, 74, 74, 74, 74]
+                    src_port_ids: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
                 lossy_queue_1:
-                    dscp: 8
+                    dscp: 0
                     ecn: 1
                     pg: 0
-                    pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 132859
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 133283
                 pkts_num_egr_mem: 376
                 pkts_num_leak_out: 0
                 wm_pg_headroom:
@@ -831,9 +791,9 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 134681
-                    pkts_num_trig_pfc: 132925
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 135105
+                    pkts_num_trig_pfc: 133349
                 wm_pg_shared_lossless:
                     cell_size: 254
                     dscp: 3
@@ -841,61 +801,61 @@ qos_params:
                     packet_size: 64
                     pg: 3
                     pkts_num_fill_min: 74
-                    pkts_num_margin: 2
-                    pkts_num_trig_pfc: 132925
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 133349
                 wm_pg_shared_lossy:
                     cell_size: 254
-                    dscp: 8
+                    dscp: 0
                     ecn: 1
                     packet_size: 64
                     pg: 0
                     pkts_num_fill_min: 7
-                    pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 132859
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 133283
                 wm_q_shared_lossless:
                     cell_size: 254
                     dscp: 3
                     ecn: 1
                     pkts_num_fill_min: 0
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 134681
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 135105
                     queue: 3
                 wm_q_shared_lossy:
                     cell_size: 254
-                    dscp: 8
+                    dscp: 0
                     ecn: 1
                     pkts_num_fill_min: 7
-                    pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 132859
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 133283
                     queue: 0
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 134681
-                    pkts_num_trig_pfc: 132925
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 135105
+                    pkts_num_trig_pfc: 133349
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 134681
-                    pkts_num_trig_pfc: 132925
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 135105
+                    pkts_num_trig_pfc: 133349
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_dismiss_pfc: 14
-                    pkts_num_margin: 2
-                    pkts_num_trig_pfc: 132925
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 133349
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_dismiss_pfc: 14
-                    pkts_num_margin: 2
-                    pkts_num_trig_pfc: 132925
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 133349
             cell_size: 254
             hdrm_pool_wm_multiplier: 2
             wrr:
@@ -903,7 +863,7 @@ qos_params:
                 ecn: 1
                 limit: 80
                 q_list: [0, 1, 3, 4, 5, 6]
-                q_pkt_cnt: [50, 50, 100, 50, 50, 350]
+                q_pkt_cnt: [100, 100, 200, 100, 100, 700]
             wrr_chg:
                 dscp_list: [0, 47, 3, 4, 46, 44]
                 ecn: 1
@@ -912,5 +872,5 @@ qos_params:
                 lossy_weight: 8
                 q_list: [0, 1, 3, 4, 5, 6]
                 q_pkt_cnt: [80, 100, 300, 100, 100, 700]
-            400000_40m: *topo-t1-isolated-d128_200000_5m
+            200000_5m: *topo-t1-isolated-d128_400000_40m
         topo-t1-isolated-d32: *topo-t1-isolated-d128

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -524,13 +524,30 @@ def test_update_saithrift_ptf(request, ptfhost, duthosts, enum_dut_hostname):
     if result["failed"] or "OK" not in result["msg"]:
         pytest.fail("Download failed/error while installing python saithrift package: {}".format(py_saithrift_url))
     ptfhost.shell("dpkg -i {}".format(os.path.join("/root", pkg_name)))
-    # In 202405 branch, the switch_sai_thrift package is inside saithrift-0.9-py3.11.egg
-    # We need to move it out to the correct location
-    PY_PATH = "/usr/lib/python3/dist-packages/"
-    SRC_PATH = PY_PATH + "saithrift-0.9-py3.11.egg/switch_sai_thrift"
-    DST_PATH = PY_PATH + "switch_sai_thrift"
-    if ptfhost.stat(path=SRC_PATH)['stat']['exists'] and not ptfhost.stat(path=DST_PATH)['stat']['exists']:
-        ptfhost.copy(src=SRC_PATH, dest=PY_PATH, remote_src=True)
+    # The saithrift deb installs switch_sai_thrift inside an egg dir named for the
+    # Python version it was built against (e.g. saithrift-0.9-py3.11.egg on
+    # bookworm/OS12, saithrift-0.9-py3.13.egg on trixie/OS13). The PTF runs from its
+    # own virtualenv (/root/env-python3) whose sys.path references that egg dir via
+    # easy-install.pth; dpkg does NOT update the .pth when the egg version changes,
+    # so switch_sai_thrift becomes unimportable when the image's Python version
+    # differs from the PTF's (e.g. a trixie/py3.13 deb on a bookworm/py3.11 PTF).
+    # Locate the actual egg (any py3.x) and copy switch_sai_thrift into the PTF
+    # virtualenv's site-packages, which is always on the runner's sys.path.
+    PY_PATH = "/usr/lib/python3/dist-packages"
+    egg_switch_sai = ptfhost.shell(
+        "ls -d {}/saithrift-0.9-py3.*.egg/switch_sai_thrift 2>/dev/null | head -1".format(PY_PATH),
+        module_ignore_errors=True,
+    )["stdout"].strip()
+    if egg_switch_sai:
+        # Prefer the PTF virtualenv site-packages (always on the ptf_runner sys.path);
+        # fall back to the system dist-packages if the virtualenv is absent.
+        site_dir = ptfhost.shell(
+            "/root/env-python3/bin/python -c "
+            "'import sysconfig; print(sysconfig.get_paths()[\"purelib\"])'",
+            module_ignore_errors=True,
+        )["stdout"].strip() or PY_PATH
+        ptfhost.shell("rm -rf {}/switch_sai_thrift".format(site_dir), module_ignore_errors=True)
+        ptfhost.copy(src=egg_switch_sai, dest=site_dir + "/", remote_src=True)
     logging.info("Python saithrift package installed successfully")
 
 


### PR DESCRIPTION
```
* 8745e6164a - [action] [PR:25189] Update qos params for topo-t1-isolated-d128 (#26140) (2026-07-14) [mssonicbld]
* f9c314f133 - [action] [PR:26087] Fix loganalyzer ignore patterns for benign iptables TACACS errors and… (#26110) (2026-07-14) [mssonicbld]
* 5cf3c58d5a - [action] [PR:26083] [hash_test] Extend sporadic-loss retry to Vxlan/Nvgre hash tests (#26111) (2026-07-14) [mssonicbld]
* 8d5c76ed6e - [action] [PR:23591] [loganalyzer] Fix end marker lost during rsyslog reload (#23562) (#26078) (2026-07-13) [mssonicbld]
* 7eccd13577 - [202511] fix: pass KVM_BUILD_ID as template parameter through pre_defined_pr_test pipeline chain (#23061) (#26053) (2026-07-13) [yijingyan2]
* 7f9713b694 - [action] [PR:26072] Bump flake8 pre-commit hook 6.0.0 -> 7.1.1 to fix f-string false positives (#26088) (2026-07-12) [mssonicbld]
* 0ffbc95a65 - [action] [PR:22147] Update ignore error list because some logs add some string like client_pid (#26090) (2026-07-11) [mssonicbld]
* 047997cdae - [cherry-pick][202511] Backport ansible-core compatibility fixes (#25781) (2026-07-11) [xwjiang-ms]
* 5c6da256d9 - [ci][202511] sonic-ubuntu-1c agent pool: migrate from python3-pip to uv to address S360 vulnerability (#25721) (#26047) (2026-07-11) [yijingyan2]
* a13aad8c65 - [action] [PR:22944] Fix conditional_mark plugin for pytest 9.0 compatibility (#25937) (2026-07-10) [mssonicbld]
* 42eb1c7591 - [ 202511 ] Skip test chassis reboot test on disaggregated chassis (#26029) (2026-07-09) [Setu Patel]
* 5d289259d7 - [action] [PR:23860] Fix test_show_lldp_table: wait for LLDP convergence before assertion (#26031) (2026-07-10) [mssonicbld]
* 303a0f268d - [action] [PR:25421] [test_pretest] Fix saithrift switch_sai_thrift import on Trixie (py3.13) PTF (#26003) (2026-07-09) [mssonicbld]
```
