### PR TITLE
202603 bgp update timer

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -618,7 +618,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
         setup_func = _setup_interfaces_dualtor
     elif tbinfo["topo"]["type"] in ["t0", "mx"]:
         setup_func = _setup_interfaces_t0_or_mx
-    elif tbinfo["topo"]["type"] in set(["t1", "t2", "m1", "lt2", "ft2", "c0"]):
+    elif tbinfo["topo"]["type"] in set(["t1", "t2", "m1", "lt2", "ft2", "c0","lma", "uma"]):
         setup_func = _setup_interfaces_t1_or_t2
     elif tbinfo["topo"]["type"] == "m0":
         if topo_scenario == "m0_l3_scenario":

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -121,6 +121,14 @@ def common_setup_teardown(
         if dut_type == "FabricSpineRouter" and confed_asn is not None:
             # For FT2, we need to use vtysh to configure an external BGP neighbor
             use_vtysh = True
+    elif dut_type in ["LowerMgmtAggregator"]:
+        neigh_type = "MgmtSpineRouter"
+        if confed_asn is not None:
+            use_vtysh = True
+    elif dut_type in ["UpperMgmtAggregator"]:
+        neigh_type = "LowerMgmtAggregator"
+        if confed_asn is not None:
+            use_vtysh = True
     else:
         neigh_type = "ToRRouter"
 

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -274,7 +274,7 @@ class TestbedInfo(object):
 
     def get_testbed_type(self, topo_name):
         pattern = re.compile(
-            r'^(wan|t0|t1|ptf|fullmesh|dualtor|ciscovs|t2|lt2|ft2|tgen|mgmttor|m0|mc0|mx|m1|c0|dpu|ptp|smartswitch|nut)'
+            r'^(wan|t0|t1|ptf|fullmesh|dualtor|ciscovs|t2|lt2|ft2|tgen|mgmttor|m0|mc0|mx|m1|c0|dpu|ptp|smartswitch|nut|lma|uma)'
         )
         match = pattern.match(topo_name)
         if match is None:


### PR DESCRIPTION
This pull request adds support for two new testbed topology types, `lma` and `uma`, across the BGP test suite. The changes ensure that these new types are recognized and handled correctly in testbed configuration, interface setup, and test case logic.

This is cherry pick PR for https://github.com/sonic-net/sonic-mgmt/pull/26723/changes#diff-08a7115d32e5a350efe1d2b8ad9ff9c7f2c7714a298cea25cac54905b3bb794d and https://github.com/sonic-net/sonic-mgmt/pull/26724
**Testbed topology support:**

* Added `lma` and `uma` to the set of recognized topology types in the `_get_namespace` function in `tests/bgp/conftest.py`, ensuring proper interface setup for these types.
* Updated the regular expression in `get_testbed_type` in `tests/common/testbed.py` to include `lma` and `uma`, allowing these types to be detected from topology names.

**BGP test logic:**

* Added handling for `LowerMgmtAggregator` and `UpperMgmtAggregator` device types in `common_setup_teardown` in `tests/bgp/test_bgp_update_timer.py`, including neighbor type assignments and conditional use of `vtysh` for configuration.