### PR TITLE
Add lma/uma topology markers to BGP tests (cherry-pick sonic-net/soni…

### DIFF
--- a/tests/bgp/test_bgp_command.py
+++ b/tests/bgp/test_bgp_command.py
@@ -6,7 +6,7 @@ from tests.common.helpers.assertions import pytest_assert
 
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", "m0", "mx", "m1", "c0"),
+    pytest.mark.topology("t0", "t1", "m0", "mx", "m1", "c0", "lma", "uma"),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -17,7 +17,7 @@ from tests.common.utilities import wait_until, delete_running_config
 from tests.common.utilities import is_ipv6_only_topology
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm1', 'lt2', 'ft2', 'c0'),
+    pytest.mark.topology('t0', 't1', 't2', 'm1', 'lt2', 'ft2', 'c0', 'lma', 'uma'),
 ]
 
 TEST_ITERATIONS = 5
@@ -67,6 +67,14 @@ def common_setup_teardown(
         neigh_type = "LowerSpineRouter"
         if dut_type == "FabricSpineRouter" and confed_asn is not None:
             # For FT2, we need to use vtysh to configure BGP neigh if BGP confed is enabled
+            use_vtysh = True
+    elif dut_type in ["LowerMgmtAggregator"]:
+        neigh_type = "MgmtSpineRouter"
+        if confed_asn is not None:
+            use_vtysh = True
+    elif dut_type in ["UpperMgmtAggregator"]:
+        neigh_type = "LowerMgmtAggregator"
+        if confed_asn is not None:
             use_vtysh = True
     else:
         neigh_type = "ToRRouter"

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 vrfname = 'default'
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", 'm1', 'lt2', 'ft2', 'c0'),
+    pytest.mark.topology("t0", "t1", 'm1', 'lt2', 'ft2', 'c0', 'lma', 'uma'),
 ]
 
 

--- a/tests/bgp/test_bgp_session_flap.py
+++ b/tests/bgp/test_bgp_session_flap.py
@@ -29,7 +29,7 @@ cpuSpike = 10
 memSpike = 1.3
 
 pytestmark = [
-    pytest.mark.topology('t1', 't2', 'm1', 'lt2', 'ft2', 'c0')
+    pytest.mark.topology('t1', 't2', 'm1', 'lt2', 'ft2', 'c0', 'lma', 'uma')
 ]
 
 

--- a/tests/bgp/test_bgp_stress_link_flap.py
+++ b/tests/bgp/test_bgp_stress_link_flap.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('t0', 't1', "m0", "mx", 'm1', 'lt2', 'ft2', 'c0')
+    pytest.mark.topology('t0', 't1', "m0", "mx", 'm1', 'lt2', 'ft2', 'c0', 'lma', 'uma')
 ]
 
 stop_tasks = False

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -23,7 +23,7 @@ STATS_COLLECT_TIMEOUT = 30
 STATS_COLLECT_INTERVAL = 5
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'lt2', 'ft2'),
+    pytest.mark.topology('t0', 't1', 't2', 'lt2', 'ft2', 'lma', 'uma'),
     pytest.mark.disable_loganalyzer
 ]
 

--- a/tests/bgp/test_frr_config_check.py
+++ b/tests/bgp/test_frr_config_check.py
@@ -5,7 +5,7 @@ from tests.common import config_reload
 from tests.common.platform.processes_utils import wait_critical_processes
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1'),
+    pytest.mark.topology('t0', 't1', 'lma', 'uma'),
     pytest.mark.disable_loganalyzer,
 ]
 


### PR DESCRIPTION
This is cherry pick of https://github.com/sonic-net/sonic-mgmt/pull/26750/changes

This pull request expands BGP test coverage to include the new `lma` (LowerMgmtAggregator) and `uma` (UpperMgmtAggregator) topologies and adds support for these device types in BGP peer shutdown logic. These changes ensure that BGP tests are consistently executed across a broader set of network topologies and devices.

**Test coverage expansion:**

* Added `lma` and `uma` topologies to the `pytest.mark.topology` decorators in all relevant BGP test files, including `test_bgp_command.py`, `test_bgp_peer_shutdown.py`, `test_bgp_session.py`, `test_bgp_session_flap.py`, `test_bgp_stress_link_flap.py`, `test_bgp_update_replication.py`, and `test_frr_config_check.py`. [[1]](diffhunk://#diff-da3244fc3518be9c9a23320e30d63b77ae3b72f91b8e278d5da97ea0bb8d8e8dL9-R9) [[2]](diffhunk://#diff-9d72d8d9e2fcf1b7573aadae84686354be322286dfce64199d0b158d8002cda0L20-R20) [[3]](diffhunk://#diff-ef133768319dd1ae104498d64acfe09b2634108048b5c11b00be6476007d566cL16-R16) [[4]](diffhunk://#diff-d3506cb2a53716c00fc369c800199d40aa8844d011e84dda2834779fb3a1c4f9L32-R32) [[5]](diffhunk://#diff-26ba042d8cc9cc1cf6eff5977b345ddfd161fc1062cb4c86581c1a99d827e843L13-R13) [[6]](diffhunk://#diff-c1f96f4e3051e2691dbbf14604519a7686e7dea0da6836239a14cd74e8a3c950L26-R26) [[7]](diffhunk://#diff-0a4e74791910af2018137d666d87b91e4b705cfc4656ee569ab814c1476bff62L8-R8)

**Test logic improvements:**

* Updated the `common_setup_teardown` function in `test_bgp_peer_shutdown.py` to handle `LowerMgmtAggregator` and `UpperMgmtAggregator` device types, setting the appropriate neighbor type and vtysh configuration logic.