### PR TITLE
Add '202606' to release conditions in YAML

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -621,7 +621,7 @@ bgp/test_bgp_suppress_fib.py:
     conditions_logical_operator: or
     conditions:
       - "release in ['201811', '201911', '202012', '202205', '202211', '202305', '202311', '202405']"
-      - "release in ['202505', '202511', '202605']"
+      - "release in ['202505', '202511', '202605', '202606']"
       - "release in ['master'] and https://github.com/sonic-net/sonic-mgmt/issues/26175"
   xfail:
     reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20756 or Mellanox platform due to https://github.com/sonic-net/sonic-buildimage/issues/24679"


### PR DESCRIPTION
backport of https://github.com/sonic-net/sonic-mgmt/pull/26176.

Description of PR
Summary:
Fixes #26175

Temporarily skip the whole bgp/test_bgp_suppress_fib.py module for the suppress-fib-pending dynamic-toggle race.

The module toggles suppress-fib-pending dynamically at runtime (via the shared config_bgp_suppress_fib() helper, no config reload). That triggers a race between orchagent, fpmsyncd and FRR where routes are intermittently not marked offloaded in FRR