### PR TITLE
[202608][PR:26405]Resolve/ptf use docker network

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -10,6 +10,11 @@
     ptf_imagetag: "latest"
   when: ptf_imagetag is not defined
 
+- name: Enable ptf_use_docker_network for BMC topology
+  set_fact:
+    ptf_use_docker_network: true
+  when: "'bmc' in topo"
+
 - name: set "PTF" container type, by default
   set_fact:
     container_type: "PTF"

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -15,6 +15,11 @@
       ptf_imagetag: "latest"
     when: ptf_imagetag is not defined
 
+  - name: Enable ptf_use_docker_network for BMC topology
+    set_fact:
+      ptf_use_docker_network: true
+    when: "'bmc' in topo"
+
   - name: Stop mux simulator
     include_tasks: control_mux_simulator.yml
     vars:


### PR DESCRIPTION
### Description of PR


This manual PR is to resolve a merge conflict to 202608 from original PR https://github.com/sonic-net/sonic-mgmt/pull/26405

Fixes https://github.com/sonic-net/sonic-mgmt/issues/26398


**Summary:**
For BMC topologies, the PTF container must be connected to the Docker management bridge network (rather than `network_mode: none`) so that it can reach the DUT via the management network.

Previously this required passing `-e ptf_use_docker_network=true` explicitly on the `add-topo` and `renumber-topo` command line. This change automatically sets `ptf_use_docker_network=true` when the topology name contains `bmc`, eliminating the need for the manual flag.

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608

### Tested branch
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608

### Approach
#### What is the motivation for this PR?

BMC topologies require PTF to use the Docker management bridge network to reach the DUT. This was previously an opt-in flag that had to be passed manually, making it easy to forget and causing failures when omitted.

#### How did you do it?

Added a `set_fact` task early in both `add_topo.yml` and `renumber_topo.yml` that sets `ptf_use_docker_network: true` when `'bmc' in topo`. All downstream conditional checks (`ptf_use_docker_network | default(false)`) then evaluate correctly for BMC topologies without any command-line changes.

#### How did you verify/test it?

Ran `./testbed-cli.sh add-topo <bmc-testbed> vault` (without `-e ptf_use_docker_network=true`) on a BMC testbed and confirmed the PTF container was started with the correct `network_mode` and `networks` configuration attached to the management bridge.

#### Any platform specific information?

Applies only to BMC topologies (topology name contains `bmc`). No impact on other topology types.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A