### PR TITLE
[ci] add autosync mapping for 2026 branches

### DIFF
--- a/.github/workflows/autosync_pub_msft.yml
+++ b/.github/workflows/autosync_pub_msft.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           set -ex
 
-          branches="202412 202506 202511_azd"
+          branches="202412 202506 202511_azd 202601 202603 202606 202607 202608"
           pushd sonic-mgmt.msft
 
           [ -z "$branches" ] && exit 1
@@ -63,6 +63,21 @@ jobs:
             fi
             if [[ $branch_head == "202511_azd" ]]; then
               branch_head=202511
+            fi
+            if [[ $branch_head == "202601" ]]; then
+              branch_head=202511
+            fi
+            if [[ $branch_head == "202603" ]]; then
+              branch_head=202511
+            fi
+            if [[ $branch_head == "202606" ]]; then
+              branch_head=202605
+            fi
+            if [[ $branch_head == "202607" ]]; then
+              branch_head=202605
+            fi
+            if [[ $branch_head == "202608" ]]; then
+              branch_head=202605
             fi
 
             git ls-remote origin refs/heads/$branch_base || continue


### PR DESCRIPTION
enable auto sync from sonic-net/sonic-mgmt to Azure/sonic-mgmt.msft for 2026 branches