### PR TITLE
Add support for 'uma' and 'lma' topology types

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -148,7 +148,7 @@ def get_change_routes_ports(vm, topo):
 
 def get_topo_type(topo_name):
     pattern = re.compile(
-        r'^(t0-mclag|t0|t1|ptf|fullmesh|dualtor|t2|mgmttor|m0|mc0|mx|m1|c0|dpu|smartswitch-t1|lt2|ft2)')
+        r'^(t0-mclag|t0|t1|ptf|fullmesh|dualtor|t2|mgmttor|m0|mc0|mx|m1|c0|dpu|smartswitch-t1|lt2|ft2|uma|lma)')
     match = pattern.match(topo_name)
     if not match:
         return "unsupported"
@@ -613,6 +613,51 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
         next_group_index = (index + 1) * upstream_neighbor_groups // vms_len
         if group_index != next_group_index:
             current_routes_offset += last_suffix
+
+def fib_lma(topo, ptf_ip, action="announce", topo_routes=None):
+    common_config = topo['configuration_properties'].get('common', {})
+    nhipv4 = common_config.get("nhipv4", NHIPV4)
+    nhipv6 = common_config.get("nhipv6", NHIPV6)
+    vms_config = topo['configuration']
+    for k, v in vms_config.items():
+        port, port6 = get_change_routes_ports(k, topo)
+        routes_v4 = []
+        routes_v6 = []
+        # The upstream UpperMgmtAggregator (UMA) neighbors originate the default
+        # route toward the LowerMgmtAggregator DUT. Downstream leaf(M2/M3)
+        # neighbors advertise only their own loopbacks via their own BGP.
+        if "core" in v["properties"]:
+            routes_v4 = [("0.0.0.0/0", nhipv4, None)]
+            routes_v6 = [("::/0", nhipv6, None)]
+        topo_routes[k] = {}
+        topo_routes[k][IPV4] = routes_v4
+        topo_routes[k][IPV6] = routes_v6
+        if action != GENERATE_WITHOUT_APPLY:
+            change_routes(action, ptf_ip, port, routes_v4)
+            change_routes(action, ptf_ip, port6, routes_v6)
+
+
+def fib_uma(topo, ptf_ip, action="announce", topo_routes={}):
+    common_config = topo['configuration_properties'].get('common', {})
+    nhipv4 = common_config.get("nhipv4", NHIPV4)
+    nhipv6 = common_config.get("nhipv6", NHIPV6)
+    vms_config = topo['configuration']
+    for k, v in vms_config.items():
+        port, port6 = get_change_routes_ports(k, topo)
+        routes_v4 = []
+        routes_v6 = []
+        # The upstream RegionalWANAggregator (RWA) neighbors originate the default
+        # route toward the UpperMgmtAggregator DUT. Downstream leaf (LMA/M1)
+        # neighbors advertise only their own loopbacks via their own BGP.
+        if "core" in v["properties"]:
+            routes_v4 = [("0.0.0.0/0", nhipv4, None)]
+            routes_v6 = [("::/0", nhipv6, None)]
+        topo_routes[k] = {}
+        topo_routes[k][IPV4] = routes_v4
+        topo_routes[k][IPV6] = routes_v6
+        if action != GENERATE_WITHOUT_APPLY:
+            change_routes(action, ptf_ip, port, routes_v4)
+            change_routes(action, ptf_ip, port6, routes_v6)
 
 
 def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce", tor_default_route=False,
@@ -1785,6 +1830,12 @@ def main():
         elif topo_type == "ft2":
             fib_ft2_routes(topo, ptf_ip, action=action, topo_routes=topo_routes)
             module.exit_json(change=True, topo_routes=convert_routes_to_str(topo_routes))
+        elif topo_type == "lma":
+            fib_lma(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(changed=True, topo_routes=convert_routes_to_str(topo_routes))
+        elif topo_type == "uma":
+            fib_uma(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(changed=True, topo_routes=convert_routes_to_str(topo_routes))
         else:
             module.exit_json(
                 msg='Unsupported topology "{}" - skipping announcing routes'.format(topo_name))


### PR DESCRIPTION
This is cherry pick PR of https://github.com/sonic-net/sonic-mgmt/pull/26853/changes#diff-68b518f15cfb2d75f404b5d982cd1b23244d0775494df25b73f029842c384ec0R1959-R1964


This pull request extends the route announcement functionality in `announce_routes.py` to support two new topology types: "lma" (LowerMgmtAggregator) and "uma" (UpperMgmtAggregator). It does this by recognizing these new topology names and providing custom route announcement logic for each. The most important changes are:

**Support for new topology types:**

* Added "lma" and "uma" to the list of recognized topology types in the `get_topo_type` function, so the script can identify and handle these topologies.

**Routing logic for new topologies:**

* Implemented a new `fib_lma` function to handle route announcements for "lma" topologies, including logic to advertise default routes from core neighbors and loopbacks from leaf neighbors.
* Implemented a new `fib_uma` function to handle route announcements for "uma" topologies, with similar logic tailored for the UMA role.

**Integration into main execution flow:**

* Updated the `main` function to call the new `fib_lma` and `fib_uma` functions when the detected topology type is "lma" or "uma", and to return the resulting routes.